### PR TITLE
fix: close CI gaps with compile link rewriting and pre-commit checks

### DIFF
--- a/.changeset/publish-link-rewrite-fixes.md
+++ b/.changeset/publish-link-rewrite-fixes.md
@@ -1,0 +1,5 @@
+---
+'@bwilliamson/mdcp-core': patch
+---
+
+Split intra-guide and publish-path link rewriting: intra-guide `./section.md` links rewrite on every compile; `compile.publishPathRewrite` drives repo-root path rewrites for publish outputs. Fix `compileGuides` to return an empty string when all guides have `outputFile`. Export `GuideConfigInput`, `MdcpConfigInput`, and `CompileOptionsInput`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Require changeset when packages change
-        run: pnpm changeset:status --since=${{ github.event.pull_request.base.sha }}
+        run: pnpm exec changeset status --since=${{ github.event.pull_request.base.sha }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 pnpm exec lint-staged
+node scripts/pre-commit-affected.mjs
 
 if command -v gitleaks >/dev/null 2>&1; then
   gitleaks protect --staged --redact --verbose

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -36,6 +36,25 @@ pnpm vale:sync            # once — Vale styles for docs/ and examples/sample-g
 
 Optional locally: `brew install gitleaks` (CI always scans).
 
+### Git hooks
+
+Pre-commit runs in two phases:
+
+| Phase           | What runs                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------- |
+| lint-staged     | Prettier and ESLint on staged files (including `.jsonc`)                                 |
+| affected checks | `scripts/pre-commit-affected.mjs` — build and test only packages touched by staged paths |
+
+| Staged paths                                            | Extra checks                                             |
+| ------------------------------------------------------- | -------------------------------------------------------- |
+| `packages/mdcp-core/**`                                 | typecheck, build, `vitest related` on changed files      |
+| `packages/mdcp-cli/**`                                  | core build (dependency), then cli typecheck, build, test |
+| `packages/mdcp-presets/**`                              | JSONC preset validation                                  |
+| `docs/**`, `DEVELOPERS.md`, package README shards       | `docs:compile:repo` + `docs:check:repo`                  |
+| Root config (`package.json`, lockfile, eslint/tsconfig) | repo-wide typecheck + `format:check`                     |
+
+CI runs the full gate: `pnpm run check`.
+
 ## Repository layout
 
 ```text
@@ -123,7 +142,7 @@ This repo's documentation is sharded under [`docs/`](docs/). Shards are the **so
 | Directory      | Audience                                          | Output                                       |
 | -------------- | ------------------------------------------------- | -------------------------------------------- |
 | `features/`    | Tool capabilities, design, consumer migration map | `docs/guides.md` (local review — gitignored) |
-| `developer/`   | Contributing to this repo (this guide)            | [`DEVELOPERS.md`](DEVELOPERS.md) (committed) |
+| `developer/`   | Contributing to this repo (this guide)            | `DEVELOPERS.md` (committed, repo root)       |
 | `client-cli/`  | npm CLI consumers                                 | `packages/mdcp-cli/README.md`                |
 | `client-core/` | Programmatic API consumers                        | `packages/mdcp-core/README.md`               |
 

--- a/docs/client-core/api-config.md
+++ b/docs/client-core/api-config.md
@@ -1,10 +1,12 @@
 # API — Config
 
-| Export                                                      | Purpose                              |
-| ----------------------------------------------------------- | ------------------------------------ |
-| `loadConfig(path, cwd)`                                     | Load and validate `mdcp.config.json` |
-| `resolveOutputPath`, `resolveGuidesRoot`, `resolveGuideDir` | Resolve paths from config            |
-| `getGuideConfig`, `xrefScanDirs`                            | Per-guide and xref scan helpers      |
-| `MdcpConfigSchema`, `MdcpConfig`, `GuideConfig`             | Zod schema and types                 |
+| Export                                                                                 | Purpose                              |
+| -------------------------------------------------------------------------------------- | ------------------------------------ |
+| `loadConfig(path, cwd)`                                                                | Load and validate `mdcp.config.json` |
+| `resolveOutputPath`, `resolveGuidesRoot`, `resolveGuideDir`                            | Resolve paths from config            |
+| `getGuideConfig`, `xrefScanDirs`                                                       | Per-guide and xref scan helpers      |
+| `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput` | Zod schema and types                 |
 
 Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` when `outputFile` is set).
