### PR TITLE
fix: scope shard markdownlint to in-scope guide paths (#17)

### DIFF
--- a/.changeset/shard-lint-scope-fix.md
+++ b/.changeset/shard-lint-scope-fix.md
@@ -1,0 +1,9 @@
+---
+'@bwilliamson/mdcp-core': patch
+'@bwilliamson/mdcp-cli': patch
+'@bwilliamson/mdcp-presets': patch
+---
+
+Scope shard markdownlint and Vale prose to registered guide shard trees only. `mdcp lint` and `mdcp check` pass `compileOrder` guide directories to markdownlint-cli2 instead of linting every `**/*.md` under `--cwd`. Add `lint.markdownlint.shardsGlobs` optional override and export `guideScanDirs` / `shardLintPaths` from core (xref scan delegates to the same helper). Remove the broad `**/*.md` glob from the shard preset — rules and exclusions only.
+
+**Old behavior:** the shard preset linted all markdown under `--cwd`, including legacy flat docs outside guide trees. Consumers who relied on that must add explicit paths to `shardsGlobs` or run markdownlint separately.

--- a/docs/client-cli/config-essentials.md
+++ b/docs/client-cli/config-essentials.md
@@ -83,16 +83,18 @@ Minimal `mdcp.config.json`:
 }
 ```
 
-| Field               | Purpose                                                |
-| ------------------- | ------------------------------------------------------ |
-| `compileOrder`      | Order of guide directories in the compiled monolith    |
-| `guides`            | Per-guide options (hooks, manifests, separate outputs) |
-| `outputDir`         | Compile output root (relative to `--cwd`)              |
-| `outputFile`        | Monolith filename (relative to `outputDir`)            |
-| `refs.registryFile` | Cross-link lookup table (relative to `outputDir`)      |
-| `lint`              | markdownlint configs, xref checks, link checking       |
-| `vale`              | Prose lint paths and `.vale.ini` location              |
-| `source`            | Monolith path — required only for `mdcp shard`         |
+| Field                           | Purpose                                                                            |
+| ------------------------------- | ---------------------------------------------------------------------------------- |
+| `compileOrder`                  | Order of guide directories in the compiled monolith                                |
+| `guides`                        | Per-guide options (hooks, manifests, separate outputs)                             |
+| `outputDir`                     | Compile output root (relative to `--cwd`)                                          |
+| `outputFile`                    | Monolith filename (relative to `outputDir`)                                        |
+| `refs.registryFile`             | Cross-link lookup table (relative to `outputDir`)                                  |
+| `lint`                          | markdownlint configs, xref checks, link checking                                   |
+| `lint.markdownlint.shardsGlobs` | Optional shard lint paths relative to `--cwd` (default: `compileOrder` guide dirs) |
+| `vale`                          | Prose lint and `.vale.ini` location                                                |
+| `vale.scanGlobs`                | Optional Vale paths relative to `--cwd` (default: same guide dirs as shard lint)   |
+| `source`                        | Monolith path — required only for `mdcp shard`                                     |
 
 **Nested `outputDir` example** — use outputDir-relative filenames:
 

--- a/docs/client-cli/optional-linters.md
+++ b/docs/client-cli/optional-linters.md
@@ -29,3 +29,25 @@ npm install -D prettier markdownlint-cli2 @bwilliamson/mdcp-presets
 Install **Vale** separately so `vale` is on your `PATH` — see [Vale installation](https://vale.sh/docs/vale-cli/installation/) (Homebrew, Chocolatey, Snap, or GitHub release). After adding a `.vale.ini`, run `vale sync` in that directory.
 
 Wire preset paths in `mdcp.config.json` under `lint.markdownlint`. See `@bwilliamson/mdcp-presets` on npm.
+
+## In-scope guide fileset
+
+MDCP knows the **full fileset** it manages: registered guides in `compileOrder`, resolved via `guides[].path` or `outputDir/<name>`. Shard markdownlint and Vale prose **only touch documents in that scope** — never legacy flat `.md` files, unregistered sibling folders, or other markdown under `--cwd` that mdcp does not compile.
+
+| Command                                        | Default scope                                   | Out of scope (skipped)                            |
+| ---------------------------------------------- | ----------------------------------------------- | ------------------------------------------------- |
+| Shard markdownlint (`mdcp lint`, `mdcp check`) | `compileOrder` guide directories                | Legacy flat docs, unrelated subdirs under `--cwd` |
+| Vale prose (`mdcp prose`, `mdcp check`)        | Same guide directories                          | Same                                              |
+| Xref lint (`mdcp check`)                       | Same guide directories                          | Same                                              |
+| Compiled markdownlint                          | Monolith and publish outputs (`compiledConfig`) | Separate pass — not shard trees                   |
+
+Optional overrides **narrow** scope further; they never widen it beyond what you explicitly list:
+
+| Config field                    | Purpose                                                                         |
+| ------------------------------- | ------------------------------------------------------------------------------- |
+| `lint.markdownlint.shardsGlobs` | Shard markdownlint paths relative to `--cwd` (default: compileOrder guide dirs) |
+| `vale.scanGlobs`                | Vale prose paths relative to `--cwd` (default: same guide dirs)                 |
+
+The `@bwilliamson/mdcp-presets` shard config supplies **rules and exclusions** (`!**/index.md`, `!guides.md`). **Scope always comes from the CLI** — not from preset globs.
+
+`mdcp fix` is out of band: it runs unscoped `prettier --write .` and `markdownlint-cli2 --fix` across the repo and is not part of mdcp's guide fileset gate.

--- a/docs/client-core/api-config.md
+++ b/docs/client-core/api-config.md
@@ -4,7 +4,7 @@
 | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | `loadConfig(path, configBase)`                                                         | Load and validate `mdcp.config.json` (`path` is resolved from `configBase`) |
 | `resolveOutputPath`, `resolveRefsPath`, `resolveGuidesRoot`, `resolveGuideDir`         | Path resolvers for outputDir-relative config fields                         |
-| `getGuideConfig`, `xrefScanDirs`                                                       | Per-guide and xref scan helpers                                             |
+| `getGuideConfig`, `guideScanDirs`, `shardLintPaths`, `xrefScanDirs`                    | In-scope guide fileset and xref scan helpers                                |
 | `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput` | Zod schema and types                                                        |
 
 ## Path resolution: `configBase` vs docs root

--- a/docs/features/feature-catalog.md
+++ b/docs/features/feature-catalog.md
@@ -58,7 +58,7 @@ Fail on bare `Ch. N` and unlinked chapter-style references.
 
 ## Peer linters (P2.1)
 
-Orchestrate markdownlint-cli2, Vale, Prettier, markdown-link-check from host repo.
+Orchestrate markdownlint-cli2, Vale, Prettier, markdown-link-check from host repo. Shard markdownlint and Vale prose only touch registered guide shard trees (`compileOrder`); optional `shardsGlobs` / `vale.scanGlobs` narrow scope further.
 
 ## Compile hooks (P2.2)
 

--- a/docs/mdcp.config.json
+++ b/docs/mdcp.config.json
@@ -35,7 +35,8 @@
   "lint": {
     "markdownlint": {
       "shardsConfig": "../packages/mdcp-presets/markdownlint-shards.markdownlint-cli2.jsonc",
-      "compiledConfig": "compiled-lint.markdownlint-cli2.jsonc"
+      "compiledConfig": "compiled-lint.markdownlint-cli2.jsonc",
+      "shardsGlobs": ["features", "developer", "client-cli", "client-core"]
     },
     "xrefs": { "enabled": true }
   },

--- a/packages/mdcp-cli/README.md
+++ b/packages/mdcp-cli/README.md
@@ -171,16 +171,18 @@ Minimal `mdcp.config.json`:
 }
 ```
 
