### PR TITLE
fix(core): insert blank line after injected compile title

### DIFF
--- a/.changeset/compile-title-newline-fix.md
+++ b/.changeset/compile-title-newline-fix.md
@@ -1,0 +1,6 @@
+---
+'@bwilliamson/mdcp-core': patch
+'@bwilliamson/mdcp-cli': patch
+---
+
+Fix compile title injection so `compile.title` is followed by a blank line before the first section heading instead of being concatenated onto the same line.

--- a/docs/client-core/api-compile.md
+++ b/docs/client-core/api-compile.md
@@ -5,7 +5,10 @@
 | `compileGuides`, `compileGuideResults`            | Stitch shards into monolith text                      |
 | `writeCompiledGuides`                             | Write monolith and publish outputs to disk            |
 | `sectionFiles`, `processSection`, `assembleGuide` | Lower-level assemble pipeline                         |
+| `formatCompileTitle`, `extractFirstHeading`, …    | Optional `compile.title` injection and deduplication  |
 | `demoteHeadings`, `stripAboutThisGuideHeading`, … | Heading transforms                                    |
 | `registerCompileHook`, `applyCompileHooks`        | Extension hooks (`stripAnchors`, `inlineDiagrams`, …) |
 
 `compileGuides` returns monolith text only — guides with `compile.outputFile` are excluded. `writeCompiledGuides` writes both the monolith and any publish targets.
+
+When `compile.title` is set, `assembleGuide` injects a `##` heading followed by a blank line before the first section. See [API — Config](./api-config.md) for per-guide compile fields.

