### PR TITLE
fix(core): normalize outputDir-relative paths for refs and monolith output

### DIFF
--- a/.changeset/refs-registry-path-fix.md
+++ b/.changeset/refs-registry-path-fix.md
@@ -1,0 +1,6 @@
+---
+'@bwilliamson/mdcp-core': patch
+'@bwilliamson/mdcp-cli': patch
+---
+
+Fix `refs.registryFile` and monolith `outputFile` path resolution when a cwd-relative path is given under `outputDir`. Both fields are relative to `outputDir`; cwd-relative values are normalized via shared `resolveUnderOutputDir` instead of double-joining.

--- a/docs/client-cli/commands-reference.md
+++ b/docs/client-cli/commands-reference.md
@@ -7,7 +7,7 @@ Every command accepts:
 | Option                | Default            | Purpose                                                                    |
 | --------------------- | ------------------ | -------------------------------------------------------------------------- |
 | `-c, --config <path>` | `mdcp.config.json` | Config file path, resolved from the **invocation directory** (not `--cwd`) |
-| `--cwd <path>`        | current directory  | Docs root — guide directories and compile outputs are relative to this     |
+| `--cwd <path>`        | current directory  | Docs root for shard trees and config path fields                           |
 
 **Repo-root npm scripts** typically use both flags:
 

--- a/docs/client-cli/config-essentials.md
+++ b/docs/client-cli/config-essentials.md
@@ -4,10 +4,10 @@
 
 These two global options answer different questions:
 