+
+`compile.publishPathRewrite` optionally rewrites shard-relative repo paths in publish outputs (for example `../../package.json` → `package.json` and `../features/foo.md` → `docs/features/foo.md`). Intra-guide `./section.md` links are rewritten to in-document `#anchor` links on **every** compile, including monolith output.

--- a/docs/client-core/compile-hooks.md
+++ b/docs/client-core/compile-hooks.md
@@ -13,7 +13,8 @@ registerCompileHook('myHook', (ctx) => {
 Built-in hook names are configured in `mdcp.config.json` under `guides[].compile.hooks`:
 
 - **`stripAnchors`** — removes explicit `{#anchor}` markers per shard
-- **`codeEvidence`**, **`reviewLinks`**, **`inlineDiagrams`** — reserved names (passthrough placeholders today; extend via `registerCompileHook` in your repo)
+- **`codeEvidence`**, **`inlineDiagrams`** — reserved names (passthrough placeholders today; extend via `registerCompileHook` in your repo)
+- **`reviewLinks`** — reserved name for consumer extensions; built-in intra-guide and `publishPathRewrite` link rewriting runs at assembly time in `assembleGuide`
 
 Default `compile.stripAnchors: true` also strips anchors on the full assembled guide without naming the hook.
 

--- a/docs/compiled-lint.markdownlint-cli2.jsonc
+++ b/docs/compiled-lint.markdownlint-cli2.jsonc
@@ -3,7 +3,7 @@
     "guides.md",
     "../DEVELOPERS.md",
     "../packages/mdcp-cli/README.md",
-    "../packages/mdcp-core/README.md"
+    "../packages/mdcp-core/README.md",
   ],
   "config": {
     "MD012": false,

--- a/docs/developer/docs-dogfooding.md
+++ b/docs/developer/docs-dogfooding.md
@@ -4,12 +4,12 @@ This repo's documentation is sharded under [`docs/`](../). Shards are the **sour
 
 ## Guide directories
 
-| Directory      | Audience                                          | Output                                             |
-| -------------- | ------------------------------------------------- | -------------------------------------------------- |
-| `features/`    | Tool capabilities, design, consumer migration map | `docs/guides.md` (local review — gitignored)       |
-| `developer/`   | Contributing to this repo (this guide)            | [`DEVELOPERS.md`](../../DEVELOPERS.md) (committed) |
-| `client-cli/`  | npm CLI consumers                                 | `packages/mdcp-cli/README.md`                      |
-| `client-core/` | Programmatic API consumers                        | `packages/mdcp-core/README.md`                     |
+| Directory      | Audience                                          | Output                                       |
+| -------------- | ------------------------------------------------- | -------------------------------------------- |
+| `features/`    | Tool capabilities, design, consumer migration map | `docs/guides.md` (local review — gitignored) |
+| `developer/`   | Contributing to this repo (this guide)            | `DEVELOPERS.md` (committed, repo root)       |
+| `client-cli/`  | npm CLI consumers                                 | `packages/mdcp-cli/README.md`                |
+| `client-core/` | Programmatic API consumers                        | `packages/mdcp-core/README.md`               |
 
 Config: [`docs/mdcp.config.json`](../mdcp.config.json). Guides with `compile.outputFile` publish to a separate path and are **excluded** from the monolith.
 

--- a/docs/developer/local-setup.md
+++ b/docs/developer/local-setup.md
@@ -27,3 +27,22 @@ pnpm vale:sync            # once — Vale styles for docs/ and examples/sample-g
 | `pnpm docs:check`        | Validate repo docs + `examples/sample-guides`                            |
 
 Optional locally: `brew install gitleaks` (CI always scans).
+
+## Git hooks
+
+Pre-commit runs in two phases:
+
+| Phase           | What runs                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------- |
+| lint-staged     | Prettier and ESLint on staged files (including `.jsonc`)                                 |
+| affected checks | `scripts/pre-commit-affected.mjs` — build and test only packages touched by staged paths |
+
+| Staged paths                                            | Extra checks                                             |
+| ------------------------------------------------------- | -------------------------------------------------------- |
+| `packages/mdcp-core/**`                                 | typecheck, build, `vitest related` on changed files      |
+| `packages/mdcp-cli/**`                                  | core build (dependency), then cli typecheck, build, test |
+| `packages/mdcp-presets/**`                              | JSONC preset validation                                  |
+| `docs/**`, `DEVELOPERS.md`, package README shards       | `docs:compile:repo` + `docs:check:repo`                  |
+| Root config (`package.json`, lockfile, eslint/tsconfig) | repo-wide typecheck + `format:check`                     |
+
+CI runs the full gate: `pnpm run check`.

--- a/docs/features/feature-catalog.md
+++ b/docs/features/feature-catalog.md
@@ -64,7 +64,9 @@ Orchestrate markdownlint-cli2, Vale, Prettier, markdown-link-check from host rep
 
 ## Compile hooks (P2.2)
 
-Per-shard transforms via `guides[].compile.hooks`. **`stripAnchors`** is fully implemented (also runs by default via `compile.stripAnchors` on the assembled guide). **`codeEvidence`**, **`reviewLinks`**, and **`inlineDiagrams`** are registered placeholders for consumer hook packs — they pass content through unchanged today.
+Per-shard transforms via `guides[].compile.hooks`. **`stripAnchors`** is fully implemented (also runs by default via `compile.stripAnchors` on the assembled guide). **`codeEvidence`** and **`inlineDiagrams`** are registered placeholders for consumer hook packs — they pass content through unchanged today.
+
+**Link rewriting at assembly time:** every compile rewrites same-guide `./section.md` links to in-document `#anchor` links. When `compile.publishPathRewrite` is set (repo dogfood: `developer` → `DEVELOPERS.md`), shard-relative `../` and `../../` paths are rewritten for publish targets. The **`reviewLinks`** hook name is reserved for consumer extensions; built-in rewriting runs in `assembleGuide` regardless of whether `reviewLinks` is listed in `hooks`.
 
 ## Agent integration (consumer repo)
 

--- a/docs/mdcp.config.json
+++ b/docs/mdcp.config.json
@@ -9,7 +9,8 @@
       "name": "developer",
       "compile": {
         "outputFile": "../DEVELOPERS.md",
-        "includeBanner": false
+        "includeBanner": false,
+        "publishPathRewrite": { "stripParentSegments": 2, "oneLevelPrefix": "docs/" }
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,11 @@
       "eslint --fix",
       "prettier --write"
     ],
-    "*.{json,md,yml,yaml}": [
+    "*.{json,jsonc,md,yml,yaml}": [
+      "prettier --write"
+    ],
+    "eslint.config.mjs": [
+      "eslint --fix",
       "prettier --write"
     ]
   },

--- a/packages/mdcp-cli/package.json
+++ b/packages/mdcp-cli/package.json
@@ -36,6 +36,7 @@
   ],
   "scripts": {
     "build": "tsup src/cli.ts --format esm --clean",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm run build"
   },
@@ -46,6 +47,7 @@
   "devDependencies": {
     "@types/node": "^25.9.3",
     "tsup": "^8.4.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/mdcp-cli/test/cli.smoke.test.ts
+++ b/packages/mdcp-cli/test/cli.smoke.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = join(__dirname, '../dist/cli.js');
+const FIXTURE = join(__dirname, '../../../examples/sample-guides');
+
+describe('cli smoke', () => {
+  it('prints version', () => {
+    const out = execFileSync('node', [CLI, '--version'], { encoding: 'utf-8' });
+    expect(out.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('compiles sample guides', () => {
+    const out = execFileSync(
+      'node',
+      [CLI, 'compile', '--config', 'mdcp.config.json', '--cwd', FIXTURE],
+      { encoding: 'utf-8' },
+    );
+    expect(out).toMatch(/guides\.md/);
+    expect(existsSync(join(FIXTURE, 'guides.md'))).toBe(true);
+  });
+
+  it('checks sample guides with vale skipped', () => {
+    const out = execFileSync(
+      'node',
+      [CLI, 'check', '--config', 'mdcp.config.json', '--cwd', FIXTURE, '--skip-vale'],
+      { encoding: 'utf-8' },
+    );
+    expect(out).toContain('mdcp check passed');
+  });
+});

--- a/packages/mdcp-cli/vitest.config.ts
+++ b/packages/mdcp-cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -62,14 +62,16 @@ Use `writeCompiledGuides` when you need to write the monolith and per-guide publ
 
 ## API — Config
 
-| Export                                                      | Purpose                              |
-| ----------------------------------------------------------- | ------------------------------------ |
-| `loadConfig(path, cwd)`                                     | Load and validate `mdcp.config.json` |
-| `resolveOutputPath`, `resolveGuidesRoot`, `resolveGuideDir` | Resolve paths from config            |
-| `getGuideConfig`, `xrefScanDirs`                            | Per-guide and xref scan helpers      |
-| `MdcpConfigSchema`, `MdcpConfig`, `GuideConfig`             | Zod schema and types                 |
+| Export                                                                                 | Purpose                              |
+| -------------------------------------------------------------------------------------- | ------------------------------------ |
+| `loadConfig(path, cwd)`                                                                | Load and validate `mdcp.config.json` |
+| `resolveOutputPath`, `resolveGuidesRoot`, `resolveGuideDir`                            | Resolve paths from config            |
+| `getGuideConfig`, `xrefScanDirs`                                                       | Per-guide and xref scan helpers      |
+| `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput` | Zod schema and types                 |
 
 Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` when `outputFile` is set).
+
+`compile.publishPathRewrite` optionally rewrites shard-relative repo paths in publish outputs (for example `../../package.json` → `package.json` and `../features/foo.md` → `docs/features/foo.md`). Intra-guide `./section.md` links are rewritten to in-document `#anchor` links on **every** compile, including monolith output.
 
 ## API — Compile
 
@@ -143,7 +145,8 @@ registerCompileHook('myHook', (ctx) => {
 Built-in hook names are configured in `mdcp.config.json` under `guides[].compile.hooks`:
 
 - **`stripAnchors`** — removes explicit `` markers per shard
-- **`codeEvidence`**, **`reviewLinks`**, **`inlineDiagrams`** — reserved names (passthrough placeholders today; extend via `registerCompileHook` in your repo)
+- **`codeEvidence`**, **`inlineDiagrams`** — reserved names (passthrough placeholders today; extend via `registerCompileHook` in your repo)
+- **`reviewLinks`** — reserved name for consumer extensions; built-in intra-guide and `publishPathRewrite` link rewriting runs at assembly time in `assembleGuide`
 
 Default `compile.stripAnchors: true` also strips anchors on the full assembled guide without naming the hook.
 

--- a/packages/mdcp-core/src/compile/assemble.ts
+++ b/packages/mdcp-core/src/compile/assemble.ts
@@ -11,7 +11,8 @@ import {
   rewriteIntraGuideFileLinks,
   rewritePublishPathLinks,
 } from './publish-links.js';
-import type { GuideConfig, MdcpConfig } from '../config/schema.js';
+import type { GuideConfig, GuideConfigInput, MdcpConfigInput } from '../config/schema.js';
+import type { PublishPathRewriteOptions } from './publish-links.js';
 
 const FILE_LINK_RE = /\[[^\]]*\]\(([^)]+\.md)(?:#[^)]*)?\)/g;
 const SLUG_LINK_RE = /\]\(#([^)]+)\)/g;
@@ -96,7 +97,8 @@ export interface AssembleGuideOptions {
   hooks?: string[];
   stripAnchors?: boolean;
   outputBasename?: string;
-  config?: MdcpConfig;
+  publishPathRewrite?: PublishPathRewriteOptions;
+  config?: MdcpConfigInput;
 }
 
 export function assembleGuide(guideDir: string, options: AssembleGuideOptions = {}): string {
@@ -141,7 +143,7 @@ export function assembleGuide(guideDir: string, options: AssembleGuideOptions = 
       {
         guideName,
         filename: name,
-        config: options.config ?? ({} as MdcpConfig),
+        config: options.config ?? ({} as MdcpConfigInput),
         outputBasename: options.outputBasename,
         sourceFile: filePath,
       },
@@ -161,10 +163,11 @@ export function assembleGuide(guideDir: string, options: AssembleGuideOptions = 
     compiled = stripExplicitAnchorMarkers(compiled);
   }
 
-  if (options.outputBasename) {
-    const slugByBasename = buildSectionSlugMap(files);
-    compiled = rewriteIntraGuideFileLinks(compiled, slugByBasename);
-    compiled = rewritePublishPathLinks(compiled);
+  const slugByBasename = buildSectionSlugMap(files);
+  compiled = rewriteIntraGuideFileLinks(compiled, slugByBasename);
+
+  if (options.publishPathRewrite) {
+    compiled = rewritePublishPathLinks(compiled, options.publishPathRewrite);
   }
 
   return compiled;
@@ -181,10 +184,13 @@ export interface CompileOptions {
   guidesRoot: string;
   compileOrder: string[];
   banner?: string;
-  guides?: GuideConfig[];
+  guides?: GuideConfigInput[];
   cwd?: string;
-  config?: MdcpConfig;
+  config?: MdcpConfigInput;
 }
+
+/** Alias for partial compile options in tests and callers that omit Zod defaults. */
+export type CompileOptionsInput = CompileOptions;
 
 function resolveGuideDir(
   name: string,
@@ -201,7 +207,7 @@ export function compileGuideResults(options: CompileOptions): CompileGuideResult
   const cwd = options.cwd ?? process.cwd();
 
   return options.compileOrder.map((name) => {
-    const cfg = guideConfigMap.get(name);
+    const cfg = guideConfigMap.get(name) as GuideConfig | undefined;
     const guideDir = resolveGuideDir(name, options.guidesRoot, cfg, cwd);
     const compile = cfg?.compile;
     const outputBasename = compile?.outputFile ? basename(compile.outputFile) : undefined;
@@ -213,6 +219,7 @@ export function compileGuideResults(options: CompileOptions): CompileGuideResult
       hooks: compile?.hooks,
       stripAnchors: compile?.stripAnchors,
       outputBasename,
+      publishPathRewrite: compile?.publishPathRewrite,
       config: options.config,
     });
 
@@ -267,7 +274,7 @@ export function compileGuides(options: CompileOptions): string {
   }
 
   if (monolith.length === 0) {
-    return results.map((r) => r.text).join('\n');
+    return '';
   }
 
   return applyMonolithBanner(options, results);

--- a/packages/mdcp-core/src/compile/hooks.ts
+++ b/packages/mdcp-core/src/compile/hooks.ts
@@ -1,10 +1,10 @@
-import type { MdcpConfig } from '../config/schema.js';
+import type { MdcpConfigInput } from '../config/schema.js';
 
 export interface CompileHookContext {
   guideName: string;
   filename: string;
   body: string;
-  config: MdcpConfig;
+  config: MdcpConfigInput;
   outputBasename?: string;
   sourceFile: string;
 }

--- a/packages/mdcp-core/src/compile/hooks/builtin.ts
+++ b/packages/mdcp-core/src/compile/hooks/builtin.ts
@@ -6,6 +6,7 @@ registerCompileHook('stripAnchors', (ctx) => stripExplicitAnchorMarkers(ctx.body
 /** Passthrough placeholder; full port in consumer hook packs. */
 registerCompileHook('codeEvidence', (ctx) => ctx.body);
 
+/** Passthrough; intra-guide and publish path link rewriting run at assembly time in assembleGuide. */
 registerCompileHook('reviewLinks', (ctx) => ctx.body);
 
 registerCompileHook('inlineDiagrams', (ctx) => ctx.body);

--- a/packages/mdcp-core/src/compile/publish-links.ts
+++ b/packages/mdcp-core/src/compile/publish-links.ts
@@ -36,11 +36,24 @@ export function buildSectionSlugMap(sectionPaths: string[]): Map<string, string>
   return slugByBasename;
 }
 
+export interface PublishPathRewriteOptions {
+  stripParentSegments: number;
+  oneLevelPrefix: string;
+}
+
 /** Rewrite shard-relative paths for publish outputs outside the guide directory. */
-export function rewritePublishPathLinks(markdown: string): string {
-  return markdown
-    .replace(/(\[[^\]]*\]\()\.\.\/\.\.\//g, '$1')
-    .replace(/(\[[^\]]*\]\()\.\.\//g, '$1docs/');
+export function rewritePublishPathLinks(
+  markdown: string,
+  options: PublishPathRewriteOptions,
+): string {
+  let out = markdown;
+  if (options.stripParentSegments >= 2) {
+    out = out.replace(/(\[[^\]]*\]\()\.\.\/\.\.\//g, '$1');
+  }
+  if (options.stripParentSegments >= 1) {
+    out = out.replace(/(\[[^\]]*\]\()\.\.\//g, `$1${options.oneLevelPrefix}`);
+  }
+  return out;
 }
 
 /** Rewrite same-guide shard links to in-document anchors for publish outputs (npm READMEs). */

--- a/packages/mdcp-core/src/config/schema.ts
+++ b/packages/mdcp-core/src/config/schema.ts
@@ -43,6 +43,13 @@ const GuideSchema = z.object({
       /** Named compile hooks (see compile/hooks.ts). */
       hooks: z.array(z.string()).optional(),
       stripAnchors: z.boolean().default(true),
+      /** Rewrite shard-relative repo paths for publish outputs (e.g. DEVELOPERS.md). */
+      publishPathRewrite: z
+        .object({
+          stripParentSegments: z.number().int().min(1).max(4),
+          oneLevelPrefix: z.string(),
+        })
+        .optional(),
     })
     .optional(),
 });
@@ -113,4 +120,6 @@ export const MdcpConfigSchema = z.object({
 });
 
 export type MdcpConfig = z.infer<typeof MdcpConfigSchema>;
+export type MdcpConfigInput = z.input<typeof MdcpConfigSchema>;
 export type GuideConfig = z.infer<typeof GuideSchema>;
+export type GuideConfigInput = z.input<typeof GuideSchema>;

--- a/packages/mdcp-core/src/index.ts
+++ b/packages/mdcp-core/src/index.ts
@@ -1,4 +1,10 @@
-export { MdcpConfigSchema, type MdcpConfig, type GuideConfig } from './config/schema.js';
+export {
+  MdcpConfigSchema,
+  type MdcpConfig,
+  type MdcpConfigInput,
+  type GuideConfig,
+  type GuideConfigInput,
+} from './config/schema.js';
 export {
   loadConfig,
   resolveOutputPath,
@@ -32,6 +38,7 @@ export {
   compileGuides,
   compileGuideResults,
   writeCompiledGuides,
+  type CompileOptionsInput,
 } from './compile/assemble.js';
 export {
   writeSectionsManifest,

--- a/packages/mdcp-core/test/compile.test.ts
+++ b/packages/mdcp-core/test/compile.test.ts
@@ -4,7 +4,12 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
-import { compileGuides, assembleGuide, writeCompiledGuides } from '../src/compile/assemble.js';
+import {
+  compileGuides,
+  assembleGuide,
+  writeCompiledGuides,
+  type CompileOptionsInput,
+} from '../src/compile/assemble.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE = join(__dirname, '../../../examples/sample-guides');
@@ -107,7 +112,7 @@ describe('compileGuides', () => {
           },
         },
       ],
-    } satisfies Parameters<typeof writeCompiledGuides>[0];
+    } satisfies CompileOptionsInput;
 
     const written = writeCompiledGuides(opts, monolithOut);
     expect(written.map((w) => w.path).sort()).toEqual([monolithOut, publishOut].sort());
@@ -159,12 +164,92 @@ describe('compileGuides', () => {
           },
         },
       ],
-    } satisfies Parameters<typeof writeCompiledGuides>[0];
+    } satisfies CompileOptionsInput;
 
     writeCompiledGuides(opts, join(work, 'guides.md'));
     const text = readFileSync(publishOut, 'utf-8');
     expect(text).toContain('[LLM collaboration](#llm-collaboration)');
     expect(text).not.toMatch(/\]\(\.\/llm-collaboration\.md\)/);
+
+    rmSync(work, { recursive: true, force: true });
+  });
+
+  it('rewrites intra-guide .md links in monolith output without outputFile', () => {
+    const work = join(tmpdir(), `mdcp-monolith-links-${Date.now()}`);
+    const guideDir = join(work, 'guide');
+    mkdirSync(guideDir, { recursive: true });
+
+    writeFileSync(join(guideDir, 'index.md'), '# Feature Guide\n\n');
+    writeFileSync(join(guideDir, 'intro.md'), '# Intro\n\nSee [Details](./details.md) for more.\n');
+    writeFileSync(join(guideDir, 'details.md'), '# Details\n\nBody.\n');
+    writeFileSync(join(guideDir, 'sections.txt'), 'intro.md\ndetails.md\n');
+
+    const out = compileGuides({
+      guidesRoot: work,
+      compileOrder: ['guide'],
+    });
+    expect(out).toContain('[Details](#details)');
+    expect(out).not.toMatch(/\]\(\.\/details\.md\)/);
+
+    rmSync(work, { recursive: true, force: true });
+  });
+
+  it('does not rewrite publish path links without publishPathRewrite config', () => {
+    const work = join(tmpdir(), `mdcp-no-path-rewrite-${Date.now()}`);
+    const guideDir = join(work, 'guide');
+    mkdirSync(guideDir, { recursive: true });
+
+    writeFileSync(join(guideDir, 'index.md'), '# @example/pkg\n\n');
+    writeFileSync(
+      join(guideDir, 'section.md'),
+      '# Section\n\nSee [Config](../mdcp.config.json).\n',
+    );
+    writeFileSync(join(guideDir, 'sections.txt'), 'section.md\n');
+
+    const publishOut = join(work, 'README.md');
+    const opts = {
+      guidesRoot: work,
+      compileOrder: ['guide'],
+      cwd: work,
+      guides: [
+        {
+          name: 'guide',
+          compile: {
+            outputFile: 'README.md',
+            includeBanner: false,
+          },
+        },
+      ],
+    } satisfies CompileOptionsInput;
+
+    writeCompiledGuides(opts, join(work, 'guides.md'));
+    const text = readFileSync(publishOut, 'utf-8');
+    expect(text).toContain('[Config](../mdcp.config.json)');
+
+    rmSync(work, { recursive: true, force: true });
+  });
+
+  it('returns empty string when all guides have publish outputs', () => {
+    const work = join(tmpdir(), `mdcp-all-publish-${Date.now()}`);
+    const guideDir = join(work, 'guide');
+    mkdirSync(guideDir, { recursive: true });
+
+    writeFileSync(join(guideDir, 'index.md'), '# Publish\n\n- [Body](body.md)\n');
+    writeFileSync(join(guideDir, 'body.md'), '# Body\n\nContent.\n');
+    writeFileSync(join(guideDir, 'sections.txt'), 'body.md\n');
+
+    const out = compileGuides({
+      guidesRoot: work,
+      compileOrder: ['guide'],
+      cwd: work,
+      guides: [
+        {
+          name: 'guide',
+          compile: { outputFile: 'README.md' },
+        },
+      ],
+    });
+    expect(out).toBe('');
 
     rmSync(work, { recursive: true, force: true });
   });

--- a/packages/mdcp-core/test/publish-links.test.ts
+++ b/packages/mdcp-core/test/publish-links.test.ts
@@ -31,7 +31,10 @@ describe('publish link rewriting', () => {
       'See [`package.json`](../../package.json) and [Feature Catalog](../features/feature-catalog.md).\n' +
       'Config: [`docs/mdcp.config.json`](../mdcp.config.json).\n';
 
-    const out = rewritePublishPathLinks(input);
+    const out = rewritePublishPathLinks(input, {
+      stripParentSegments: 2,
+      oneLevelPrefix: 'docs/',
+    });
     expect(out).toContain('[`package.json`](package.json)');
     expect(out).toContain('[Feature Catalog](docs/features/feature-catalog.md)');
     expect(out).toContain('[`docs/mdcp.config.json`](docs/mdcp.config.json)');

--- a/packages/mdcp-presets/package.json
+++ b/packages/mdcp-presets/package.json
@@ -36,7 +36,6 @@
     "./markdownlint-compiled.markdownlint-cli2.jsonc": "./markdownlint-compiled.markdownlint-cli2.jsonc"
   },
   "scripts": {
-    "typecheck": "node -e \"console.log('no typecheck')\"",
-    "prepublishOnly": "node -e \"console.log('presets ready')\""
+    "prepublishOnly": "node ../../scripts/validate-presets.mjs"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.6.1)(yaml@2.9.0))
 
   packages/mdcp-core:
     dependencies:

--- a/scripts/pre-commit-affected.mjs
+++ b/scripts/pre-commit-affected.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+
+function stagedFiles() {
+  return execSync('git diff --cached --name-only', { encoding: 'utf-8' })
+    .split('\n')
+    .filter(Boolean);
+}
+
+function run(cmd) {
+  console.log(`> ${cmd}`);
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+function matches(files, prefix) {
+  return files.some((f) => f.startsWith(prefix));
+}
+
+const files = stagedFiles();
+if (files.length === 0) process.exit(0);
+
+const rootConfigChanged = files.some(
+  (f) =>
+    f === 'package.json' ||
+    f === 'pnpm-lock.yaml' ||
+    f === 'eslint.config.mjs' ||
+    (f.startsWith('tsconfig') && f.endsWith('.json')),
+);
+
+let coreBuilt = false;
+
+function ensureCoreBuild() {
+  if (!coreBuilt) {
+    run('pnpm --filter @bwilliamson/mdcp-core run build');
+    coreBuilt = true;
+  }
+}
+
+if (matches(files, 'packages/mdcp-core/')) {
+  run('pnpm --filter @bwilliamson/mdcp-core run typecheck');
+  run('pnpm --filter @bwilliamson/mdcp-core run build');
+  const corePaths = files
+    .filter((f) => f.startsWith('packages/mdcp-core/'))
+    .map((f) => f.slice('packages/mdcp-core/'.length));
+  if (corePaths.length > 0) {
+    run(
+      `pnpm --filter @bwilliamson/mdcp-core exec vitest related --run ${corePaths.map((p) => `"${p}"`).join(' ')}`,
+    );
+  }
+  coreBuilt = true;
+}
+
+if (matches(files, 'packages/mdcp-cli/')) {
+  ensureCoreBuild();
+  run('pnpm --filter @bwilliamson/mdcp-cli run typecheck');
+  run('pnpm --filter @bwilliamson/mdcp-cli run build');
+  run('pnpm --filter @bwilliamson/mdcp-cli run test');
+}
+
+if (matches(files, 'packages/mdcp-presets/')) {
+  run('node scripts/validate-presets.mjs');
+}
+
+const docsChanged =
+  matches(files, 'docs/') ||
+  files.includes('DEVELOPERS.md') ||
+  files.some((f) => /^packages\/[^/]+\/README\.md$/.test(f));
+
+if (docsChanged) {
+  ensureCoreBuild();
+  run('pnpm --filter @bwilliamson/mdcp-cli run build');
+  run('pnpm run docs:compile:repo');
+  run('pnpm run docs:check:repo');
+}
+
+if (rootConfigChanged) {
+  run('pnpm run typecheck');
+  run('pnpm run format:check');
+}

--- a/scripts/release-tag.mjs
+++ b/scripts/release-tag.mjs
@@ -76,7 +76,7 @@ function bumpVersion(current, bumpType) {
       return `${v.major}.${v.minor}.${v.patch + 1}`;
     case 'build': {
       const buildMatch = v.prerelease?.match(/^build\.(\d+)$/);
-      if (buildMatch && v.prerelease.startsWith('build.')) {
+      if (buildMatch) {
         return `${v.base}-build.${Number(buildMatch[1]) + 1}`;
       }
       return `${v.base}-build.1`;
@@ -257,6 +257,7 @@ async function main() {
 
   let bumpType = null;
   while (!bumpType) {
+    // --dry-run defaults to minor (2) for predictable non-interactive output.
     const choice = dryRun ? '2' : await prompt('Select bump type (1-4): ');
     const selected = BUMP_MENU.find((item) => item.key === choice);
     if (selected) {

--- a/scripts/validate-presets.mjs
+++ b/scripts/validate-presets.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const presetsDir = join(__dirname, '../packages/mdcp-presets');
+
+const files = [
+  'markdownlint-shards.markdownlint-cli2.jsonc',
+  'markdownlint-compiled.markdownlint-cli2.jsonc',
+];
+
+function stripJsoncComments(text) {
+  return text
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/,\s*([}\]])/g, '$1');
+}
+
+for (const file of files) {
+  const path = join(presetsDir, file);
+  try {
+    JSON.parse(stripJsoncComments(readFileSync(path, 'utf-8')));
+    console.log(`OK ${file}`);
+  } catch (err) {
+    console.error(`Invalid JSONC in ${file}: ${err.message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- Split intra-guide `./section.md` → `#anchor` rewriting (all compiles) from config-driven `publishPathRewrite` (developer guide → `DEVELOPERS.md` only)
- Fix `compileGuides` to return empty string when all guides have `outputFile`; export `GuideConfigInput`, `MdcpConfigInput`, and `CompileOptionsInput`
- Close hook/CI gaps: lint-staged covers `.jsonc`, pre-commit runs affected build/test/docs via `scripts/pre-commit-affected.mjs`, presets validated on publish
- Add mdcp-cli vitest smoke tests and a patch changeset for `@bwilliamson/mdcp-core`

## Test plan
- [x] Pre-commit hooks pass (lint-staged, affected typecheck/build/test, docs compile/check)
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (mdcp-core + mdcp-cli)
- [ ] CI `pnpm run check` on PR

Made with [Cursor](https://cursor.com)