-| Field               | Purpose                                                |
-| ------------------- | ------------------------------------------------------ |
-| `compileOrder`      | Order of guide directories in the compiled monolith    |
-| `guides`            | Per-guide options (hooks, manifests, separate outputs) |
-| `outputDir`         | Compile output root (relative to `--cwd`)              |
-| `outputFile`        | Monolith filename (relative to `outputDir`)            |
-| `refs.registryFile` | Cross-link lookup table (relative to `outputDir`)      |
-| `lint`              | markdownlint configs, xref checks, link checking       |
-| `vale`              | Prose lint paths and `.vale.ini` location              |
-| `source`            | Monolith path — required only for `mdcp shard`         |
+| Field                           | Purpose                                                                            |
+| ------------------------------- | ---------------------------------------------------------------------------------- |
+| `compileOrder`                  | Order of guide directories in the compiled monolith                                |
+| `guides`                        | Per-guide options (hooks, manifests, separate outputs)                             |
+| `outputDir`                     | Compile output root (relative to `--cwd`)                                          |
+| `outputFile`                    | Monolith filename (relative to `outputDir`)                                        |
+| `refs.registryFile`             | Cross-link lookup table (relative to `outputDir`)                                  |
+| `lint`                          | markdownlint configs, xref checks, link checking                                   |
+| `lint.markdownlint.shardsGlobs` | Optional shard lint paths relative to `--cwd` (default: `compileOrder` guide dirs) |
+| `vale`                          | Prose lint and `.vale.ini` location                                                |
+| `vale.scanGlobs`                | Optional Vale paths relative to `--cwd` (default: same guide dirs as shard lint)   |
+| `source`                        | Monolith path — required only for `mdcp shard`                                     |
 
 **Nested `outputDir` example** — use outputDir-relative filenames:
 