-| Option         | Resolved from                                                                        | Purpose                                                         |
-| -------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
-| **`--config`** | **Invocation directory** — where you run the command (repo root in most npm scripts) | Locates `mdcp.config.json` on disk                              |
-| **`--cwd`**    | N/A (you pass the docs root explicitly)                                              | Guide directories, compile outputs, and paths inside the config |
+| Option         | Resolved from                                                                        | Purpose                                                       |
+| -------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| **`--config`** | **Invocation directory** — where you run the command (repo root in most npm scripts) | Locates `mdcp.config.json` on disk                            |
+| **`--cwd`**    | N/A (you pass the docs root explicitly)                                              | Docs root — see [Config path bases](#config-path-bases) below |
 
 `--config` and `--cwd` use independent path bases — the config path is not prefixed with `--cwd`.
 
@@ -45,7 +45,30 @@ Here `--cwd` defaults to `docs/` (the invocation directory), which matches the s
 
 ### Programmatic API
 
-`loadConfig(configPath, configBase)` in `@bwilliamson/mdcp-core` mirrors the CLI: pass the invocation directory as `configBase`, and the docs root separately when resolving guide paths (`resolveGuideDir`, `resolveOutputPath`, etc.). See [API — Config](../client-core/api-config.md).
+`loadConfig(configPath, configBase)` in `@bwilliamson/mdcp-core` mirrors the CLI: pass the invocation directory as `configBase`, and the docs root separately when resolving guide paths (`resolveGuideDir`, `resolveOutputPath`, `resolveRefsPath`, etc.). See [API — Config](../client-core/api-config.md).
+
+### Config path bases
+
+Config path fields use **three bases**. Mixing them up is the most common path bug.
+
+| Base                    | Set by                                     | Example (`--cwd docs`)                                                           |
+| ----------------------- | ------------------------------------------ | -------------------------------------------------------------------------------- |
+| **Invocation dir**      | where you run the command                  | `--config docs/mdcp.config.json` from repo root → `<repo>/docs/mdcp.config.json` |
+| **Docs root** (`--cwd`) | explicit flag (defaults to invocation dir) | `guides/features/` → `docs/features/`                                            |
+| **`outputDir`**         | config field under `--cwd`                 | `_build/compiled` → `docs/_build/compiled/`                                      |
+
+| Config field         | Resolved from            | Example value               | Resolves to (`--cwd docs`)       |
+| -------------------- | ------------------------ | --------------------------- | -------------------------------- |
+| `guides[].path`      | `--cwd`                  | `features`                  | `docs/features/`                 |
+| Default guide dir    | `outputDir` + guide name | (omit `path`)               | `docs/<outputDir>/<name>/`       |
+| `compile.outputFile` | `--cwd`                  | `../packages/foo/README.md` | `<repo>/packages/foo/README.md`  |
+| `outputDir`          | `--cwd`                  | `_build/compiled`           | `docs/_build/compiled/`          |
+| `outputFile`         | `outputDir`              | `guides.md`                 | `docs/_build/compiled/guides.md` |
+| `refs.registryFile`  | `outputDir`              | `refs.json`                 | `docs/_build/compiled/refs.json` |
+
+Monolith `outputFile` and `refs.registryFile` share the same rule: **relative to `outputDir`**, not `--cwd`. Per-guide `compile.outputFile` is always **relative to `--cwd`**.
+
+If you accidentally give a cwd-relative path for `outputFile` or `refs.registryFile` that already lies under `outputDir` (for example `"_build/compiled/refs.json"` when `outputDir` is `"_build/compiled"`), MDCP normalizes it. Prefer outputDir-relative values in config (`"refs.json"`, `"guides.md"`).
 
 ---
 
@@ -64,11 +87,23 @@ Minimal `mdcp.config.json`:
 | ------------------- | ------------------------------------------------------ |
 | `compileOrder`      | Order of guide directories in the compiled monolith    |
 | `guides`            | Per-guide options (hooks, manifests, separate outputs) |
-| `outputFile`        | Compiled monolith path                                 |
-| `refs.registryFile` | Cross-link lookup table path                           |
+| `outputDir`         | Compile output root (relative to `--cwd`)              |
+| `outputFile`        | Monolith filename (relative to `outputDir`)            |
+| `refs.registryFile` | Cross-link lookup table (relative to `outputDir`)      |
 | `lint`              | markdownlint configs, xref checks, link checking       |
 | `vale`              | Prose lint paths and `.vale.ini` location              |
 | `source`            | Monolith path — required only for `mdcp shard`         |
+
+**Nested `outputDir` example** — use outputDir-relative filenames:
+
+```json
+{
+  "outputDir": "_build/compiled",
+  "outputFile": "guides.md",
+  "compileOrder": ["overview"],
+  "refs": { "registryFile": "refs.json" }
+}
+```
 
 Per-guide `compile.outputFile` writes a publish target (relative to `--cwd`) and excludes that guide from the monolith. Use `compile.includeBanner: false` for npm README outputs.
 

--- a/docs/client-cli/install-and-quick-start.md
+++ b/docs/client-cli/install-and-quick-start.md
@@ -63,4 +63,4 @@ Global options (apply to every command):
 | Option                | Default            | Purpose                                                                 |
 | --------------------- | ------------------ | ----------------------------------------------------------------------- |
 | `-c, --config <path>` | `mdcp.config.json` | Path to config file (relative to the invocation directory, not `--cwd`) |
-| `--cwd <path>`        | current directory  | Docs root (guide dirs and output paths are relative to this)            |
+| `--cwd <path>`        | current directory  | Docs root for shard trees and config path fields                        |

--- a/docs/client-core/api-config.md
+++ b/docs/client-core/api-config.md
@@ -3,18 +3,22 @@
 | Export                                                                                 | Purpose                                                                     |
 | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | `loadConfig(path, configBase)`                                                         | Load and validate `mdcp.config.json` (`path` is resolved from `configBase`) |
-| `resolveOutputPath`, `resolveGuidesRoot`, `resolveGuideDir`                            | Resolve paths from config (relative to docs root / `--cwd`)                 |
+| `resolveOutputPath`, `resolveRefsPath`, `resolveGuidesRoot`, `resolveGuideDir`         | Path resolvers for outputDir-relative config fields                         |
 | `getGuideConfig`, `xrefScanDirs`                                                       | Per-guide and xref scan helpers                                             |
 | `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput` | Zod schema and types                                                        |
 
 ## Path resolution: `configBase` vs docs root
 
-The CLI and core library use **two different base directories**:
+The CLI and core library use **separate path bases**:
 
-| Concern                    | Base directory                                            | Example                                                                          |
-| -------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Finding `mdcp.config.json` | `configBase` — invocation `process.cwd()` in the CLI      | `--config docs/mdcp.config.json` from repo root → `<repo>/docs/mdcp.config.json` |
-| Guide dirs, outputs, refs  | Docs root — `--cwd` argument (defaults to invocation cwd) | `resolveGuideDir('features', config, cwd)` → `<cwd>/features`                    |
+| Concern                               | Base directory                                       | Example                                                                          |
+| ------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Finding `mdcp.config.json`            | `configBase` — invocation `process.cwd()` in the CLI | `--config docs/mdcp.config.json` from repo root → `<repo>/docs/mdcp.config.json` |
+| `guides[].path`, `compile.outputFile` | Docs root — `--cwd`                                  | `resolveGuideDir('features', config, cwd)` → `<cwd>/features`                    |
+| `outputDir`                           | Docs root — `--cwd`                                  | `resolveGuidesRoot(config, cwd)` → `<cwd>/<outputDir>`                           |
+| `outputFile`, `refs.registryFile`     | `outputDir` (under docs root)                        | `resolveOutputPath(config, cwd)` → `<cwd>/<outputDir>/guides.md`                 |
+
+`resolveOutputPath` and `resolveRefsPath` both use the same `outputDir`-relative rule and normalize cwd-relative values that already fall under `outputDir`. Details: [API — Refs](./api-refs-validation.md).
 
 ```typescript
 import { loadConfig, resolveGuideDir } from '@bwilliamson/mdcp-core';
@@ -24,7 +28,9 @@ const config = loadConfig('docs/mdcp.config.json', process.cwd());
 const featuresDir = resolveGuideDir('features', config, join(process.cwd(), 'docs'));
 ```
 
-Pass `process.cwd()` (or the invocation directory) as `configBase` for `loadConfig`. Pass the docs root as the `cwd` argument to `resolveGuideDir`, `resolveOutputPath`, and `resolveGuidesRoot`.
+Pass `process.cwd()` (or the invocation directory) as `configBase` for `loadConfig`. Pass the docs root as the `cwd` argument to `resolveGuideDir`, `resolveOutputPath`, `resolveGuidesRoot`, and `resolveRefsPath`.
+
+Consumer path table: [Config essentials — path bases](../client-cli/config-essentials.md#config-path-bases).
 
 Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` when `outputFile` is set).
 

--- a/docs/client-core/api-refs-validation.md
+++ b/docs/client-core/api-refs-validation.md
@@ -8,6 +8,30 @@
 | `genRefsFromCompiled`, `readRefsRegistry`, `checkRefsRegistry` | `refs.json` lifecycle      |
 | `resolveRefsPath`, `writeRefsRegistry`                         | Path and I/O helpers       |
 
+### `resolveRefsPath(cwd, outputDir, registryFile)`
+
+Resolves the on-disk path for the refs registry. Implemented via the same `outputDir`-relative helper as `resolveOutputPath`. Pass the docs root as `cwd` (the CLI `--cwd` value).
+
+- `outputDir` is relative to `cwd`.
+- `registryFile` is relative to `outputDir` (not `cwd`).
+
+```typescript
+resolveRefsPath('/docs', '_build/compiled', 'refs.json');
+// → /docs/_build/compiled/refs.json
+
+resolveRefsPath('/docs', '.', 'refs.json');
+// → /docs/refs.json
+```
+
+If `registryFile` or monolith `outputFile` is accidentally given as a cwd-relative path that already falls under `outputDir`, MDCP uses the cwd-relative interpretation so the path is not joined twice:
+
+```typescript
+resolveRefsPath('/docs', '_build/compiled', '_build/compiled/refs.json');
+// → /docs/_build/compiled/refs.json (normalized)
+```
+
+Prefer outputDir-relative values in config (for example `"refs.json"` when `outputDir` is `"_build/compiled"`). See [Config essentials — path bases](../client-cli/config-essentials.md#config-path-bases).
+
 ## Manifest
 
 | Export                                               | Purpose                                   |

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -19,15 +19,15 @@ You never hand-maintain the compiled file. Shards are the source of truth; `guid
 
 ## Core vocabulary
 
-| Term               | Meaning                                                                                                                                          |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Shard**          | A single `.md` file that becomes part of a guide (for example `01-intro.md`).                                                                    |
-| **Guide**          | A directory of shards plus a manifest (`index.md` or `shards.md`) and `sections.txt`. Named in `compileOrder`.                                   |
-| **Monolith**       | The default compiled output (`outputFile`, usually `guides.md`) — all guides without their own `compile.outputFile`, stitched in `compileOrder`. |
-| **Publish output** | A per-guide compiled file (for example `packages/mdcp-cli/README.md`) written instead of being included in the monolith.                         |
-| **Refs registry**  | `refs.json` — GitHub-style slugs and semantic keys from compiled headings, used by `mdcp refs lookup`.                                           |
-| **`--cwd`**        | Docs root: guide paths, `compile.outputFile`, and default output paths resolve relative to this directory.                                       |
-| **`--config`**     | Config file path, resolved relative to the **invocation** directory (where you run the command), not `--cwd`.                                    |
+| Term               | Meaning                                                                                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Shard**          | A single `.md` file that becomes part of a guide (for example `01-intro.md`).                                                                                 |
+| **Guide**          | A directory of shards plus a manifest (`index.md` or `shards.md`) and `sections.txt`. Named in `compileOrder`.                                                |
+| **Monolith**       | The default compiled output (`outputFile`, usually `guides.md`) — all guides without their own `compile.outputFile`, stitched in `compileOrder`.              |
+| **Publish output** | A per-guide compiled file (for example `packages/mdcp-cli/README.md`) written instead of being included in the monolith.                                      |
+| **Refs registry**  | `refs.json` — GitHub-style slugs and semantic keys from compiled headings, used by `mdcp refs lookup`.                                                        |
+| **`--cwd`**        | Docs root (`--cwd`): shard paths, `outputDir`, and per-guide `compile.outputFile`. Monolith `outputFile` and `refs.registryFile` are relative to `outputDir`. |
+| **`--config`**     | Config file path, resolved relative to the **invocation** directory (where you run the command), not `--cwd`.                                                 |
 
 ### Path resolution (`--config` vs `--cwd`)
 
@@ -38,11 +38,14 @@ The CLI uses two separate path bases. This matters for npm scripts run from the 
 mdcp compile --config docs/mdcp.config.json --cwd docs
 ```
 
-| Path                                 | Resolved from            | Resolves to (example)         |
-| ------------------------------------ | ------------------------ | ----------------------------- |
-| `--config docs/mdcp.config.json`     | Invocation dir (`/repo`) | `/repo/docs/mdcp.config.json` |
-| Guide `features/`                    | `--cwd` (`docs`)         | `/repo/docs/features/`        |
-| `compile.outputFile: "../README.md"` | `--cwd`                  | `/repo/README.md`             |
+| Path                                 | Resolved from            | Resolves to (example)                  |
+| ------------------------------------ | ------------------------ | -------------------------------------- |
+| `--config docs/mdcp.config.json`     | Invocation dir (`/repo`) | `/repo/docs/mdcp.config.json`          |
+| Guide `features/`                    | `--cwd` (`docs`)         | `/repo/docs/features/`                 |
+| `outputDir: "_build/compiled"`       | `--cwd`                  | `/repo/docs/_build/compiled/`          |
+| `outputFile: "guides.md"`            | `outputDir`              | `/repo/docs/_build/compiled/guides.md` |
+| `refs.registryFile: "refs.json"`     | `outputDir`              | `/repo/docs/_build/compiled/refs.json` |
+| `compile.outputFile: "../README.md"` | `--cwd`                  | `/repo/README.md`                      |
 
 When your shell is already in the docs directory, use `--config mdcp.config.json` (or the default) and omit `--cwd` unless you need a different docs root.
 
@@ -152,7 +155,7 @@ Peer linters are **not bundled**. CI uses `--require-lint` / `--require-vale` to
 
 - **`compileOrder`** — which guides exist and in what order they appear in the monolith.
 - **`guides[].compile`** — per-guide manifest name, hooks, publish path, title, scope root, etc.
-- **`refs`** — where `refs.json` lives and slug algorithm.
+- **`refs`** — `registryFile` and monolith `outputFile` paths (relative to `outputDir`) and slug algorithm.
 - **`lint` / `vale`** — peer linter config paths and scan globs.
 - **`export.llm`** — what to strip for agent context.
 

--- a/packages/mdcp-cli/README.md
+++ b/packages/mdcp-cli/README.md
@@ -65,7 +65,7 @@ Global options (apply to every command):
 | Option                | Default            | Purpose                                                                 |
 | --------------------- | ------------------ | ----------------------------------------------------------------------- |
 | `-c, --config <path>` | `mdcp.config.json` | Path to config file (relative to the invocation directory, not `--cwd`) |
-| `--cwd <path>`        | current directory  | Docs root (guide dirs and output paths are relative to this)            |
+| `--cwd <path>`        | current directory  | Docs root for shard trees and config path fields                        |
 
 ## Project layout
 
@@ -91,10 +91,10 @@ Guides can also set `compile.outputFile` to publish a standalone document (for e
 
 These two global options answer different questions:
 
-| Option         | Resolved from                                                                        | Purpose                                                         |
-| -------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
-| **`--config`** | **Invocation directory** — where you run the command (repo root in most npm scripts) | Locates `mdcp.config.json` on disk                              |
-| **`--cwd`**    | N/A (you pass the docs root explicitly)                                              | Guide directories, compile outputs, and paths inside the config |
+| Option         | Resolved from                                                                        | Purpose                                                       |
+| -------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| **`--config`** | **Invocation directory** — where you run the command (repo root in most npm scripts) | Locates `mdcp.config.json` on disk                            |
+| **`--cwd`**    | N/A (you pass the docs root explicitly)                                              | Docs root — see [Config path bases](#config-path-bases) below |
 
 `--config` and `--cwd` use independent path bases — the config path is not prefixed with `--cwd`.
 
@@ -132,7 +132,30 @@ Here `--cwd` defaults to `docs/` (the invocation directory), which matches the s
 
 #### Programmatic API
 
-`loadConfig(configPath, configBase)` in `@bwilliamson/mdcp-core` mirrors the CLI: pass the invocation directory as `configBase`, and the docs root separately when resolving guide paths (`resolveGuideDir`, `resolveOutputPath`, etc.). See [API — Config](../client-core/api-config.md).
+`loadConfig(configPath, configBase)` in `@bwilliamson/mdcp-core` mirrors the CLI: pass the invocation directory as `configBase`, and the docs root separately when resolving guide paths (`resolveGuideDir`, `resolveOutputPath`, `resolveRefsPath`, etc.). See [API — Config](../client-core/api-config.md).
+
+#### Config path bases
+
+Config path fields use **three bases**. Mixing them up is the most common path bug.
+
+| Base                    | Set by                                     | Example (`--cwd docs`)                                                           |
+| ----------------------- | ------------------------------------------ | -------------------------------------------------------------------------------- |
+| **Invocation dir**      | where you run the command                  | `--config docs/mdcp.config.json` from repo root → `<repo>/docs/mdcp.config.json` |
+| **Docs root** (`--cwd`) | explicit flag (defaults to invocation dir) | `guides/features/` → `docs/features/`                                            |
+| **`outputDir`**         | config field under `--cwd`                 | `_build/compiled` → `docs/_build/compiled/`                                      |
+
+| Config field         | Resolved from            | Example value               | Resolves to (`--cwd docs`)       |
+| -------------------- | ------------------------ | --------------------------- | -------------------------------- |
+| `guides[].path`      | `--cwd`                  | `features`                  | `docs/features/`                 |
+| Default guide dir    | `outputDir` + guide name | (omit `path`)               | `docs/<outputDir>/<name>/`       |
+| `compile.outputFile` | `--cwd`                  | `../packages/foo/README.md` | `<repo>/packages/foo/README.md`  |
+| `outputDir`          | `--cwd`                  | `_build/compiled`           | `docs/_build/compiled/`          |
+| `outputFile`         | `outputDir`              | `guides.md`                 | `docs/_build/compiled/guides.md` |
+| `refs.registryFile`  | `outputDir`              | `refs.json`                 | `docs/_build/compiled/refs.json` |
+
+Monolith `outputFile` and `refs.registryFile` share the same rule: **relative to `outputDir`**, not `--cwd`. Per-guide `compile.outputFile` is always **relative to `--cwd`**.
+
+If you accidentally give a cwd-relative path for `outputFile` or `refs.registryFile` that already lies under `outputDir` (for example `"_build/compiled/refs.json"` when `outputDir` is `"_build/compiled"`), MDCP normalizes it. Prefer outputDir-relative values in config (`"refs.json"`, `"guides.md"`).
 
 ---
 
@@ -151,11 +174,23 @@ Minimal `mdcp.config.json`:
 | ------------------- | ------------------------------------------------------ |
 | `compileOrder`      | Order of guide directories in the compiled monolith    |
 | `guides`            | Per-guide options (hooks, manifests, separate outputs) |
-| `outputFile`        | Compiled monolith path                                 |
-| `refs.registryFile` | Cross-link lookup table path                           |
+| `outputDir`         | Compile output root (relative to `--cwd`)              |
+| `outputFile`        | Monolith filename (relative to `outputDir`)            |
+| `refs.registryFile` | Cross-link lookup table (relative to `outputDir`)      |
 | `lint`              | markdownlint configs, xref checks, link checking       |
 | `vale`              | Prose lint paths and `.vale.ini` location              |
 | `source`            | Monolith path — required only for `mdcp shard`         |
+
+**Nested `outputDir` example** — use outputDir-relative filenames:
+
+```json
+{
+  "outputDir": "_build/compiled",
+  "outputFile": "guides.md",
+  "compileOrder": ["overview"],
+  "refs": { "registryFile": "refs.json" }
+}
+```
 
 Per-guide `compile.outputFile` writes a publish target (relative to `--cwd`) and excludes that guide from the monolith. Use `compile.includeBanner: false` for npm README outputs.
 
@@ -177,7 +212,7 @@ Every command accepts:
 | Option                | Default            | Purpose                                                                    |
 | --------------------- | ------------------ | -------------------------------------------------------------------------- |
 | `-c, --config <path>` | `mdcp.config.json` | Config file path, resolved from the **invocation directory** (not `--cwd`) |
-| `--cwd <path>`        | current directory  | Docs root — guide directories and compile outputs are relative to this     |
+| `--cwd <path>`        | current directory  | Docs root for shard trees and config path fields                           |
 
 **Repo-root npm scripts** typically use both flags:
 

--- a/packages/mdcp-cli/test/cli.smoke.test.ts
+++ b/packages/mdcp-cli/test/cli.smoke.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = join(__dirname, '../dist/cli.js');
@@ -42,5 +43,36 @@ describe('cli smoke', () => {
       { encoding: 'utf-8', cwd: REPO_ROOT },
     );
     expect(out).toMatch(/sections/);
+  });
+
+  it('normalizes cwd-relative refs.registryFile under outputDir (#11)', () => {
+    const docs = mkdtempSync(join(tmpdir(), 'mdcp-smoke-'));
+    try {
+      const guide = join(docs, 'g');
+      mkdirSync(guide, { recursive: true });
+      writeFileSync(join(guide, 'index.md'), '[intro](introduction.md)\n');
+      writeFileSync(join(guide, 'sections.txt'), 'introduction.md\n');
+      writeFileSync(join(guide, 'introduction.md'), '# Guide\n\n## Hello\n');
+      writeFileSync(
+        join(docs, 'mdcp.config.json'),
+        JSON.stringify({
+          outputDir: '_build/compiled',
+          outputFile: 'guides.md',
+          compileOrder: ['g'],
+          guides: [{ name: 'g', path: 'g' }],
+          refs: { registryFile: '_build/compiled/refs.json' },
+          lint: { xrefs: { enabled: false } },
+        }),
+      );
+
+      execFileSync(
+        'node',
+        [CLI, 'check', '--config', 'mdcp.config.json', '--cwd', docs, '--skip-vale'],
+        { encoding: 'utf-8', cwd: docs },
+      );
+      expect(existsSync(join(docs, '_build/compiled/refs.json'))).toBe(true);
+    } finally {
+      rmSync(docs, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -65,18 +65,22 @@ Use `writeCompiledGuides` when you need to write the monolith and per-guide publ
 | Export                                                                                 | Purpose                                                                     |
 | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | `loadConfig(path, configBase)`                                                         | Load and validate `mdcp.config.json` (`path` is resolved from `configBase`) |
-| `resolveOutputPath`, `resolveGuidesRoot`, `resolveGuideDir`                            | Resolve paths from config (relative to docs root / `--cwd`)                 |
+| `resolveOutputPath`, `resolveRefsPath`, `resolveGuidesRoot`, `resolveGuideDir`         | Path resolvers for outputDir-relative config fields                         |
 | `getGuideConfig`, `xrefScanDirs`                                                       | Per-guide and xref scan helpers                                             |
 | `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput` | Zod schema and types                                                        |
 
 ### Path resolution: `configBase` vs docs root
 
-The CLI and core library use **two different base directories**:
+The CLI and core library use **separate path bases**:
 
-| Concern                    | Base directory                                            | Example                                                                          |
-| -------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Finding `mdcp.config.json` | `configBase` — invocation `process.cwd()` in the CLI      | `--config docs/mdcp.config.json` from repo root → `<repo>/docs/mdcp.config.json` |
-| Guide dirs, outputs, refs  | Docs root — `--cwd` argument (defaults to invocation cwd) | `resolveGuideDir('features', config, cwd)` → `<cwd>/features`                    |
+| Concern                               | Base directory                                       | Example                                                                          |
+| ------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Finding `mdcp.config.json`            | `configBase` — invocation `process.cwd()` in the CLI | `--config docs/mdcp.config.json` from repo root → `<repo>/docs/mdcp.config.json` |
+| `guides[].path`, `compile.outputFile` | Docs root — `--cwd`                                  | `resolveGuideDir('features', config, cwd)` → `<cwd>/features`                    |
+| `outputDir`                           | Docs root — `--cwd`                                  | `resolveGuidesRoot(config, cwd)` → `<cwd>/<outputDir>`                           |
+| `outputFile`, `refs.registryFile`     | `outputDir` (under docs root)                        | `resolveOutputPath(config, cwd)` → `<cwd>/<outputDir>/guides.md`                 |
+
+`resolveOutputPath` and `resolveRefsPath` both use the same `outputDir`-relative rule and normalize cwd-relative values that already fall under `outputDir`. Details: [API — Refs](#api-refs-and-validation).
 
 ```typescript
 import { loadConfig, resolveGuideDir } from '@bwilliamson/mdcp-core';
@@ -86,7 +90,9 @@ const config = loadConfig('docs/mdcp.config.json', process.cwd());
 const featuresDir = resolveGuideDir('features', config, join(process.cwd(), 'docs'));
 ```
 
-Pass `process.cwd()` (or the invocation directory) as `configBase` for `loadConfig`. Pass the docs root as the `cwd` argument to `resolveGuideDir`, `resolveOutputPath`, and `resolveGuidesRoot`.
+Pass `process.cwd()` (or the invocation directory) as `configBase` for `loadConfig`. Pass the docs root as the `cwd` argument to `resolveGuideDir`, `resolveOutputPath`, `resolveGuidesRoot`, and `resolveRefsPath`.
+
+Consumer path table: [Config essentials — path bases](../client-cli/config-essentials.md#config-path-bases).
 
 Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` when `outputFile` is set).
 
@@ -113,6 +119,30 @@ Per-guide `compile.outputFile` writes a publish target and excludes that guide f
 | `buildSlugRegistry`, `lookupHeadings`, `githubSlugify`         | GitHub-style heading slugs |
 | `genRefsFromCompiled`, `readRefsRegistry`, `checkRefsRegistry` | `refs.json` lifecycle      |
 | `resolveRefsPath`, `writeRefsRegistry`                         | Path and I/O helpers       |
+
+#### `resolveRefsPath(cwd, outputDir, registryFile)`
+
+Resolves the on-disk path for the refs registry. Implemented via the same `outputDir`-relative helper as `resolveOutputPath`. Pass the docs root as `cwd` (the CLI `--cwd` value).
+
+- `outputDir` is relative to `cwd`.
+- `registryFile` is relative to `outputDir` (not `cwd`).
+
+```typescript
+resolveRefsPath('/docs', '_build/compiled', 'refs.json');
+// → /docs/_build/compiled/refs.json
+
+resolveRefsPath('/docs', '.', 'refs.json');
+// → /docs/refs.json
+```
+
+If `registryFile` or monolith `outputFile` is accidentally given as a cwd-relative path that already falls under `outputDir`, MDCP uses the cwd-relative interpretation so the path is not joined twice:
+
+```typescript
+resolveRefsPath('/docs', '_build/compiled', '_build/compiled/refs.json');
+// → /docs/_build/compiled/refs.json (normalized)
+```
+
+Prefer outputDir-relative values in config (for example `"refs.json"` when `outputDir` is `"_build/compiled"`). See [Config essentials — path bases](../client-cli/config-essentials.md#config-path-bases).
 
 ### Manifest
 

--- a/packages/mdcp-core/src/config/load.ts
+++ b/packages/mdcp-core/src/config/load.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { MdcpConfigSchema, type MdcpConfig, type GuideConfig } from './schema.js';
+import { resolveUnderOutputDir } from './paths.js';
 
 export function loadConfig(configPath: string, configBase: string): MdcpConfig {
   const abs = resolve(configBase, configPath);
@@ -12,7 +13,11 @@ export function loadConfig(configPath: string, configBase: string): MdcpConfig {
 }
 
 export function resolveOutputPath(config: MdcpConfig, cwd: string): string {
-  return resolve(cwd, config.outputDir, config.outputFile);
+  return resolveUnderOutputDir(cwd, config.outputDir, config.outputFile);
+}
+
+export function resolveRefsPath(cwd: string, outputDir: string, file: string): string {
+  return resolveUnderOutputDir(cwd, outputDir, file);
 }
 
 export function resolveGuidesRoot(config: MdcpConfig, cwd: string): string {

--- a/packages/mdcp-core/src/config/paths.ts
+++ b/packages/mdcp-core/src/config/paths.ts
@@ -1,0 +1,20 @@
+import { resolve, relative, isAbsolute } from 'node:path';
+
+function isUnder(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+/**
+ * Resolve `file` under `outputDir` (both relative to docs root `cwd`).
+ * When `file` is accidentally cwd-relative but already under `outputDir`, use the cwd-relative path.
+ */
+export function resolveUnderOutputDir(cwd: string, outputDir: string, file: string): string {
+  const outputRoot = resolve(cwd, outputDir);
+  const underOutputDir = resolve(outputRoot, file);
+  const cwdRelative = resolve(cwd, file);
+  if (cwdRelative !== underOutputDir && isUnder(outputRoot, cwdRelative)) {
+    return cwdRelative;
+  }
+  return underOutputDir;
+}

--- a/packages/mdcp-core/src/config/schema.ts
+++ b/packages/mdcp-core/src/config/schema.ts
@@ -72,7 +72,9 @@ const GuideSchema = z.object({
 
 export const MdcpConfigSchema = z.object({
   source: z.string().optional(),
+  /** Compile output root relative to --cwd (default guide shard dirs live here too). */
   outputDir: z.string().default('.'),
+  /** Monolith filename relative to outputDir (not --cwd). */
   outputFile: z.string().default('guides.md'),
   compileOrder: z.array(z.string()).min(1),
   banner: z.string().optional(),
@@ -80,6 +82,7 @@ export const MdcpConfigSchema = z.object({
 
   refs: z
     .object({
+      /** Registry path relative to outputDir (not --cwd). */
       registryFile: z.string().default('refs.json'),
       slugAlgorithm: z.enum(['github']).default('github'),
     })

--- a/packages/mdcp-core/src/index.ts
+++ b/packages/mdcp-core/src/index.ts
@@ -8,6 +8,7 @@ export {
 export {
   loadConfig,
   resolveOutputPath,
+  resolveRefsPath,
   resolveGuidesRoot,
   resolveGuideDir,
   getGuideConfig,
@@ -57,7 +58,6 @@ export {
   readRefsRegistry,
   checkRefsRegistry,
   genRefsFromCompiled,
-  resolveRefsPath,
 } from './refs/registry.js';
 export { lintXrefs } from './xrefs/lint.js';
 export {

--- a/packages/mdcp-core/src/refs/registry.ts
+++ b/packages/mdcp-core/src/refs/registry.ts
@@ -1,5 +1,4 @@
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { buildSlugRegistry, type RefsRegistry } from './slugs.js';
 
 export function writeRefsRegistry(registry: RefsRegistry, outputPath: string): void {
@@ -32,8 +31,4 @@ export function genRefsFromCompiled(compiledText: string, registryPath: string):
   const registry = buildSlugRegistry(compiledText);
   writeRefsRegistry(registry, registryPath);
   return registry;
-}
-
-export function resolveRefsPath(cwd: string, outputDir: string, file: string): string {
-  return resolve(cwd, outputDir, file);
 }

--- a/packages/mdcp-core/test/config.test.ts
+++ b/packages/mdcp-core/test/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { MdcpConfigSchema } from '../src/config/schema.js';
-import { loadConfig } from '../src/config/load.js';
+import { loadConfig, resolveOutputPath, resolveRefsPath } from '../src/config/load.js';
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { useTmpDir, withTmpDir } from './helpers/tmp-dir.js';
@@ -60,5 +60,29 @@ describe('loadConfig', () => {
       const cfg = loadConfig('docs/mdcp.config.json', repo);
       expect(cfg.compileOrder).toEqual(['a']);
     });
+  });
+});
+
+describe('resolveUnderOutputDir paths', () => {
+  it('resolves outputFile relative to outputDir', () => {
+    const config = MdcpConfigSchema.parse({
+      compileOrder: ['a'],
+      outputDir: '_build/compiled',
+      outputFile: 'guides.md',
+    });
+    expect(resolveOutputPath(config, '/docs')).toBe('/docs/_build/compiled/guides.md');
+  });
+
+  it('normalizes cwd-relative outputFile under outputDir', () => {
+    const config = MdcpConfigSchema.parse({
+      compileOrder: ['a'],
+      outputDir: '_build/compiled',
+      outputFile: '_build/compiled/guides.md',
+    });
+    expect(resolveOutputPath(config, '/docs')).toBe('/docs/_build/compiled/guides.md');
+  });
+
+  it('resolves refs.registryFile via resolveRefsPath', () => {
+    expect(resolveRefsPath('/docs', '.', 'refs.json')).toBe('/docs/refs.json');
   });
 });

--- a/packages/mdcp-core/test/refs.test.ts
+++ b/packages/mdcp-core/test/refs.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { githubSlugify, buildSlugRegistry, lookupHeadings } from '../src/refs/slugs.js';
 import { genRefsFromCompiled, checkRefsRegistry } from '../src/refs/registry.js';
+import { resolveRefsPath } from '../src/config/load.js';
 import { useTmpDir } from './helpers/tmp-dir.js';
 
 describe('githubSlugify', () => {
@@ -36,6 +37,40 @@ describe('semantic chapter keys', () => {
     const entry = reg.headings.find((h) => h.title.includes('ADM Chapter 1'));
     expect(entry?.key).toBe('adm.ch1');
     expect(reg.slugs[entry!.slug]).toBe('adm.ch1');
+  });
+});
+
+describe('resolveRefsPath', () => {
+  it('resolves registryFile relative to outputDir (#11)', () => {
+    const cwd = '/docs';
+    expect(resolveRefsPath(cwd, '_build/compiled', 'refs.json')).toBe(
+      '/docs/_build/compiled/refs.json',
+    );
+  });
+
+  it('normalizes cwd-relative registryFile under outputDir (#11)', () => {
+    const cwd = '/docs';
+    expect(resolveRefsPath(cwd, '_build/compiled', '_build/compiled/refs.json')).toBe(
+      '/docs/_build/compiled/refs.json',
+    );
+  });
+
+  it('keeps nested paths relative to outputDir', () => {
+    const cwd = '/docs';
+    expect(resolveRefsPath(cwd, '_build/compiled', 'meta/refs.json')).toBe(
+      '/docs/_build/compiled/meta/refs.json',
+    );
+  });
+
+  it('resolves registryFile when outputDir is "."', () => {
+    expect(resolveRefsPath('/docs', '.', 'refs.json')).toBe('/docs/refs.json');
+  });
+
+  it('does not treat outputDir-relative refs.json as cwd-relative', () => {
+    const cwd = '/docs';
+    expect(resolveRefsPath(cwd, '_build/compiled', 'refs.json')).toBe(
+      '/docs/_build/compiled/refs.json',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes #11: `refs.registryFile` no longer double-joins with `outputDir` when given a cwd-relative path under the output tree.
- Introduces shared `resolveUnderOutputDir` used by both `resolveRefsPath` and `resolveOutputPath` so monolith `outputFile` gets the same normalization.
- Adds regression tests (unit + CLI smoke) and documents config path bases in one place (`config-essentials.md`, API docs, features overview).

## Test plan

- [x] `pnpm test` — core (74) + CLI (5) tests pass
- [x] `pnpm run docs:check:repo` — compile, refs, markdownlint, Vale
- [x] Unit: `resolveRefsPath` / `resolveOutputPath` normalization with nested `outputDir`
- [x] CLI smoke: `mdcp check` with `refs.registryFile: "_build/compiled/refs.json"`


Made with [Cursor](https://cursor.com)