--- a/docs/client-core/api-config.md
+++ b/docs/client-core/api-config.md
@@ -34,4 +34,6 @@ Consumer path table: [Config essentials — path bases](../client-cli/config-ess
 
 Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` when `outputFile` is set).
 
+`compile.title` injects a `##` heading at the start of the assembled guide, separated from the first section by a blank line. When the first shard’s top heading matches the title text, that duplicate heading is stripped before assembly.
+
 `compile.publishPathRewrite` optionally rewrites shard-relative repo paths in publish outputs (for example `../../package.json` → `package.json` and `../features/foo.md` → `docs/features/foo.md`). Intra-guide `./section.md` links are rewritten to in-document `#anchor` links on **every** compile, including monolith output.

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -129,7 +129,7 @@ For each guide in `compileOrder`, core:
 
 1. **Reads section files** — from `sections.txt`, or from link order in the manifest (`index.md` / `shards.md`). Optional `compile.sectionsHeading` limits which manifest links count.
 2. **Transforms each shard** — demotes headings to fit the guide level; strips `about-this-guide` preamble; runs named **compile hooks** (`stripAnchors`, `codeEvidence`, `inlineDiagrams`, `reviewLinks`, …).
-3. **Assembles the guide body** — injects optional `compile.title`; concatenates sections in order.
+3. **Assembles the guide body** — injects optional `compile.title` as a `##` heading followed by a blank line, then concatenates sections in order. When the first shard’s top heading matches the title, that duplicate heading is stripped.
 4. **Rewrites links** — same-guide `./section.md` → in-document `#anchor`; optional `publishPathRewrite` for repo-root paths on publish outputs.
 5. **Writes outputs** — monolith file and/or per-guide `compile.outputFile`.
 

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -96,6 +96,8 @@ Consumer path table: [Config essentials — path bases](../client-cli/config-ess
 
 Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` when `outputFile` is set).
 
+`compile.title` injects a `##` heading at the start of the assembled guide, separated from the first section by a blank line. When the first shard’s top heading matches the title text, that duplicate heading is stripped before assembly.
+
 `compile.publishPathRewrite` optionally rewrites shard-relative repo paths in publish outputs (for example `../../package.json` → `package.json` and `../features/foo.md` → `docs/features/foo.md`). Intra-guide `./section.md` links are rewritten to in-document `#anchor` links on **every** compile, including monolith output.
 
 ## API — Compile
@@ -105,10 +107,13 @@ Per-guide `compile.outputFile` writes a publish target and excludes that guide f
 | `compileGuides`, `compileGuideResults`            | Stitch shards into monolith text                      |
 | `writeCompiledGuides`                             | Write monolith and publish outputs to disk            |
 | `sectionFiles`, `processSection`, `assembleGuide` | Lower-level assemble pipeline                         |
+| `formatCompileTitle`, `extractFirstHeading`, …    | Optional `compile.title` injection and deduplication  |
 | `demoteHeadings`, `stripAboutThisGuideHeading`, … | Heading transforms                                    |
 | `registerCompileHook`, `applyCompileHooks`        | Extension hooks (`stripAnchors`, `inlineDiagrams`, …) |
 
 `compileGuides` returns monolith text only — guides with `compile.outputFile` are excluded. `writeCompiledGuides` writes both the monolith and any publish targets.
+
+When `compile.title` is set, `assembleGuide` injects a `##` heading followed by a blank line before the first section. See [API — Config](#api-config) for per-guide compile fields.
 
 ## API — Refs and validation
 

--- a/packages/mdcp-core/src/compile/assemble.ts
+++ b/packages/mdcp-core/src/compile/assemble.ts
@@ -134,7 +134,7 @@ export function assembleGuide(guideDir: string, options: AssembleGuideOptions = 
   });
 
   if (useTitle) {
-    parts.push(formatCompileTitle(useTitle), '');
+    parts.push(`${formatCompileTitle(useTitle)}\n\n`);
   } else {
     const h1 = extractGuideH1(indexText);
     if (h1) parts.push(h1);

--- a/packages/mdcp-core/src/config/schema.ts
+++ b/packages/mdcp-core/src/config/schema.ts
@@ -35,7 +35,7 @@ const GuideSchema = z.object({
       manifest: z.string().default('index.md'),
       /** When set, only links after this ## heading are used for sections.txt / compile order. */
       sectionsHeading: z.string().optional(),
-      /** Injected compile title as ## heading. */
+      /** Injected compile title as ## heading, followed by a blank line before the first section. */
       title: z.string().optional(),
       scopeRoot: z.string().optional(),
       /** Per-guide output path relative to --cwd (excluded from monolith). */

--- a/packages/mdcp-core/test/compile.test.ts
+++ b/packages/mdcp-core/test/compile.test.ts
@@ -63,6 +63,22 @@ describe('compileGuides', () => {
     expect(output).toContain('## Coverage and where to look');
   });
 
+  it('inserts a blank line after injected compile title before first section', () => {
+    withTmpDir('mdcp-compile-title-', (work) => {
+      writeFileSync(join(work, 'index.md'), '# Guide\n\n- [Section](section.md)\n');
+      writeFileSync(join(work, 'section.md'), '### Product surfaces\n\nContent.\n');
+      writeFileSync(join(work, 'sections.txt'), 'section.md\n');
+
+      const out = assembleGuide(work, {
+        title: 'Compound glossary',
+        manifest: 'index.md',
+      });
+
+      expect(out).toMatch(/^## Compound glossary\n\n#### Product surfaces/m);
+      expect(out).not.toMatch(/^## Compound glossary#{2,}/m);
+    });
+  });
+
   it('strips explicit anchor markers from compiled output', () => {
     withTmpDir('mdcp-compile-', (work) => {
       writeFileSync(join(work, 'index.md'), '# Example\n\n- [Section](section.md)\n');


### PR DESCRIPTION
## Summary

- Fixes #12: when `compile.title` is set, the injected `##` heading was concatenated onto the first section heading because `parts.join('')` with an empty string part adds no newline.
- Adds a regression fixture test in `mdcp-core` compile tests.
- Documents `compile.title` behavior in features overview, API docs, schema JSDoc, and compiled README.

## Test plan

- [x] `pnpm test` — all core and CLI tests pass
- [x] New test: `inserts a blank line after injected compile title before first section`
- [x] Pre-commit hook: typecheck, build, vitest related, docs compile/check pass


Made with [Cursor](https://cursor.com)