@@ -554,3 +556,25 @@ npm install -D prettier markdownlint-cli2 @bwilliamson/mdcp-presets
 Install **Vale** separately so `vale` is on your `PATH` — see [Vale installation](https://vale.sh/docs/vale-cli/installation/) (Homebrew, Chocolatey, Snap, or GitHub release). After adding a `.vale.ini`, run `vale sync` in that directory.
 
 Wire preset paths in `mdcp.config.json` under `lint.markdownlint`. See `@bwilliamson/mdcp-presets` on npm.
+
+### In-scope guide fileset
+
+MDCP knows the **full fileset** it manages: registered guides in `compileOrder`, resolved via `guides[].path` or `outputDir/<name>`. Shard markdownlint and Vale prose **only touch documents in that scope** — never legacy flat `.md` files, unregistered sibling folders, or other markdown under `--cwd` that mdcp does not compile.
+
+| Command                                        | Default scope                                   | Out of scope (skipped)                            |
+| ---------------------------------------------- | ----------------------------------------------- | ------------------------------------------------- |
+| Shard markdownlint (`mdcp lint`, `mdcp check`) | `compileOrder` guide directories                | Legacy flat docs, unrelated subdirs under `--cwd` |
+| Vale prose (`mdcp prose`, `mdcp check`)        | Same guide directories                          | Same                                              |
+| Xref lint (`mdcp check`)                       | Same guide directories                          | Same                                              |
+| Compiled markdownlint                          | Monolith and publish outputs (`compiledConfig`) | Separate pass — not shard trees                   |
+
+Optional overrides **narrow** scope further; they never widen it beyond what you explicitly list:
+
+| Config field                    | Purpose                                                                         |
+| ------------------------------- | ------------------------------------------------------------------------------- |
+| `lint.markdownlint.shardsGlobs` | Shard markdownlint paths relative to `--cwd` (default: compileOrder guide dirs) |
+| `vale.scanGlobs`                | Vale prose paths relative to `--cwd` (default: same guide dirs)                 |
+
+The `@bwilliamson/mdcp-presets` shard config supplies **rules and exclusions** (`!**/index.md`, `!guides.md`). **Scope always comes from the CLI** — not from preset globs.
+
+`mdcp fix` is out of band: it runs unscoped `prettier --write .` and `markdownlint-cli2 --fix` across the repo and is not part of mdcp's guide fileset gate.

--- a/packages/mdcp-cli/src/cli.ts
+++ b/packages/mdcp-cli/src/cli.ts
@@ -9,6 +9,8 @@ import {
   resolveGuidesRoot,
   resolveGuideDir,
   getGuideConfig,
+  guideScanDirs,
+  shardLintPaths,
   xrefScanDirs,
   compileGuides,
   writeCompiledGuides,
@@ -35,6 +37,10 @@ interface GlobalOpts {
 
 function getConfig(opts: GlobalOpts) {
   return loadConfig(opts.config, process.cwd());
+}
+
+function valeScanPaths(config: MdcpConfig, cwd: string): string[] {
+  return config.vale?.scanGlobs?.map((g) => resolve(cwd, g)) ?? guideScanDirs(config, cwd);
 }
 
 function guideEntries(config: MdcpConfig, cwd: string) {
@@ -203,10 +209,11 @@ program
     const compiledCfg = config.lint?.markdownlint?.compiledConfig;
 
     if (shardsCfg) {
+      const shardPaths = shardLintPaths(config, opts.cwd);
       const r = runPeer(tool, {
         require: lintOpts.requireLint,
         cwd: opts.cwd,
-        args: ['--config', shardsCfg],
+        args: ['--config', shardsCfg, ...shardPaths],
       });
       if (r.exitCode !== 0) process.exit(r.exitCode);
     }
@@ -232,7 +239,7 @@ program
     const opts = cmd.parent.opts() as GlobalOpts;
     const config = getConfig(opts);
     const tool = findPeerBinary('vale', opts.cwd);
-    const scanPaths = config.vale?.scanGlobs ?? guideEntries(config, opts.cwd).map((g) => g.dir);
+    const scanPaths = valeScanPaths(config, opts.cwd);
     const valeConfig = config.vale?.config ?? '.vale.ini';
     const minLevel = valeMinAlertLevel(config, proseOpts.strict);
     const args = minLevel
@@ -354,10 +361,11 @@ program
     const shardsCfg = config.lint?.markdownlint?.shardsConfig;
     const compiledCfg = config.lint?.markdownlint?.compiledConfig;
     if (shardsCfg) {
+      const shardPaths = shardLintPaths(config, opts.cwd);
       const r = runPeer(mdlint, {
         require: checkOpts.requireLint,
         cwd: opts.cwd,
-        args: ['--config', shardsCfg],
+        args: ['--config', shardsCfg, ...shardPaths],
       });
       if (r.exitCode !== 0) failed = true;
     }
@@ -383,7 +391,7 @@ program
 
     if (!checkOpts.skipVale) {
       const vale = findPeerBinary('vale', opts.cwd);
-      const scanPaths = config.vale?.scanGlobs ?? guideEntries(config, opts.cwd).map((g) => g.dir);
+      const scanPaths = valeScanPaths(config, opts.cwd);
       const valeConfig = config.vale?.config ?? '.vale.ini';
       const minLevel = valeMinAlertLevel(config, true) ?? 'error';
       const r = runPeer(vale, {

--- a/packages/mdcp-cli/test/cli.smoke.test.ts
+++ b/packages/mdcp-cli/test/cli.smoke.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
@@ -10,6 +10,44 @@ const CLI = join(__dirname, '../dist/cli.js');
 const REPO_ROOT = join(__dirname, '../../..');
 const FIXTURE = join(REPO_ROOT, 'examples/sample-guides');
 const SAMPLE_CONFIG = 'examples/sample-guides/mdcp.config.json';
+const SHARDS_PRESET = join(
+  REPO_ROOT,
+  'packages/mdcp-presets/markdownlint-shards.markdownlint-cli2.jsonc',
+);
+
+function valeInstalled(): boolean {
+  return spawnSync('vale', ['--version'], { encoding: 'utf-8' }).status === 0;
+}
+
+function writeInScopeLintFixture(docs: string, configExtra: Record<string, unknown> = {}): void {
+  mkdirSync(join(docs, 'guide'), { recursive: true });
+  mkdirSync(join(docs, 'other-guide'), { recursive: true });
+  writeFileSync(
+    join(docs, 'getting-started.md'),
+    'This legacy flat doc has no top-level heading.\n',
+  );
+  writeFileSync(
+    join(docs, 'other-guide', 'stray.md'),
+    'Unregistered guide content without a heading.\n',
+  );
+  writeFileSync(join(docs, 'guide', 'index.md'), '# Guide\n\n- [section](section.md)\n');
+  writeFileSync(join(docs, 'guide', 'section.md'), '# Guide\n\n## Hello\n');
+  writeFileSync(
+    join(docs, 'mdcp.config.json'),
+    JSON.stringify({
+      outputDir: '.',
+      outputFile: 'guides.md',
+      compileOrder: ['guide'],
+      guides: [{ name: 'guide', path: 'guide' }],
+      refs: { registryFile: 'refs.json' },
+      lint: {
+        xrefs: { enabled: false },
+        markdownlint: { shardsConfig: SHARDS_PRESET },
+      },
+      ...configExtra,
+    }),
+  );
+}
 
 describe('cli smoke', () => {
   it('prints version', () => {
@@ -70,6 +108,101 @@ describe('cli smoke', () => {
         { encoding: 'utf-8', cwd: docs },
       );
       expect(existsSync(join(docs, '_build/compiled/refs.json'))).toBe(true);
+    } finally {
+      rmSync(docs, { recursive: true, force: true });
+    }
+  });
+
+  it('skips out-of-scope markdown for shard lint (#17)', () => {
+    const docs = mkdtempSync(join(tmpdir(), 'mdcp-scope-'));
+    try {
+      writeInScopeLintFixture(docs);
+      const out = execFileSync(
+        'node',
+        [
+          CLI,
+          'check',
+          '--config',
+          'mdcp.config.json',
+          '--cwd',
+          docs,
+          '--skip-vale',
+          '--require-lint',
+        ],
+        { encoding: 'utf-8', cwd: docs },
+      );
+      expect(out).toContain('mdcp check passed');
+    } finally {
+      rmSync(docs, { recursive: true, force: true });
+    }
+  });
+
+  it('honors shardsGlobs override for shard lint (#17)', () => {
+    const docs = mkdtempSync(join(tmpdir(), 'mdcp-shards-globs-'));
+    try {
+      mkdirSync(join(docs, 'narrow'), { recursive: true });
+      mkdirSync(join(docs, 'wide'), { recursive: true });
+      writeFileSync(join(docs, 'narrow', 'index.md'), '# Narrow\n\n- [a](a.md)\n');
+      writeFileSync(join(docs, 'narrow', 'a.md'), '# Narrow\n\n## A\n');
+      writeFileSync(join(docs, 'wide', 'index.md'), '# Wide\n\n- [b](b.md)\n');
+      writeFileSync(join(docs, 'wide', 'b.md'), 'No heading — would fail MD041 if linted.\n');
+      writeFileSync(
+        join(docs, 'mdcp.config.json'),
+        JSON.stringify({
+          outputDir: '.',
+          outputFile: 'guides.md',
+          compileOrder: ['narrow', 'wide'],
+          guides: [
+            { name: 'narrow', path: 'narrow' },
+            { name: 'wide', path: 'wide' },
+          ],
+          refs: { registryFile: 'refs.json' },
+          lint: {
+            xrefs: { enabled: false },
+            markdownlint: {
+              shardsConfig: SHARDS_PRESET,
+              shardsGlobs: ['narrow'],
+            },
+          },
+        }),
+      );
+
+      const out = execFileSync(
+        'node',
+        [
+          CLI,
+          'check',
+          '--config',
+          'mdcp.config.json',
+          '--cwd',
+          docs,
+          '--skip-vale',
+          '--require-lint',
+        ],
+        { encoding: 'utf-8', cwd: docs },
+      );
+      expect(out).toContain('mdcp check passed');
+    } finally {
+      rmSync(docs, { recursive: true, force: true });
+    }
+  });
+
+  it('skips out-of-scope markdown for Vale prose (#17)', () => {
+    if (!valeInstalled()) return;
+
+    const docs = mkdtempSync(join(tmpdir(), 'mdcp-vale-scope-'));
+    try {
+      writeInScopeLintFixture(docs);
+      writeFileSync(
+        join(docs, '.vale.ini'),
+        `StylesPath = ${join(REPO_ROOT, 'docs/styles')}\nMinAlertLevel = error\n`,
+      );
+
+      execFileSync(
+        'node',
+        [CLI, 'check', '--config', 'mdcp.config.json', '--cwd', docs, '--require-lint'],
+        { encoding: 'utf-8', cwd: docs },
+      );
     } finally {
       rmSync(docs, { recursive: true, force: true });
     }

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -66,7 +66,7 @@ Use `writeCompiledGuides` when you need to write the monolith and per-guide publ
 | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | `loadConfig(path, configBase)`                                                         | Load and validate `mdcp.config.json` (`path` is resolved from `configBase`) |
 | `resolveOutputPath`, `resolveRefsPath`, `resolveGuidesRoot`, `resolveGuideDir`         | Path resolvers for outputDir-relative config fields                         |
-| `getGuideConfig`, `xrefScanDirs`                                                       | Per-guide and xref scan helpers                                             |
+| `getGuideConfig`, `guideScanDirs`, `shardLintPaths`, `xrefScanDirs`                    | In-scope guide fileset and xref scan helpers                                |
 | `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput` | Zod schema and types                                                        |
 
 ### Path resolution: `configBase` vs docs root

--- a/packages/mdcp-core/src/config/load.ts
+++ b/packages/mdcp-core/src/config/load.ts
@@ -46,15 +46,22 @@ export function getGuideConfig(config: MdcpConfig, name: string): GuideConfig | 
   return config.guides?.find((g) => g.name === name);
 }
 
-export function xrefScanDirs(config: MdcpConfig, cwd: string): string[] {
+/** Registered guide directories under cwd — the mdcp-managed fileset. */
+export function guideScanDirs(config: MdcpConfig, cwd: string): string[] {
   const dirs = new Set<string>();
   for (const name of config.compileOrder) {
-    const guide = getGuideConfig(config, name);
-    if (guide?.path) {
-      dirs.add(resolve(cwd, guide.path));
-    } else {
-      dirs.add(join(resolveGuidesRoot(config, cwd), name));
-    }
+    dirs.add(resolveGuideDir(name, config, cwd));
   }
   return [...dirs];
+}
+
+/** Shard markdownlint paths: optional shardsGlobs override, else guideScanDirs. */
+export function shardLintPaths(config: MdcpConfig, cwd: string): string[] {
+  const globs = config.lint?.markdownlint?.shardsGlobs;
+  if (globs?.length) return globs.map((g) => resolve(cwd, g));
+  return guideScanDirs(config, cwd);
+}
+
+export function xrefScanDirs(config: MdcpConfig, cwd: string): string[] {
+  return guideScanDirs(config, cwd);
 }

--- a/packages/mdcp-core/src/config/schema.ts
+++ b/packages/mdcp-core/src/config/schema.ts
@@ -97,6 +97,8 @@ export const MdcpConfigSchema = z.object({
         .object({
           shardsConfig: z.string().optional(),
           compiledConfig: z.string().optional(),
+          /** Shard lint paths relative to --cwd (default: compileOrder guide dirs). */
+          shardsGlobs: z.array(z.string()).optional(),
         })
         .optional(),
       links: z

--- a/packages/mdcp-core/src/index.ts
+++ b/packages/mdcp-core/src/index.ts
@@ -13,6 +13,8 @@ export {
   resolveGuidesRoot,
   resolveGuideDir,
   getGuideConfig,
+  guideScanDirs,
+  shardLintPaths,
   xrefScanDirs,
 } from './config/load.js';
 export {

--- a/packages/mdcp-core/test/guide-scan-dirs.test.ts
+++ b/packages/mdcp-core/test/guide-scan-dirs.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { resolve, join } from 'node:path';
+import { MdcpConfigSchema } from '../src/config/schema.js';
+import { guideScanDirs, shardLintPaths, xrefScanDirs } from '../src/config/load.js';
+
+describe('guideScanDirs', () => {
+  it('returns compileOrder guide dirs under cwd', () => {
+    const config = MdcpConfigSchema.parse({
+      compileOrder: ['features', 'developer'],
+      guides: [{ name: 'features' }, { name: 'developer', path: 'dev' }],
+    });
+    const cwd = '/docs';
+    expect(guideScanDirs(config, cwd)).toEqual([resolve(cwd, 'features'), resolve(cwd, 'dev')]);
+  });
+
+  it('xrefScanDirs matches guideScanDirs', () => {
+    const config = MdcpConfigSchema.parse({
+      outputDir: '_build',
+      compileOrder: ['a', 'b'],
+      guides: [{ name: 'b', path: 'custom/b' }],
+    });
+    const cwd = '/repo/docs';
+    expect(xrefScanDirs(config, cwd)).toEqual(guideScanDirs(config, cwd));
+  });
+});
+
+describe('shardLintPaths', () => {
+  it('parses lint.markdownlint.shardsGlobs in schema', () => {
+    const config = MdcpConfigSchema.parse({
+      compileOrder: ['g'],
+      lint: { markdownlint: { shardsGlobs: ['glossary', 'review'] } },
+    });
+    expect(config.lint?.markdownlint?.shardsGlobs).toEqual(['glossary', 'review']);
+  });
+
+  it('defaults to guideScanDirs when shardsGlobs omitted', () => {
+    const config = MdcpConfigSchema.parse({
+      compileOrder: ['guide'],
+      guides: [{ name: 'guide', path: 'guide' }],
+    });
+    const cwd = '/docs';
+    expect(shardLintPaths(config, cwd)).toEqual(guideScanDirs(config, cwd));
+  });
+
+  it('resolves shardsGlobs relative to cwd', () => {
+    const config = MdcpConfigSchema.parse({
+      compileOrder: ['guide'],
+      lint: { markdownlint: { shardsGlobs: ['glossary', 'review/security'] } },
+    });
+    const cwd = '/docs';
+    expect(shardLintPaths(config, cwd)).toEqual([
+      join('/docs', 'glossary'),
+      join('/docs', 'review/security'),
+    ]);
+  });
+});

--- a/packages/mdcp-presets/README.md
+++ b/packages/mdcp-presets/README.md
@@ -17,10 +17,10 @@ npm install -D @bwilliamson/mdcp-presets markdownlint-cli2 @bwilliamson/mdcp-cli
 
 ## Presets
 
-| File                                            | Targets                                                          | Intent                                                                                  |
-| ----------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `markdownlint-shards.markdownlint-cli2.jsonc`   | All `**/*.md` except `guides.md`, `index.md`, and `node_modules` | Relaxed rules for shard authoring — each shard starts with `#`, duplicates are expected |
-| `markdownlint-compiled.markdownlint-cli2.jsonc` | `guides.md` only                                                 | Stricter link rules (`MD052`, `MD053`) on the compiled monolith                         |
+| File                                            | Targets                                       | Intent                                                                                  |
+| ----------------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `markdownlint-shards.markdownlint-cli2.jsonc`   | Registered guide shard trees (scope from CLI) | Relaxed rules for shard authoring — each shard starts with `#`, duplicates are expected |
+| `markdownlint-compiled.markdownlint-cli2.jsonc` | `guides.md` only                              | Stricter link rules (`MD052`, `MD053`) on the compiled monolith                         |
 
 ### Shard preset highlights
 
@@ -57,6 +57,8 @@ mdcp check --require-lint
 ```
 
 `mdcp lint` runs the shards config first, recompiles, then runs the compiled config.
+
+Shard lint scope comes from `compileOrder` guide directories (or `lint.markdownlint.shardsGlobs` in config) — the preset supplies rules and exclusions only, not file scope.
 
 ## Package exports
 

--- a/packages/mdcp-presets/markdownlint-shards.markdownlint-cli2.jsonc
+++ b/packages/mdcp-presets/markdownlint-shards.markdownlint-cli2.jsonc
@@ -18,5 +18,5 @@
     "MD052": false,
     "MD053": false,
   },
-  "globs": ["**/*.md", "!guides.md", "!**/index.md", "!node_modules"],
+  "globs": ["!guides.md", "!**/index.md", "!node_modules"],
 }


### PR DESCRIPTION
## Summary

Fixes #17. MDCP now enforces an **in-scope guide fileset** for lint and prose: shard markdownlint and Vale only touch registered guide shard trees (`compileOrder` + `guides[].path`), never legacy flat docs or unregistered folders under `--cwd`.

- Add `guideScanDirs` / `shardLintPaths` in core; `xrefScanDirs` delegates to the same helper
- Add optional `lint.markdownlint.shardsGlobs` (mirrors `vale.scanGlobs` for narrowing)
- Pass guide paths to markdownlint-cli2 in `mdcp lint` and `mdcp check`
- Unify Vale default scan paths via `guideScanDirs`
- Remove broad `**/*.md` glob from shard preset (rules + exclusions only)

## Test plan

- [x] `pnpm test` — unit tests for `guideScanDirs` / `shardLintPaths`
- [x] CLI fixture with out-of-scope legacy flat `.md` and unregistered guide dir — `mdcp check --require-lint` passes
- [x] `shardsGlobs` override narrows scope correctly
- [x] `pnpm docs:check:repo` — dogfood lint scoped to four guide dirs

## Breaking note

The shard preset previously linted all markdown under `--cwd`. Consumers who relied on incidental lint of non-guide files must add those paths to `shardsGlobs` or run markdownlint separately.


Made with [Cursor](https://cursor.com)