### PR TITLE
feat(core): implement codeEvidence compile hook

### DIFF
--- a/.changeset/code-evidence-hook.md
+++ b/.changeset/code-evidence-hook.md
@@ -1,0 +1,8 @@
+---
+'@bwilliamson/mdcp-core': minor
+'@bwilliamson/mdcp-cli': minor
+---
+
+Implement the `codeEvidence` compile hook: resolve evidence links to GitHub `#L` line fragments (from link labels, URL fragments, or line-range text), rebase paths relative to the rendered output (per-guide `compile.outputFile` or monolith path), and use `compile.scopeRoot` for cross-tree file lookup.
+
+Export `resolveGuideLinkBase`. Remove unused `hooksConfig.codeEvidence.searchRoots` — shard-relative paths and `compile.scopeRoot` cover the same cases with less config.

--- a/docs/client-core/compile-hooks.md
+++ b/docs/client-core/compile-hooks.md
@@ -13,11 +13,112 @@ registerCompileHook('myHook', (ctx) => {
 Built-in hook names are configured in `mdcp.config.json` under `guides[].compile.hooks`:
 
 - **`stripAnchors`** — removes explicit `{#anchor}` markers per shard
-- **`codeEvidence`** — rewrites Evidence / source-file links to `#L` fragments
+- **`codeEvidence`** — rewrites Evidence / source-file links to `#L` line fragments (see [codeEvidence](#codeevidence) below)
 - **`inlineInserts`** — inlines captioned insert shards (diagrams, tables, figures, media) from shared libraries
 - **`reviewLinks`** — rewrites finding and cross-guide links for monolith cohesion (`hooksConfig.reviewLinks.targetMonolith`)
 
 Optional hook config under `guides[].compile.hooksConfig`. For manifest compile order and `compile.sectionsHeading`, see [Manifest compile order](../features/manifest-compile-order.md).
+
+## codeEvidence
+
+Specification for the `codeEvidence` compile hook. Tests in `packages/mdcp-core/test/code-evidence.test.ts` map to the sections below (docs first, then TDD).
+
+### codeEvidence purpose
+
+Architecture and technical review shards cite **repo source files** as evidence. At compile time, the hook:
+
+1. Resolves **line ranges** from link text (for example `L6-L8`, `lines 12–15`, `:42`)
+2. Resolves **symbols** from the URL fragment (`file.ts#symbol`) or from the link label when no fragment is present (for example ``[`orgCount`](../../functions/src/foo.ts)``)
+3. Appends GitHub-style **`#L` fragments** (`#L6`, `#L6-L8`) to the link target
+4. When the guide has `compile.outputFile`, rewrites the target path to be **relative to the compiled output** so links work in the rendered monolith or publish file
+
+Pair with `compile.publishPathRewrite` when publish outputs need repo-root path normalization (for example `../../package.json` → `package.json`).
+
+### codeEvidence link matching
+
+A link is rewritten when **all** of the following hold:
+
+- Standard markdown link syntax: `[label](path)`
+- Target path is a **source file** (common extensions such as `.ts`, `.py`, `.go`, or extensionless paths like `Makefile`)
+- Target is not `http://`, `https://`, or `#…`
+
+Markdown (`.md`) links, external URLs, and same-guide shard links are left unchanged.
+
+### codeEvidence line ranges
+
+Line ranges are parsed from the **link label** first, then from the path (before any `#` fragment). Supported forms:
+
+| Form in label or path | Fragment           |
+| --------------------- | ------------------ |
+| `L6-L8`, `L6–L8`      | `#L6-L8`           |
+| `L42`, `line 42`      | `#L42`             |
+| `:10-20`, `:10`       | `#L10-L20`, `#L10` |
+
+If the URL already has a normalized `#L…` fragment, the hook preserves it (normalizing case to `#L`).
+
+### codeEvidence symbols
+
+When no line range is found:
+
+1. If the URL has a `#fragment` that is not already `#L…`, treat the fragment as a **symbol name** and scan the resolved source file for a matching declaration or reference.
+2. Otherwise, treat the **link label** as the symbol (backticks and surrounding whitespace stripped).
+
+Symbol lookup scans for identifier matches and common declaration forms (`function`, `class`, `const`, `export`, call sites).
+
+### codeEvidence path resolution
+
+Source file lookup order:
+
+1. Relative to the current shard directory
+2. Relative to the shard parent directory
+3. `process.cwd()` and its parent
+4. `compile.scopeRoot` (when set on the guide)
+5. Optional `hooksConfig.codeEvidence.searchRoots`
+
+When `compile.outputFile` is set, the hook rewrites the link target path to a POSIX path **relative to the compiled output file**, preserving any `#L…` fragment added by the hook.
+
+### codeEvidence exclusions
+
+The hook **does not** transform:
+
+- Markdown shard links (`.md`)
+- External URLs
+- Source links when the file cannot be resolved and no line range appears in label or path
+- Body text when `codeEvidence` is not in `compile.hooks`
+
+### codeEvidence config
+
+```json
+{
+  "name": "architecture-review",
+  "compile": {
+    "scopeRoot": ".",
+    "outputFile": "architecture-review.md",
+    "hooks": ["stripAnchors", "codeEvidence"],
+    "hooksConfig": {
+      "codeEvidence": { "searchRoots": ["functions/src"] }
+    }
+  }
+}
+```
+
+### codeEvidence compile example
+
+Shard input (under `review/claim.md`):
+
+```markdown
+Evidence: [`orgCount`](../../functions/src/foo.ts)
+
+See [firestore.rules L6-L8](../../firestore.rules).
+```
+
+Compiled output (when `functions/src/foo.ts` defines `orgCount` on line 6 and output is `architecture-review.md` at repo root):
+
+```markdown
+Evidence: [`orgCount`](functions/src/foo.ts#L6)
+
+See [firestore.rules L6-L8](firestore.rules#L6-L8).
+```
 
 ## inlineInserts
 

--- a/docs/client-core/compile-hooks.md
+++ b/docs/client-core/compile-hooks.md
@@ -30,7 +30,7 @@ Architecture and technical review shards cite **repo source files** as evidence.
 1. Resolves **line ranges** from link text (for example `L6-L8`, `lines 12–15`, `:42`)
 2. Resolves **symbols** from the URL fragment (`file.ts#symbol`) or from the link label when no fragment is present (for example ``[`orgCount`](../../functions/src/foo.ts)``)
 3. Appends GitHub-style **`#L` fragments** (`#L6`, `#L6-L8`) to the link target
-4. When the guide has `compile.outputFile`, rewrites the target path to be **relative to the compiled output** so links work in the rendered monolith or publish file
+4. Rewrites the target path to be **relative to the rendered output** — the per-guide `compile.outputFile` when set, otherwise the monolith path (`outputDir` + `outputFile` from config)
 
 Pair with `compile.publishPathRewrite` when publish outputs need repo-root path normalization (for example `../../package.json` → `package.json`).
 
@@ -72,10 +72,9 @@ Source file lookup order:
 1. Relative to the current shard directory
 2. Relative to the shard parent directory
 3. `process.cwd()` and its parent
-4. `compile.scopeRoot` (when set on the guide)
-5. Optional `hooksConfig.codeEvidence.searchRoots`
+4. `compile.scopeRoot` (when set on the guide — same field used for manifest scoping)
 
-When `compile.outputFile` is set, the hook rewrites the link target path to a POSIX path **relative to the compiled output file**, preserving any `#L…` fragment added by the hook.
+When a source file is resolved, the hook rewrites the link target to a POSIX path **relative to the rendered output document**, preserving any `#L…` fragment added by the hook. No hook-specific config is required: shard-relative paths in source are resolved as written, then rebased for where the compiled file lands.
 
 ### codeEvidence exclusions
 
@@ -88,16 +87,26 @@ The hook **does not** transform:
 
 ### codeEvidence config
 
+Minimal setup — add the hook name. Path rewriting uses the monolith or per-guide output path automatically:
+
+```json
+{
+  "name": "architecture-review",
+  "compile": {
+    "hooks": ["stripAnchors", "codeEvidence"]
+  }
+}
+```
+
+When the guide publishes to its own file instead of the monolith, set `compile.outputFile` (paths are rebased to that file). When shards link across directories outside the guide tree, set `compile.scopeRoot` (typically `"."` for repo root) so manifest scoping and evidence lookup share one root:
+
 ```json
 {
   "name": "architecture-review",
   "compile": {
     "scopeRoot": ".",
     "outputFile": "architecture-review.md",
-    "hooks": ["stripAnchors", "codeEvidence"],
-    "hooksConfig": {
-      "codeEvidence": { "searchRoots": ["functions/src"] }
-    }
+    "hooks": ["stripAnchors", "codeEvidence"]
   }
 }
 ```

--- a/docs/features/feature-catalog.md
+++ b/docs/features/feature-catalog.md
@@ -65,7 +65,7 @@ Orchestrate markdownlint-cli2, Vale, Prettier, markdown-link-check from host rep
 Per-shard transforms via `guides[].compile.hooks`. Built-in hooks:
 
 - **`stripAnchors`** — removes `{#anchor}` markers (also default via `compile.stripAnchors`)
-- **`codeEvidence`** — rewrites repo source links to `#L` line fragments (symbol or line range in link text)
+- **`codeEvidence`** — rewrites repo source links to `#L` line fragments (symbol or line range in link text); optional `hooksConfig.codeEvidence.searchRoots`. See [Compile hooks](../client-core/compile-hooks.md#codeevidence).
 - **`inlineInserts`** — inlines captioned insert shards from shared libraries (`diagrams/`, `tables/`, `figures/`, `media/`); shard bodies may include tables, prose, or media (images, video, audio); numbered `####` headings per kind (`Table 1. …`); first mention per guide inlines, later references back-link. Optional `hooksConfig.inlineInserts.searchRoots`. See [Compile hooks](../client-core/compile-hooks.md#inlineinserts).
 - **`reviewLinks`** — rewrites `FIND-*.md` and cross-guide links when `hooksConfig.reviewLinks.targetMonolith` is set
 

--- a/docs/features/feature-catalog.md
+++ b/docs/features/feature-catalog.md
@@ -65,7 +65,7 @@ Orchestrate markdownlint-cli2, Vale, Prettier, markdown-link-check from host rep
 Per-shard transforms via `guides[].compile.hooks`. Built-in hooks:
 
 - **`stripAnchors`** — removes `{#anchor}` markers (also default via `compile.stripAnchors`)
-- **`codeEvidence`** — rewrites repo source links to `#L` line fragments (symbol or line range in link text); optional `hooksConfig.codeEvidence.searchRoots`. See [Compile hooks](../client-core/compile-hooks.md#codeevidence).
+- **`codeEvidence`** — rewrites repo source links to `#L` line fragments (symbol or line range in link text); rebases paths for the rendered output automatically. See [Compile hooks](../client-core/compile-hooks.md#codeevidence).
 - **`inlineInserts`** — inlines captioned insert shards from shared libraries (`diagrams/`, `tables/`, `figures/`, `media/`); shard bodies may include tables, prose, or media (images, video, audio); numbered `####` headings per kind (`Table 1. …`); first mention per guide inlines, later references back-link. Optional `hooksConfig.inlineInserts.searchRoots`. See [Compile hooks](../client-core/compile-hooks.md#inlineinserts).
 - **`reviewLinks`** — rewrites `FIND-*.md` and cross-guide links when `hooksConfig.reviewLinks.targetMonolith` is set
 

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -216,7 +216,7 @@ Architecture and technical review shards cite **repo source files** as evidence.
 1. Resolves **line ranges** from link text (for example `L6-L8`, `lines 12–15`, `:42`)
 2. Resolves **symbols** from the URL fragment (`file.ts#symbol`) or from the link label when no fragment is present (for example ``[`orgCount`](../../functions/src/foo.ts)``)
 3. Appends GitHub-style **`#L` fragments** (`#L6`, `#L6-L8`) to the link target
-4. When the guide has `compile.outputFile`, rewrites the target path to be **relative to the compiled output** so links work in the rendered monolith or publish file
+4. Rewrites the target path to be **relative to the rendered output** — the per-guide `compile.outputFile` when set, otherwise the monolith path (`outputDir` + `outputFile` from config)
 
 Pair with `compile.publishPathRewrite` when publish outputs need repo-root path normalization (for example `../../package.json` → `package.json`).
 
@@ -258,10 +258,9 @@ Source file lookup order:
 1. Relative to the current shard directory
 2. Relative to the shard parent directory
 3. `process.cwd()` and its parent
-4. `compile.scopeRoot` (when set on the guide)
-5. Optional `hooksConfig.codeEvidence.searchRoots`
+4. `compile.scopeRoot` (when set on the guide — same field used for manifest scoping)
 
-When `compile.outputFile` is set, the hook rewrites the link target path to a POSIX path **relative to the compiled output file**, preserving any `#L…` fragment added by the hook.
+When a source file is resolved, the hook rewrites the link target to a POSIX path **relative to the rendered output document**, preserving any `#L…` fragment added by the hook. No hook-specific config is required: shard-relative paths in source are resolved as written, then rebased for where the compiled file lands.
 
 #### codeEvidence exclusions
 
@@ -274,16 +273,26 @@ The hook **does not** transform:
 
 #### codeEvidence config
 
+Minimal setup — add the hook name. Path rewriting uses the monolith or per-guide output path automatically:
+
+```json
+{
+  "name": "architecture-review",
+  "compile": {
+    "hooks": ["stripAnchors", "codeEvidence"]
+  }
+}
+```
+
+When the guide publishes to its own file instead of the monolith, set `compile.outputFile` (paths are rebased to that file). When shards link across directories outside the guide tree, set `compile.scopeRoot` (typically `"."` for repo root) so manifest scoping and evidence lookup share one root:
+
 ```json
 {
   "name": "architecture-review",
   "compile": {
     "scopeRoot": ".",
     "outputFile": "architecture-review.md",
-    "hooks": ["stripAnchors", "codeEvidence"],
-    "hooksConfig": {
-      "codeEvidence": { "searchRoots": ["functions/src"] }
-    }
+    "hooks": ["stripAnchors", "codeEvidence"]
   }
 }
 ```

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -199,11 +199,112 @@ registerCompileHook('myHook', (ctx) => {
 Built-in hook names are configured in `mdcp.config.json` under `guides[].compile.hooks`:
 
 - **`stripAnchors`** — removes explicit `` markers per shard
-- **`codeEvidence`** — rewrites Evidence / source-file links to `#L` fragments
+- **`codeEvidence`** — rewrites Evidence / source-file links to `#L` line fragments (see [codeEvidence](#codeevidence) below)
 - **`inlineInserts`** — inlines captioned insert shards (diagrams, tables, figures, media) from shared libraries
 - **`reviewLinks`** — rewrites finding and cross-guide links for monolith cohesion (`hooksConfig.reviewLinks.targetMonolith`)
 
 Optional hook config under `guides[].compile.hooksConfig`. For manifest compile order and `compile.sectionsHeading`, see [Manifest compile order](../features/manifest-compile-order.md).
+
+### codeEvidence
+
+Specification for the `codeEvidence` compile hook. Tests in `packages/mdcp-core/test/code-evidence.test.ts` map to the sections below (docs first, then TDD).
+
+#### codeEvidence purpose
+
+Architecture and technical review shards cite **repo source files** as evidence. At compile time, the hook:
+
+1. Resolves **line ranges** from link text (for example `L6-L8`, `lines 12–15`, `:42`)
+2. Resolves **symbols** from the URL fragment (`file.ts#symbol`) or from the link label when no fragment is present (for example ``[`orgCount`](../../functions/src/foo.ts)``)
+3. Appends GitHub-style **`#L` fragments** (`#L6`, `#L6-L8`) to the link target
+4. When the guide has `compile.outputFile`, rewrites the target path to be **relative to the compiled output** so links work in the rendered monolith or publish file
+
+Pair with `compile.publishPathRewrite` when publish outputs need repo-root path normalization (for example `../../package.json` → `package.json`).
+
+#### codeEvidence link matching
+
+A link is rewritten when **all** of the following hold:
+
+- Standard markdown link syntax: `[label](path)`
+- Target path is a **source file** (common extensions such as `.ts`, `.py`, `.go`, or extensionless paths like `Makefile`)
+- Target is not `http://`, `https://`, or `#…`
+
+Markdown (`.md`) links, external URLs, and same-guide shard links are left unchanged.
+
+#### codeEvidence line ranges
+
+Line ranges are parsed from the **link label** first, then from the path (before any `#` fragment). Supported forms:
+
+| Form in label or path | Fragment           |
+| --------------------- | ------------------ |
+| `L6-L8`, `L6–L8`      | `#L6-L8`           |
+| `L42`, `line 42`      | `#L42`             |
+| `:10-20`, `:10`       | `#L10-L20`, `#L10` |
+
+If the URL already has a normalized `#L…` fragment, the hook preserves it (normalizing case to `#L`).
+
+#### codeEvidence symbols
+
+When no line range is found:
+
+1. If the URL has a `#fragment` that is not already `#L…`, treat the fragment as a **symbol name** and scan the resolved source file for a matching declaration or reference.
+2. Otherwise, treat the **link label** as the symbol (backticks and surrounding whitespace stripped).
+
+Symbol lookup scans for identifier matches and common declaration forms (`function`, `class`, `const`, `export`, call sites).
+
+#### codeEvidence path resolution
+
+Source file lookup order:
+
+1. Relative to the current shard directory
+2. Relative to the shard parent directory
+3. `process.cwd()` and its parent
+4. `compile.scopeRoot` (when set on the guide)
+5. Optional `hooksConfig.codeEvidence.searchRoots`
+
+When `compile.outputFile` is set, the hook rewrites the link target path to a POSIX path **relative to the compiled output file**, preserving any `#L…` fragment added by the hook.
+
+#### codeEvidence exclusions
+
+The hook **does not** transform:
+
+- Markdown shard links (`.md`)
+- External URLs
+- Source links when the file cannot be resolved and no line range appears in label or path
+- Body text when `codeEvidence` is not in `compile.hooks`
+
+#### codeEvidence config
+
+```json
+{
+  "name": "architecture-review",
+  "compile": {
+    "scopeRoot": ".",
+    "outputFile": "architecture-review.md",
+    "hooks": ["stripAnchors", "codeEvidence"],
+    "hooksConfig": {
+      "codeEvidence": { "searchRoots": ["functions/src"] }
+    }
+  }
+}
+```
+
+#### codeEvidence compile example
+
+Shard input (under `review/claim.md`):
+
+```markdown
+Evidence: [`orgCount`](../../functions/src/foo.ts)
+
+See [firestore.rules L6-L8](../../firestore.rules).
+```
+
+Compiled output (when `functions/src/foo.ts` defines `orgCount` on line 6 and output is `architecture-review.md` at repo root):
+
+```markdown
+Evidence: [`orgCount`](functions/src/foo.ts#L6)
+
+See [firestore.rules L6-L8](firestore.rules#L6-L8).
+```
 
 ### inlineInserts
 

--- a/packages/mdcp-core/src/compile/assemble.ts
+++ b/packages/mdcp-core/src/compile/assemble.ts
@@ -104,6 +104,8 @@ export interface AssembleGuideOptions {
   hooks?: string[];
   stripAnchors?: boolean;
   outputBasename?: string;
+  /** Absolute path to compiled guide output when compile.outputFile is set. */
+  outputFile?: string;
   publishPathRewrite?: PublishPathRewriteOptions;
   config?: MdcpConfigInput;
 }
@@ -155,6 +157,8 @@ export function assembleGuide(guideDir: string, options: AssembleGuideOptions = 
         filename: name,
         config: options.config ?? ({} as MdcpConfigInput),
         outputBasename: options.outputBasename,
+        outputFile: options.outputFile,
+        scopeRoot: options.scopeRoot,
         sourceFile: filePath,
         hookState,
       },
@@ -232,6 +236,7 @@ export function compileGuideResults(options: CompileOptions): CompileGuideResult
       hooks: compile?.hooks,
       stripAnchors: compile?.stripAnchors,
       outputBasename,
+      outputFile: compile?.outputFile ? resolve(cwd, compile.outputFile) : undefined,
       publishPathRewrite: compile?.publishPathRewrite,
       config: options.config,
     });

--- a/packages/mdcp-core/src/compile/assemble.ts
+++ b/packages/mdcp-core/src/compile/assemble.ts
@@ -12,6 +12,7 @@ import {
   rewritePublishPathLinks,
 } from './publish-links.js';
 import type { GuideConfig, GuideConfigInput, MdcpConfigInput } from '../config/schema.js';
+import { resolveGuideLinkBase } from '../config/load.js';
 import type { PublishPathRewriteOptions } from './publish-links.js';
 
 const FILE_LINK_RE = /\[[^\]]*\]\(([^)]+\.md)(?:#[^)]*)?\)/g;
@@ -104,7 +105,7 @@ export interface AssembleGuideOptions {
   hooks?: string[];
   stripAnchors?: boolean;
   outputBasename?: string;
-  /** Absolute path to compiled guide output when compile.outputFile is set. */
+  /** Absolute path to the rendered document (per-guide output or monolith). */
   outputFile?: string;
   publishPathRewrite?: PublishPathRewriteOptions;
   config?: MdcpConfigInput;
@@ -227,6 +228,8 @@ export function compileGuideResults(options: CompileOptions): CompileGuideResult
     const compile = cfg?.compile;
     const outputBasename = compile?.outputFile ? basename(compile.outputFile) : undefined;
 
+    const linkBase = resolveGuideLinkBase(options.config ?? {}, cwd, compile);
+
     const text = assembleGuide(guideDir, {
       manifest: compile?.manifest,
       scopeRoot: compile?.scopeRoot ? resolve(cwd, compile.scopeRoot) : undefined,
@@ -236,7 +239,7 @@ export function compileGuideResults(options: CompileOptions): CompileGuideResult
       hooks: compile?.hooks,
       stripAnchors: compile?.stripAnchors,
       outputBasename,
-      outputFile: compile?.outputFile ? resolve(cwd, compile.outputFile) : undefined,
+      outputFile: linkBase,
       publishPathRewrite: compile?.publishPathRewrite,
       config: options.config,
     });

--- a/packages/mdcp-core/src/compile/hooks.ts
+++ b/packages/mdcp-core/src/compile/hooks.ts
@@ -21,7 +21,11 @@ export interface CompileHookContext {
   body: string;
   config: MdcpConfigInput;
   outputBasename?: string;
+  /** Absolute path to compiled guide output when compile.outputFile is set. */
+  outputFile?: string;
   sourceFile: string;
+  /** Absolute repo / scope root for resolving evidence paths (compile.scopeRoot). */
+  scopeRoot?: string;
   /** Mutable per-guide state shared across shard hook invocations during assemble. */
   hookState?: CompileHookState;
 }

--- a/packages/mdcp-core/src/compile/hooks.ts
+++ b/packages/mdcp-core/src/compile/hooks.ts
@@ -21,7 +21,7 @@ export interface CompileHookContext {
   body: string;
   config: MdcpConfigInput;
   outputBasename?: string;
-  /** Absolute path to compiled guide output when compile.outputFile is set. */
+  /** Absolute path to the rendered document (per-guide output or monolith). */
   outputFile?: string;
   sourceFile: string;
   /** Absolute repo / scope root for resolving evidence paths (compile.scopeRoot). */

--- a/packages/mdcp-core/src/compile/hooks/code-evidence.ts
+++ b/packages/mdcp-core/src/compile/hooks/code-evidence.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, relative } from 'node:path';
 import type { CompileHook } from '../hooks.js';
-import { hookSearchRoots, resolveRelativeFile } from './path-resolve.js';
+import { defaultSearchRoots, resolveRelativeFile } from './path-resolve.js';
 
 const MD_LINK_RE = /\[([^\]]*)\]\(([^)]+)\)/g;
 
@@ -43,6 +43,12 @@ export function symbolFromLabel(label: string): string | null {
   if (!stripped || lineRangeFromText(stripped)) return null;
   if (!IDENT_RE.test(stripped)) return null;
   return stripped;
+}
+
+function evidenceSearchRoots(scopeRoot?: string): string[] {
+  const roots = defaultSearchRoots();
+  if (scopeRoot) roots.push(scopeRoot);
+  return roots;
 }
 
 function lineForSymbol(filePath: string, symbol: string): string | null {
@@ -110,8 +116,7 @@ function rewriteEvidenceLink(
 
 export const codeEvidenceHook: CompileHook = (ctx) => {
   const guideDir = dirname(ctx.sourceFile);
-  const searchRoots = hookSearchRoots(ctx, 'codeEvidence');
-  if (ctx.scopeRoot) searchRoots.push(ctx.scopeRoot);
+  const searchRoots = evidenceSearchRoots(ctx.scopeRoot);
 
   return ctx.body.replace(MD_LINK_RE, (match, label: string, target: string) => {
     if (!isSourcePath(target.split('#')[0])) return match;

--- a/packages/mdcp-core/src/compile/hooks/code-evidence.ts
+++ b/packages/mdcp-core/src/compile/hooks/code-evidence.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { dirname, relative } from 'node:path';
 import type { CompileHook } from '../hooks.js';
 import { hookSearchRoots, resolveRelativeFile } from './path-resolve.js';
 
@@ -11,7 +11,9 @@ const LINE_RANGE_RE =
 const SOURCE_EXT_RE =
   /\.(ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|rb|php|cs|swift|rules|yaml|yml|json|toml|sh|bash|zsh|sql|graphql|proto|vue|svelte)$/i;
 
-function isSourcePath(path: string): boolean {
+const IDENT_RE = /^[\w$]+$/;
+
+export function isSourcePath(path: string): boolean {
   if (!path || path.startsWith('http://') || path.startsWith('https://') || path.startsWith('#')) {
     return false;
   }
@@ -20,12 +22,12 @@ function isSourcePath(path: string): boolean {
   return SOURCE_EXT_RE.test(base) || !base.includes('.');
 }
 
-function formatLineFragment(start: string, end?: string): string {
+export function formatLineFragment(start: string, end?: string): string {
   if (end && end !== start) return `L${start}-L${end}`;
   return `L${start}`;
 }
 
-function lineRangeFromText(text: string): string | null {
+export function lineRangeFromText(text: string): string | null {
   LINE_RANGE_RE.lastIndex = 0;
   const m = LINE_RANGE_RE.exec(text);
   if (!m) return null;
@@ -36,14 +38,23 @@ function lineRangeFromText(text: string): string | null {
   return null;
 }
 
+export function symbolFromLabel(label: string): string | null {
+  const stripped = label.replace(/^`+|`+$/g, '').trim();
+  if (!stripped || lineRangeFromText(stripped)) return null;
+  if (!IDENT_RE.test(stripped)) return null;
+  return stripped;
+}
+
 function lineForSymbol(filePath: string, symbol: string): string | null {
   const text = readFileSync(filePath, 'utf-8');
   const lines = text.split('\n');
+  const escaped = symbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const patterns = [
-    new RegExp(`\\b${symbol}\\b`),
-    new RegExp(`\\bfunction\\s+${symbol}\\b`),
-    new RegExp(`\\bclass\\s+${symbol}\\b`),
-    new RegExp(`\\b${symbol}\\s*\\(`),
+    new RegExp(`\\b${escaped}\\b`),
+    new RegExp(`\\bfunction\\s+${escaped}\\b`),
+    new RegExp(`\\bclass\\s+${escaped}\\b`),
+    new RegExp(`\\b(?:const|let|var|export)\\s+${escaped}\\b`),
+    new RegExp(`\\b${escaped}\\s*\\(`),
   ];
   for (let i = 0; i < lines.length; i++) {
     if (patterns.some((re) => re.test(lines[i]))) {
@@ -53,11 +64,21 @@ function lineForSymbol(filePath: string, symbol: string): string | null {
   return null;
 }
 
+function posixRelative(fromDir: string, toFile: string): string {
+  return relative(fromDir, toFile).replace(/\\/g, '/');
+}
+
+function outputPathForLink(pathPart: string, resolved: string | null, outputFile?: string): string {
+  if (!resolved || !outputFile) return pathPart;
+  return posixRelative(dirname(outputFile), resolved);
+}
+
 function rewriteEvidenceLink(
   label: string,
   target: string,
   guideDir: string,
   searchRoots: string[],
+  outputFile?: string,
 ): string {
   const [pathPart, fragment] = target.split('#');
   if (!isSourcePath(pathPart)) return `[${label}](${target})`;
@@ -65,27 +86,35 @@ function rewriteEvidenceLink(
   const existingLine = fragment?.match(/^L\d+(?:-L\d+)?$/i);
   if (existingLine) {
     const normalized = fragment.replace(/^l/i, 'L');
-    return `[${label}](${pathPart}#${normalized})`;
+    const resolved = resolveRelativeFile(pathPart, guideDir, searchRoots);
+    const outPath = outputPathForLink(pathPart, resolved, outputFile);
+    return `[${label}](${outPath}#${normalized})`;
   }
 
+  const resolved = resolveRelativeFile(pathPart, guideDir, searchRoots);
+
   let lineFrag = lineRangeFromText(label) ?? lineRangeFromText(pathPart);
-  if (!lineFrag && fragment && !fragment.match(/^L\d/i)) {
-    const resolved = resolveRelativeFile(pathPart, guideDir, searchRoots);
-    if (resolved) {
-      lineFrag = lineForSymbol(resolved, fragment) ?? null;
-    }
+  if (!lineFrag && fragment && !fragment.match(/^L\d/i) && resolved) {
+    lineFrag = lineForSymbol(resolved, fragment);
+  }
+  if (!lineFrag && resolved) {
+    const symbol = symbolFromLabel(label);
+    if (symbol) lineFrag = lineForSymbol(resolved, symbol);
   }
 
   if (!lineFrag) return `[${label}](${target})`;
-  return `[${label}](${pathPart}#${lineFrag})`;
+
+  const outPath = outputPathForLink(pathPart, resolved, outputFile);
+  return `[${label}](${outPath}#${lineFrag})`;
 }
 
 export const codeEvidenceHook: CompileHook = (ctx) => {
   const guideDir = dirname(ctx.sourceFile);
   const searchRoots = hookSearchRoots(ctx, 'codeEvidence');
+  if (ctx.scopeRoot) searchRoots.push(ctx.scopeRoot);
 
   return ctx.body.replace(MD_LINK_RE, (match, label: string, target: string) => {
     if (!isSourcePath(target.split('#')[0])) return match;
-    return rewriteEvidenceLink(label, target, guideDir, searchRoots);
+    return rewriteEvidenceLink(label, target, guideDir, searchRoots, ctx.outputFile);
   });
 };

--- a/packages/mdcp-core/src/compile/hooks/path-resolve.ts
+++ b/packages/mdcp-core/src/compile/hooks/path-resolve.ts
@@ -8,7 +8,7 @@ export function defaultSearchRoots(): string[] {
 
 export function hookSearchRoots(
   ctx: Pick<CompileHookContext, 'guideName' | 'config'>,
-  configKey: 'codeEvidence' | 'inlineInserts' | 'reviewLinks',
+  configKey: 'inlineInserts' | 'reviewLinks',
 ): string[] {
   const roots = defaultSearchRoots();
   const guideCfg = ctx.config.guides?.find((g) => g.name === ctx.guideName);

--- a/packages/mdcp-core/src/config/load.ts
+++ b/packages/mdcp-core/src/config/load.ts
@@ -30,6 +30,18 @@ export function resolveGuideDir(name: string, config: MdcpConfig, cwd: string): 
   return join(resolveGuidesRoot(config, cwd), name);
 }
 
+/** Absolute path to the rendered document readers open (per-guide output or monolith). */
+export function resolveGuideLinkBase(
+  config: { outputDir?: string; outputFile?: string },
+  cwd: string,
+  compile?: { outputFile?: string },
+): string {
+  if (compile?.outputFile) return resolve(cwd, compile.outputFile);
+  const outputDir = config.outputDir ?? '.';
+  const outputFile = config.outputFile ?? 'guides.md';
+  return resolveUnderOutputDir(cwd, outputDir, outputFile);
+}
+
 export function getGuideConfig(config: MdcpConfig, name: string): GuideConfig | undefined {
   return config.guides?.find((g) => g.name === name);
 }

--- a/packages/mdcp-core/src/config/schema.ts
+++ b/packages/mdcp-core/src/config/schema.ts
@@ -46,11 +46,6 @@ const GuideSchema = z.object({
       hooks: z.array(z.string()).optional(),
       hooksConfig: z
         .object({
-          codeEvidence: z
-            .object({
-              searchRoots: z.array(z.string()).optional(),
-            })
-            .optional(),
           reviewLinks: z
             .object({
               targetMonolith: z.string().optional(),

--- a/packages/mdcp-core/src/index.ts
+++ b/packages/mdcp-core/src/index.ts
@@ -8,6 +8,7 @@ export {
 export {
   loadConfig,
   resolveOutputPath,
+  resolveGuideLinkBase,
   resolveRefsPath,
   resolveGuidesRoot,
   resolveGuideDir,

--- a/packages/mdcp-core/test/builtin-hooks.test.ts
+++ b/packages/mdcp-core/test/builtin-hooks.test.ts
@@ -23,30 +23,6 @@ const baseCtx = {
 describe('builtin compile hooks', () => {
   const work = useTmpDir('mdcp-hooks-');
 
-  it('codeEvidence adds line fragments from link text', () => {
-    const out = applyCompileHooks(
-      'See [firestore.rules L6-L8](firestore.rules) for rules.',
-      { ...baseCtx, sourceFile: '/tmp/claim.md' },
-      ['codeEvidence'],
-    );
-    expect(out).toContain('](firestore.rules#L6-L8)');
-  });
-
-  it('codeEvidence resolves symbol fragments when file exists', () => {
-    const guideDir = join(work.path, 'review');
-    mkdirSync(guideDir, { recursive: true });
-    writeFileSync(join(guideDir, 'util.ts'), 'export function helper() {\n  return 1;\n}\n');
-    const sourceFile = join(guideDir, 'claim.md');
-    withCwd(work.path, () => {
-      const out = applyCompileHooks(
-        'Evidence: [helper](util.ts#helper)',
-        { ...baseCtx, sourceFile },
-        ['codeEvidence'],
-      );
-      expect(out).toMatch(/util\.ts#L\d+\)/);
-    });
-  });
-
   it('reviewLinks rewrites FIND shard links to monolith anchors', () => {
     const outcomes = join(work.path, 'review', 'outcomes');
     mkdirSync(outcomes, { recursive: true });

--- a/packages/mdcp-core/test/code-evidence.test.ts
+++ b/packages/mdcp-core/test/code-evidence.test.ts
@@ -12,15 +12,14 @@ import {
   lineRangeFromText,
   symbolFromLabel,
 } from '../src/compile/hooks/code-evidence.js';
-import { assembleGuide } from '../src/compile/assemble.js';
+import { assembleGuide, compileGuides } from '../src/compile/assemble.js';
+import { resolveGuideLinkBase } from '../src/config/load.js';
 import { useTmpDir, withCwd } from './helpers/tmp-dir.js';
 
 const baseCtx = {
   guideName: 'review',
   filename: 'claim.md',
-  config: {
-    guides: [{ name: 'review', compile: { scopeRoot: '.', outputFile: 'architecture-review.md' } }],
-  } as never,
+  config: { guides: [{ name: 'review' }] } as never,
 };
 
 function runCodeEvidence(body: string, sourceFile: string, extra: object = {}) {
@@ -114,6 +113,45 @@ describe('codeEvidence — path rewrite for rendered output', () => {
       });
       expect(out).toContain('[`orgCount`](../functions/src/foo.ts#L1)');
       expect(out).not.toContain('../../functions/src/foo.ts');
+    });
+  });
+
+  it('rewrites evidence paths relative to monolith output by default', () => {
+    const functionsDir = join(work.path, 'functions', 'src');
+    const guideDir = join(work.path, 'docs', 'review');
+    mkdirSync(functionsDir, { recursive: true });
+    mkdirSync(guideDir, { recursive: true });
+    writeFileSync(join(functionsDir, 'foo.ts'), 'export const orgCount = 1;\n');
+    writeFileSync(join(guideDir, 'index.md'), '# Review\n\n- [Claim](./claim.md)\n');
+    writeFileSync(
+      join(guideDir, 'claim.md'),
+      'Evidence: [`orgCount`](../../functions/src/foo.ts)\n',
+    );
+
+    withCwd(work.path, () => {
+      const out = compileGuides({
+        guidesRoot: join(work.path, 'docs'),
+        compileOrder: ['review'],
+        cwd: work.path,
+        config: {
+          outputDir: 'docs',
+          outputFile: 'guides.md',
+          compileOrder: ['review'],
+        },
+        guides: [{ name: 'review', compile: { hooks: ['codeEvidence'] } }],
+      });
+      expect(out).toContain('[`orgCount`](../functions/src/foo.ts#L1)');
+      expect(out).not.toContain('../../functions/src/foo.ts');
+    });
+  });
+
+  it('resolveGuideLinkBase prefers per-guide output over monolith', () => {
+    withCwd(work.path, () => {
+      expect(
+        resolveGuideLinkBase({ outputDir: 'docs', outputFile: 'guides.md' }, work.path, {
+          outputFile: 'architecture-review.md',
+        }),
+      ).toBe(join(work.path, 'architecture-review.md'));
     });
   });
 

--- a/packages/mdcp-core/test/code-evidence.test.ts
+++ b/packages/mdcp-core/test/code-evidence.test.ts
@@ -1,0 +1,145 @@
+/**
+ * codeEvidence — tests driven by the spec in docs/client-core/compile-hooks.md.
+ * Docs first, then TDD: each describe block maps to a spec section.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { applyCompileHooks } from '../src/compile/hooks.js';
+import '../src/compile/hooks/builtin.js';
+import {
+  isSourcePath,
+  lineRangeFromText,
+  symbolFromLabel,
+} from '../src/compile/hooks/code-evidence.js';
+import { assembleGuide } from '../src/compile/assemble.js';
+import { useTmpDir, withCwd } from './helpers/tmp-dir.js';
+
+const baseCtx = {
+  guideName: 'review',
+  filename: 'claim.md',
+  config: {
+    guides: [{ name: 'review', compile: { scopeRoot: '.', outputFile: 'architecture-review.md' } }],
+  } as never,
+};
+
+function runCodeEvidence(body: string, sourceFile: string, extra: object = {}) {
+  return applyCompileHooks(body, { ...baseCtx, sourceFile, ...extra }, ['codeEvidence']);
+}
+
+describe('codeEvidence — link matching', () => {
+  it('matches source file paths and skips markdown or external URLs', () => {
+    expect(isSourcePath('util.ts')).toBe(true);
+    expect(isSourcePath('../../functions/src/foo.ts')).toBe(true);
+    expect(isSourcePath('firestore.rules')).toBe(true);
+    expect(isSourcePath('./intro.md')).toBe(false);
+    expect(isSourcePath('https://example.com/a.ts')).toBe(false);
+    expect(isSourcePath('#anchor')).toBe(false);
+  });
+});
+
+describe('codeEvidence — line range detection', () => {
+  it('parses common line range forms from label text', () => {
+    expect(lineRangeFromText('firestore.rules L6-L8')).toBe('L6-L8');
+    expect(lineRangeFromText('line 42')).toBe('L42');
+    expect(lineRangeFromText(':10-20')).toBe('L10-L20');
+    expect(lineRangeFromText(':7')).toBe('L7');
+    expect(lineRangeFromText('orgCount')).toBeNull();
+  });
+});
+
+describe('codeEvidence — symbol resolution', () => {
+  it('extracts symbol names from backtick labels', () => {
+    expect(symbolFromLabel('`orgCount`')).toBe('orgCount');
+    expect(symbolFromLabel('orgCount')).toBe('orgCount');
+    expect(symbolFromLabel('L6-L8')).toBeNull();
+  });
+
+  const work = useTmpDir('mdcp-code-evidence-');
+
+  it('resolves symbol from URL fragment when file exists', () => {
+    const guideDir = join(work.path, 'review');
+    mkdirSync(guideDir, { recursive: true });
+    writeFileSync(join(guideDir, 'util.ts'), 'export function helper() {\n  return 1;\n}\n');
+    const sourceFile = join(guideDir, 'claim.md');
+    withCwd(work.path, () => {
+      const out = runCodeEvidence('Evidence: [helper](util.ts#helper)', sourceFile);
+      expect(out).toMatch(/util\.ts#L\d+\)/);
+    });
+  });
+
+  it('resolves symbol from link label when no URL fragment is present', () => {
+    const functionsDir = join(work.path, 'functions', 'src');
+    const guideDir = join(work.path, 'docs', 'review');
+    mkdirSync(functionsDir, { recursive: true });
+    mkdirSync(guideDir, { recursive: true });
+    writeFileSync(
+      join(functionsDir, 'foo.ts'),
+      'export const orgCount = 3;\nexport const other = 1;\n',
+    );
+    const sourceFile = join(guideDir, 'claim.md');
+    withCwd(work.path, () => {
+      const out = runCodeEvidence(
+        'Evidence: [`orgCount`](../../functions/src/foo.ts)',
+        sourceFile,
+        { scopeRoot: work.path },
+      );
+      expect(out).toContain('foo.ts#L1)');
+    });
+  });
+});
+
+describe('codeEvidence — path rewrite for rendered output', () => {
+  const work = useTmpDir('mdcp-code-evidence-path-');
+
+  it('rewrites shard-relative paths relative to compile.outputFile', () => {
+    const functionsDir = join(work.path, 'functions', 'src');
+    const guideDir = join(work.path, 'docs', 'review');
+    mkdirSync(functionsDir, { recursive: true });
+    mkdirSync(guideDir, { recursive: true });
+    writeFileSync(join(functionsDir, 'foo.ts'), 'export const orgCount = 1;\n');
+    writeFileSync(join(guideDir, 'index.md'), '# Review\n\n- [Claim](./claim.md)\n');
+    writeFileSync(
+      join(guideDir, 'claim.md'),
+      'Evidence: [`orgCount`](../../functions/src/foo.ts)\n',
+    );
+
+    withCwd(work.path, () => {
+      const out = assembleGuide(guideDir, {
+        manifest: 'index.md',
+        hooks: ['codeEvidence'],
+        scopeRoot: work.path,
+        outputFile: join(work.path, 'docs', 'architecture-review.md'),
+        config: baseCtx.config,
+      });
+      expect(out).toContain('[`orgCount`](../functions/src/foo.ts#L1)');
+      expect(out).not.toContain('../../functions/src/foo.ts');
+    });
+  });
+
+  it('adds line fragments from label text without resolving symbols', () => {
+    const out = runCodeEvidence(
+      'See [firestore.rules L6-L8](firestore.rules) for rules.',
+      '/tmp/claim.md',
+    );
+    expect(out).toContain('](firestore.rules#L6-L8)');
+  });
+});
+
+describe('codeEvidence — exclusions', () => {
+  const work = useTmpDir('mdcp-code-evidence-excl-');
+
+  it('leaves markdown shard links unchanged', () => {
+    const guideDir = join(work.path, 'review');
+    mkdirSync(guideDir, { recursive: true });
+    const body = 'See [intro](./intro.md) for context.';
+    expect(runCodeEvidence(body, join(guideDir, 'claim.md'))).toBe(body);
+  });
+
+  it('leaves unresolved source links without line hints unchanged', () => {
+    const guideDir = join(work.path, 'review');
+    mkdirSync(guideDir, { recursive: true });
+    const body = 'Evidence: [`missing`](../../nowhere/missing.ts)';
+    expect(runCodeEvidence(body, join(guideDir, 'claim.md'))).toBe(body);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a full `codeEvidence` compile hook spec in `docs/client-core/compile-hooks.md` (line ranges, symbol resolution from labels/fragments, path lookup, output-relative rewriting).
- Implement hook behavior: resolve evidence links to GitHub `#L` fragments, resolve symbols from link labels (e.g. `` [`orgCount`](../../functions/src/foo.ts) ``), include `compile.scopeRoot` in file lookup, and rewrite paths relative to `compile.outputFile` so links work in rendered output.
- Add TDD coverage in `packages/mdcp-core/test/code-evidence.test.ts` including an `assembleGuide` integration test.

Closes #15.

## Test plan

- [x] `pnpm --filter @bwilliamson/mdcp-core exec vitest run`
- [x] Pre-commit hook (typecheck, related tests, docs compile/check)
- [ ] Consumer review shard with `` [`orgCount`](../../functions/src/foo.ts) `` and `"hooks": ["codeEvidence"]` produces `#L…` fragment and output-relative path
- [ ] Pair with `compile.publishPathRewrite` on publish outputs (e.g. `../../functions/…` → `functions/…#L…`)


Made with [Cursor](https://cursor.com)