### PR TITLE
Document and fix compile.outputFile vs outputDir semantics (#18)

### DIFF
--- a/.changeset/compile-outputfile-outputdir-join.md
+++ b/.changeset/compile-outputfile-outputdir-join.md
@@ -1,0 +1,10 @@
+---
+'@bwilliamson/mdcp-core': patch
+'@bwilliamson/mdcp-cli': patch
+---
+
+Join bare `compile.outputFile` values under `outputDir` (same normalization as monolith `outputFile` and `refs.registryFile`). Paths with `..` still resolve from `--cwd` for repo publish targets (npm READMEs, `DEVELOPERS.md`).
+
+**Previously:** `"compile": { "outputFile": "glossary.md" }` with `"outputDir": "_build/compiled"` wrote `<cwd>/glossary.md`. **Now:** it writes `<cwd>/_build/compiled/glossary.md`. Explicit cwd paths like `"_build/compiled/glossary.md"` normalize to the same location. Workaround paths remain valid; bare filenames are preferred with nested `outputDir`.
+
+Export `resolveGuideOutputPath` from `@bwilliamson/mdcp-core`.

--- a/docs/client-cli/config-essentials.md
+++ b/docs/client-cli/config-essentials.md
@@ -66,9 +66,21 @@ Config path fields use **three bases**. Mixing them up is the most common path b
 | `outputFile`         | `outputDir`              | `guides.md`                 | `docs/_build/compiled/guides.md` |
 | `refs.registryFile`  | `outputDir`              | `refs.json`                 | `docs/_build/compiled/refs.json` |
 
-Monolith `outputFile` and `refs.registryFile` share the same rule: **relative to `outputDir`**, not `--cwd`. Per-guide `compile.outputFile` is always **relative to `--cwd`**.
+Monolith `outputFile` and `refs.registryFile` share the same rule: **relative to `outputDir`**, not `--cwd`.
 
-If you accidentally give a cwd-relative path for `outputFile` or `refs.registryFile` that already lies under `outputDir` (for example `"_build/compiled/refs.json"` when `outputDir` is `"_build/compiled"`), MDCP normalizes it. Prefer outputDir-relative values in config (`"refs.json"`, `"guides.md"`).
+### Per-guide `compile.outputFile`
+
+Per-guide publish paths use a **different rule** from the monolith filename:
+
+| `compile.outputFile` shape             | Resolved from               | Example (`--cwd docs`, `outputDir: "_build/compiled"`)          |
+| -------------------------------------- | --------------------------- | --------------------------------------------------------------- |
+| Simple name or subpath (no `..`)       | `outputDir` under `--cwd`   | `"glossary.md"` → `docs/_build/compiled/glossary.md`            |
+| Path with `..` (repo publish)          | `--cwd`                     | `"../packages/foo/README.md"` → `<repo>/packages/foo/README.md` |
+| Already cwd-relative under `outputDir` | Normalized (no double join) | `"_build/compiled/glossary.md"` → same as `"glossary.md"`       |
+
+**Common mistake:** expecting a bare filename to land next to the monolith when `outputDir` is nested. Before vNext, `"glossary.md"` wrote to `docs/glossary.md`. MDCP now joins bare names under `outputDir`; use a `..` path only when publishing outside the docs tree (npm READMEs, repo-root `DEVELOPERS.md`).
+
+If you accidentally give a cwd-relative path for monolith `outputFile` or `refs.registryFile` that already lies under `outputDir` (for example `"_build/compiled/refs.json"` when `outputDir` is `"_build/compiled"`), MDCP normalizes it. Prefer outputDir-relative values in config (`"refs.json"`, `"guides.md"`).
 
 ---
 
@@ -107,7 +119,7 @@ Minimal `mdcp.config.json`:
 }
 ```
 
-Per-guide `compile.outputFile` writes a publish target (relative to `--cwd`) and excludes that guide from the monolith. Use `compile.includeBanner: false` for npm README outputs.
+Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. With nested `outputDir`, a bare filename resolves under `outputDir` (path bases table). Use `compile.includeBanner: false` for npm README outputs.
 
 ### `sectionsHeading`
 

--- a/docs/client-cli/config-essentials.md
+++ b/docs/client-cli/config-essentials.md
@@ -57,14 +57,14 @@ Config path fields use **three bases**. Mixing them up is the most common path b
 | **Docs root** (`--cwd`) | explicit flag (defaults to invocation dir) | `guides/features/` → `docs/features/`                                            |
 | **`outputDir`**         | config field under `--cwd`                 | `_build/compiled` → `docs/_build/compiled/`                                      |
 
-| Config field         | Resolved from            | Example value               | Resolves to (`--cwd docs`)       |
-| -------------------- | ------------------------ | --------------------------- | -------------------------------- |
-| `guides[].path`      | `--cwd`                  | `features`                  | `docs/features/`                 |
-| Default guide dir    | `outputDir` + guide name | (omit `path`)               | `docs/<outputDir>/<name>/`       |
-| `compile.outputFile` | `--cwd`                  | `../packages/foo/README.md` | `<repo>/packages/foo/README.md`  |
-| `outputDir`          | `--cwd`                  | `_build/compiled`           | `docs/_build/compiled/`          |
-| `outputFile`         | `outputDir`              | `guides.md`                 | `docs/_build/compiled/guides.md` |
-| `refs.registryFile`  | `outputDir`              | `refs.json`                 | `docs/_build/compiled/refs.json` |
+| Config field         | Resolved from                                | Example value     | Resolves to (`--cwd docs`)         |
+| -------------------- | -------------------------------------------- | ----------------- | ---------------------------------- |
+| `guides[].path`      | `--cwd`                                      | `features`        | `docs/features/`                   |
+| Default guide dir    | `outputDir` + guide name                     | (omit `path`)     | `docs/<outputDir>/<name>/`         |
+| `compile.outputFile` | `outputDir` (or `--cwd` when path uses `..`) | `glossary.md`     | `docs/_build/compiled/glossary.md` |
+| `outputDir`          | `--cwd`                                      | `_build/compiled` | `docs/_build/compiled/`            |
+| `outputFile`         | `outputDir`                                  | `guides.md`       | `docs/_build/compiled/guides.md`   |
+| `refs.registryFile`  | `outputDir`                                  | `refs.json`       | `docs/_build/compiled/refs.json`   |
 
 Monolith `outputFile` and `refs.registryFile` share the same rule: **relative to `outputDir`**, not `--cwd`.
 
@@ -78,7 +78,7 @@ Per-guide publish paths use a **different rule** from the monolith filename:
 | Path with `..` (repo publish)          | `--cwd`                     | `"../packages/foo/README.md"` → `<repo>/packages/foo/README.md` |
 | Already cwd-relative under `outputDir` | Normalized (no double join) | `"_build/compiled/glossary.md"` → same as `"glossary.md"`       |
 
-**Common mistake:** expecting a bare filename to land next to the monolith when `outputDir` is nested. Before vNext, `"glossary.md"` wrote to `docs/glossary.md`. MDCP now joins bare names under `outputDir`; use a `..` path only when publishing outside the docs tree (npm READMEs, repo-root `DEVELOPERS.md`).
+**Common mistake:** expecting a bare filename to land next to the monolith when `outputDir` is nested. MDCP joins bare names under `outputDir`; use a `..` path only when publishing outside the docs tree (npm READMEs, repo-root `DEVELOPERS.md`).
 
 If you accidentally give a cwd-relative path for monolith `outputFile` or `refs.registryFile` that already lies under `outputDir` (for example `"_build/compiled/refs.json"` when `outputDir` is `"_build/compiled"`), MDCP normalizes it. Prefer outputDir-relative values in config (`"refs.json"`, `"guides.md"`).
 
@@ -132,7 +132,7 @@ When a manifest has preamble prose with example inline links before an ordered `
   "compile": {
     "title": "Compound glossary",
     "sectionsHeading": "Sections",
-    "outputFile": "_build/compiled/glossary.md"
+    "outputFile": "glossary.md"
   }
 }
 ```

--- a/docs/client-core/api-config.md
+++ b/docs/client-core/api-config.md
@@ -11,14 +11,15 @@
 
 The CLI and core library use **separate path bases**:
 
-| Concern                               | Base directory                                       | Example                                                                          |
-| ------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Finding `mdcp.config.json`            | `configBase` — invocation `process.cwd()` in the CLI | `--config docs/mdcp.config.json` from repo root → `<repo>/docs/mdcp.config.json` |
-| `guides[].path`, `compile.outputFile` | Docs root — `--cwd`                                  | `resolveGuideDir('features', config, cwd)` → `<cwd>/features`                    |
-| `outputDir`                           | Docs root — `--cwd`                                  | `resolveGuidesRoot(config, cwd)` → `<cwd>/<outputDir>`                           |
-| `outputFile`, `refs.registryFile`     | `outputDir` (under docs root)                        | `resolveOutputPath(config, cwd)` → `<cwd>/<outputDir>/guides.md`                 |
+| Concern                           | Base directory                                       | Example                                                                          |
+| --------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Finding `mdcp.config.json`        | `configBase` — invocation `process.cwd()` in the CLI | `--config docs/mdcp.config.json` from repo root → `<repo>/docs/mdcp.config.json` |
+| `guides[].path`                   | Docs root — `--cwd`                                  | `resolveGuideDir('features', config, cwd)` → `<cwd>/features`                    |
+| `outputDir`                       | Docs root — `--cwd`                                  | `resolveGuidesRoot(config, cwd)` → `<cwd>/<outputDir>`                           |
+| `outputFile`, `refs.registryFile` | `outputDir` (under docs root)                        | `resolveOutputPath(config, cwd)` → `<cwd>/<outputDir>/guides.md`                 |
+| `compile.outputFile`              | `outputDir` when no `..`; else `--cwd` (publish)     | `resolveGuideOutputPath(cwd, outputDir, file)` → `<cwd>/<outputDir>/glossary.md` |
 
-`resolveOutputPath` and `resolveRefsPath` both use the same `outputDir`-relative rule and normalize cwd-relative values that already fall under `outputDir`. Details: [API — Refs](./api-refs-validation.md).
+`resolveOutputPath` and `resolveRefsPath` both use the same `outputDir`-relative rule and normalize cwd-relative values that already fall under `outputDir`. Per-guide outputs use `resolveGuideOutputPath` (same join/normalize helper; `..` paths skip the join for repo publish targets). Details: [API — Refs](./api-refs-validation.md).
 
 ```typescript
 import { loadConfig, resolveGuideDir } from '@bwilliamson/mdcp-core';
@@ -32,7 +33,7 @@ Pass `process.cwd()` (or the invocation directory) as `configBase` for `loadConf
 
 Consumer path table: [Config essentials — path bases](../client-cli/config-essentials.md#config-path-bases).
 
-Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` when `outputFile` is set).
+Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. Bare filenames resolve under `outputDir`; paths with `..` resolve from `--cwd` for npm READMEs and repo-root publish targets. `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` when `outputFile` is set).
 
 `compile.title` injects a `##` heading at the start of the assembled guide, separated from the first section by a blank line. When the first shard’s top heading matches the title text, that duplicate heading is stripped before assembly.
 

--- a/docs/client-core/api-config.md
+++ b/docs/client-core/api-config.md
@@ -1,11 +1,11 @@
 # API — Config
 
-| Export                                                                                 | Purpose                                                                     |
-| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `loadConfig(path, configBase)`                                                         | Load and validate `mdcp.config.json` (`path` is resolved from `configBase`) |
-| `resolveOutputPath`, `resolveRefsPath`, `resolveGuidesRoot`, `resolveGuideDir`         | Path resolvers for outputDir-relative config fields                         |
-| `getGuideConfig`, `guideScanDirs`, `shardLintPaths`, `xrefScanDirs`                    | In-scope guide fileset and xref scan helpers                                |
-| `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput` | Zod schema and types                                                        |
+| Export                                                                                                   | Purpose                                                                     |
+| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `loadConfig(path, configBase)`                                                                           | Load and validate `mdcp.config.json` (`path` is resolved from `configBase`) |
+| `resolveOutputPath`, `resolveRefsPath`, `resolveGuideOutputPath`, `resolveGuidesRoot`, `resolveGuideDir` | Path resolvers for config output paths                                      |
+| `getGuideConfig`, `guideScanDirs`, `shardLintPaths`, `xrefScanDirs`                                      | In-scope guide fileset and xref scan helpers                                |
+| `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput`                   | Zod schema and types                                                        |
 
 ## Path resolution: `configBase` vs docs root
 

--- a/docs/client-core/compile-hooks/cross-guide-links.md
+++ b/docs/client-core/compile-hooks/cross-guide-links.md
@@ -59,6 +59,7 @@ Minimal multi-output setup — index and rewrite run automatically from `compile
 
 ```json
 {
+  "outputDir": "_build/compiled",
   "compileOrder": ["glossary", "architecture-review", "technical-guide"],
   "guides": [
     {

--- a/docs/features/feature-catalog.md
+++ b/docs/features/feature-catalog.md
@@ -10,7 +10,7 @@ Stitch shard directories into canonical monoliths or publish outputs. Demotes he
 mdcp compile --config mdcp.config.json --cwd .
 ```
 
-Guides with `compile.outputFile` write to a separate path (for example npm READMEs) and are excluded from the monolith.
+Guides with `compile.outputFile` write to a separate path (for example npm READMEs or files under `outputDir`) and are excluded from the monolith. Path bases: [Config essentials — path bases](../client-cli/config-essentials.md#config-path-bases).
 
 ## Refs + lookup (P0.2)
 

--- a/docs/features/legacy-migration.md
+++ b/docs/features/legacy-migration.md
@@ -23,6 +23,20 @@ Port map from `legacy/` bash/Python to TypeScript packages.
 
 This repository dogfoods the pattern under `docs/` — see [examples/sample-guides](../../examples/sample-guides/) for a minimal fixture.
 
+## Config path bases (monolith vs per-guide output)
+
+Three path bases appear in every config. Mixing them up is the most common migration bug after switching from hand-rolled compile scripts.
+
+| Field                             | Base                                                      | Notes                                                                           |
+| --------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `outputDir`                       | `--cwd`                                                   | Compile output root; default guide shard dirs live here too                     |
+| `outputFile`, `refs.registryFile` | `outputDir`                                               | Monolith and refs registry — not `--cwd`                                        |
+| `compile.outputFile`              | `outputDir` when the value has no `..`; otherwise `--cwd` | Publish targets outside the docs tree use `..` (for example `../DEVELOPERS.md`) |
+
+**Nested `outputDir`:** use outputDir-relative monolith names (`"guides.md"`, `"refs.json"`). Per-guide outputs can use a bare filename (`"glossary.md"`) — MDCP writes `docs/_build/compiled/glossary.md`, not `docs/glossary.md`. Explicit cwd paths like `"_build/compiled/glossary.md"` still work and normalize to the same location.
+
+Full tables and examples: [Config essentials — path bases](../client-cli/config-essentials.md#config-path-bases).
+
 ## md-tree fork criteria
 
 Document in [Design constraints](./design-constraints.md) when:

--- a/docs/features/manifest-compile-order.md
+++ b/docs/features/manifest-compile-order.md
@@ -61,7 +61,7 @@ Set `guides[].compile.sectionsHeading` to the `##` heading that starts the real 
   "compile": {
     "title": "Compound glossary",
     "sectionsHeading": "Sections",
-    "outputFile": "_build/compiled/glossary.md"
+    "outputFile": "glossary.md"
   }
 }
 ```

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -38,14 +38,15 @@ The CLI uses two separate path bases. This matters for npm scripts run from the 
 mdcp compile --config docs/mdcp.config.json --cwd docs
 ```
 
-| Path                                 | Resolved from            | Resolves to (example)                  |
-| ------------------------------------ | ------------------------ | -------------------------------------- |
-| `--config docs/mdcp.config.json`     | Invocation dir (`/repo`) | `/repo/docs/mdcp.config.json`          |
-| Guide `features/`                    | `--cwd` (`docs`)         | `/repo/docs/features/`                 |
-| `outputDir: "_build/compiled"`       | `--cwd`                  | `/repo/docs/_build/compiled/`          |
-| `outputFile: "guides.md"`            | `outputDir`              | `/repo/docs/_build/compiled/guides.md` |
-| `refs.registryFile: "refs.json"`     | `outputDir`              | `/repo/docs/_build/compiled/refs.json` |
-| `compile.outputFile: "../README.md"` | `--cwd`                  | `/repo/README.md`                      |
+| Path                                 | Resolved from            | Resolves to (example)                    |
+| ------------------------------------ | ------------------------ | ---------------------------------------- |
+| `--config docs/mdcp.config.json`     | Invocation dir (`/repo`) | `/repo/docs/mdcp.config.json`            |
+| Guide `features/`                    | `--cwd` (`docs`)         | `/repo/docs/features/`                   |
+| `outputDir: "_build/compiled"`       | `--cwd`                  | `/repo/docs/_build/compiled/`            |
+| `outputFile: "guides.md"`            | `outputDir`              | `/repo/docs/_build/compiled/guides.md`   |
+| `refs.registryFile: "refs.json"`     | `outputDir`              | `/repo/docs/_build/compiled/refs.json`   |
+| `compile.outputFile: "glossary.md"`  | `outputDir` (nested)     | `/repo/docs/_build/compiled/glossary.md` |
+| `compile.outputFile: "../README.md"` | `--cwd` (publish)        | `/repo/README.md`                        |
 
 When your shell is already in the docs directory, use `--config mdcp.config.json` (or the default) and omit `--cwd` unless you need a different docs root.
 

--- a/packages/mdcp-cli/README.md
+++ b/packages/mdcp-cli/README.md
@@ -145,18 +145,30 @@ Config path fields use **three bases**. Mixing them up is the most common path b
 | **Docs root** (`--cwd`) | explicit flag (defaults to invocation dir) | `guides/features/` → `docs/features/`                                            |
 | **`outputDir`**         | config field under `--cwd`                 | `_build/compiled` → `docs/_build/compiled/`                                      |
 
-| Config field         | Resolved from            | Example value               | Resolves to (`--cwd docs`)       |
-| -------------------- | ------------------------ | --------------------------- | -------------------------------- |
-| `guides[].path`      | `--cwd`                  | `features`                  | `docs/features/`                 |
-| Default guide dir    | `outputDir` + guide name | (omit `path`)               | `docs/<outputDir>/<name>/`       |
-| `compile.outputFile` | `--cwd`                  | `../packages/foo/README.md` | `<repo>/packages/foo/README.md`  |
-| `outputDir`          | `--cwd`                  | `_build/compiled`           | `docs/_build/compiled/`          |
-| `outputFile`         | `outputDir`              | `guides.md`                 | `docs/_build/compiled/guides.md` |
-| `refs.registryFile`  | `outputDir`              | `refs.json`                 | `docs/_build/compiled/refs.json` |
+| Config field         | Resolved from                                | Example value     | Resolves to (`--cwd docs`)         |
+| -------------------- | -------------------------------------------- | ----------------- | ---------------------------------- |
+| `guides[].path`      | `--cwd`                                      | `features`        | `docs/features/`                   |
+| Default guide dir    | `outputDir` + guide name                     | (omit `path`)     | `docs/<outputDir>/<name>/`         |
+| `compile.outputFile` | `outputDir` (or `--cwd` when path uses `..`) | `glossary.md`     | `docs/_build/compiled/glossary.md` |
+| `outputDir`          | `--cwd`                                      | `_build/compiled` | `docs/_build/compiled/`            |
+| `outputFile`         | `outputDir`                                  | `guides.md`       | `docs/_build/compiled/guides.md`   |
+| `refs.registryFile`  | `outputDir`                                  | `refs.json`       | `docs/_build/compiled/refs.json`   |
 
-Monolith `outputFile` and `refs.registryFile` share the same rule: **relative to `outputDir`**, not `--cwd`. Per-guide `compile.outputFile` is always **relative to `--cwd`**.
+Monolith `outputFile` and `refs.registryFile` share the same rule: **relative to `outputDir`**, not `--cwd`.
 
-If you accidentally give a cwd-relative path for `outputFile` or `refs.registryFile` that already lies under `outputDir` (for example `"_build/compiled/refs.json"` when `outputDir` is `"_build/compiled"`), MDCP normalizes it. Prefer outputDir-relative values in config (`"refs.json"`, `"guides.md"`).
+#### Per-guide `compile.outputFile`
+
+Per-guide publish paths use a **different rule** from the monolith filename:
+
+| `compile.outputFile` shape             | Resolved from               | Example (`--cwd docs`, `outputDir: "_build/compiled"`)          |
+| -------------------------------------- | --------------------------- | --------------------------------------------------------------- |
+| Simple name or subpath (no `..`)       | `outputDir` under `--cwd`   | `"glossary.md"` → `docs/_build/compiled/glossary.md`            |
+| Path with `..` (repo publish)          | `--cwd`                     | `"../packages/foo/README.md"` → `<repo>/packages/foo/README.md` |
+| Already cwd-relative under `outputDir` | Normalized (no double join) | `"_build/compiled/glossary.md"` → same as `"glossary.md"`       |
+
+**Common mistake:** expecting a bare filename to land next to the monolith when `outputDir` is nested. MDCP joins bare names under `outputDir`; use a `..` path only when publishing outside the docs tree (npm READMEs, repo-root `DEVELOPERS.md`).
+
+If you accidentally give a cwd-relative path for monolith `outputFile` or `refs.registryFile` that already lies under `outputDir` (for example `"_build/compiled/refs.json"` when `outputDir` is `"_build/compiled"`), MDCP normalizes it. Prefer outputDir-relative values in config (`"refs.json"`, `"guides.md"`).
 
 ---
 
@@ -195,7 +207,7 @@ Minimal `mdcp.config.json`:
 }
 ```
 
-Per-guide `compile.outputFile` writes a publish target (relative to `--cwd`) and excludes that guide from the monolith. Use `compile.includeBanner: false` for npm README outputs.
+Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. With nested `outputDir`, a bare filename resolves under `outputDir` (path bases table). Use `compile.includeBanner: false` for npm README outputs.
 
 #### `sectionsHeading`
 
@@ -208,7 +220,7 @@ When a manifest has preamble prose with example inline links before an ordered `
   "compile": {
     "title": "Compound glossary",
     "sectionsHeading": "Sections",
-    "outputFile": "_build/compiled/glossary.md"
+    "outputFile": "glossary.md"
   }
 }
 ```

--- a/packages/mdcp-cli/test/cli.smoke.test.ts
+++ b/packages/mdcp-cli/test/cli.smoke.test.ts
@@ -113,6 +113,42 @@ describe('cli smoke', () => {
     }
   });
 
+  it('writes per-guide outputFile under nested outputDir (#18)', () => {
+    const docs = mkdtempSync(join(tmpdir(), 'mdcp-outfile-'));
+    try {
+      const guide = join(docs, 'glossary');
+      mkdirSync(guide, { recursive: true });
+      writeFileSync(join(guide, 'index.md'), '# Glossary\n\n- [term](term.md)\n');
+      writeFileSync(join(guide, 'term.md'), '# Glossary\n\n## Term\n');
+      writeFileSync(
+        join(docs, 'mdcp.config.json'),
+        JSON.stringify({
+          outputDir: '_build/compiled',
+          outputFile: 'guides.md',
+          compileOrder: ['glossary'],
+          guides: [
+            {
+              name: 'glossary',
+              path: 'glossary',
+              compile: { outputFile: 'glossary.md' },
+            },
+          ],
+          refs: { registryFile: 'refs.json' },
+          lint: { xrefs: { enabled: false } },
+        }),
+      );
+
+      execFileSync('node', [CLI, 'compile', '--config', 'mdcp.config.json', '--cwd', docs], {
+        encoding: 'utf-8',
+        cwd: docs,
+      });
+      expect(existsSync(join(docs, '_build/compiled/glossary.md'))).toBe(true);
+      expect(existsSync(join(docs, 'glossary.md'))).toBe(false);
+    } finally {
+      rmSync(docs, { recursive: true, force: true });
+    }
+  });
+
   it('skips out-of-scope markdown for shard lint (#17)', () => {
     const docs = mkdtempSync(join(tmpdir(), 'mdcp-scope-'));
     try {

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -62,25 +62,26 @@ Use `writeCompiledGuides` when you need to write the monolith and per-guide publ
 
 ## API — Config
 
-| Export                                                                                 | Purpose                                                                     |
-| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `loadConfig(path, configBase)`                                                         | Load and validate `mdcp.config.json` (`path` is resolved from `configBase`) |
-| `resolveOutputPath`, `resolveRefsPath`, `resolveGuidesRoot`, `resolveGuideDir`         | Path resolvers for outputDir-relative config fields                         |
-| `getGuideConfig`, `guideScanDirs`, `shardLintPaths`, `xrefScanDirs`                    | In-scope guide fileset and xref scan helpers                                |
-| `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput` | Zod schema and types                                                        |
+| Export                                                                                                   | Purpose                                                                     |
+| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `loadConfig(path, configBase)`                                                                           | Load and validate `mdcp.config.json` (`path` is resolved from `configBase`) |
+| `resolveOutputPath`, `resolveRefsPath`, `resolveGuideOutputPath`, `resolveGuidesRoot`, `resolveGuideDir` | Path resolvers for config output paths                                      |
+| `getGuideConfig`, `guideScanDirs`, `shardLintPaths`, `xrefScanDirs`                                      | In-scope guide fileset and xref scan helpers                                |
+| `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput`                   | Zod schema and types                                                        |
 
 ### Path resolution: `configBase` vs docs root
 
 The CLI and core library use **separate path bases**:
 
-| Concern                               | Base directory                                       | Example                                                                          |
-| ------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Finding `mdcp.config.json`            | `configBase` — invocation `process.cwd()` in the CLI | `--config docs/mdcp.config.json` from repo root → `<repo>/docs/mdcp.config.json` |
-| `guides[].path`, `compile.outputFile` | Docs root — `--cwd`                                  | `resolveGuideDir('features', config, cwd)` → `<cwd>/features`                    |
-| `outputDir`                           | Docs root — `--cwd`                                  | `resolveGuidesRoot(config, cwd)` → `<cwd>/<outputDir>`                           |
-| `outputFile`, `refs.registryFile`     | `outputDir` (under docs root)                        | `resolveOutputPath(config, cwd)` → `<cwd>/<outputDir>/guides.md`                 |
+| Concern                           | Base directory                                       | Example                                                                          |
+| --------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Finding `mdcp.config.json`        | `configBase` — invocation `process.cwd()` in the CLI | `--config docs/mdcp.config.json` from repo root → `<repo>/docs/mdcp.config.json` |
+| `guides[].path`                   | Docs root — `--cwd`                                  | `resolveGuideDir('features', config, cwd)` → `<cwd>/features`                    |
+| `outputDir`                       | Docs root — `--cwd`                                  | `resolveGuidesRoot(config, cwd)` → `<cwd>/<outputDir>`                           |
+| `outputFile`, `refs.registryFile` | `outputDir` (under docs root)                        | `resolveOutputPath(config, cwd)` → `<cwd>/<outputDir>/guides.md`                 |
+| `compile.outputFile`              | `outputDir` when no `..`; else `--cwd` (publish)     | `resolveGuideOutputPath(cwd, outputDir, file)` → `<cwd>/<outputDir>/glossary.md` |
 
-`resolveOutputPath` and `resolveRefsPath` both use the same `outputDir`-relative rule and normalize cwd-relative values that already fall under `outputDir`. Details: [API — Refs](#api-refs-and-validation).
+`resolveOutputPath` and `resolveRefsPath` both use the same `outputDir`-relative rule and normalize cwd-relative values that already fall under `outputDir`. Per-guide outputs use `resolveGuideOutputPath` (same join/normalize helper; `..` paths skip the join for repo publish targets). Details: [API — Refs](#api-refs-and-validation).
 
 ```typescript
 import { loadConfig, resolveGuideDir } from '@bwilliamson/mdcp-core';
@@ -94,7 +95,7 @@ Pass `process.cwd()` (or the invocation directory) as `configBase` for `loadConf
 
 Consumer path table: [Config essentials — path bases](#config-path-bases).
 
-Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` when `outputFile` is set).
+Per-guide `compile.outputFile` writes a publish target and excludes that guide from the monolith. Bare filenames resolve under `outputDir`; paths with `..` resolve from `--cwd` for npm READMEs and repo-root publish targets. `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` when `outputFile` is set).
 
 `compile.title` injects a `##` heading at the start of the assembled guide, separated from the first section by a blank line. When the first shard’s top heading matches the title text, that duplicate heading is stripped before assembly.
 
@@ -588,6 +589,7 @@ Minimal multi-output setup — index and rewrite run automatically from `compile
 
 ```json
 {
+  "outputDir": "_build/compiled",
   "compileOrder": ["glossary", "architecture-review", "technical-guide"],
   "guides": [
     {

--- a/packages/mdcp-core/src/compile/assemble.ts
+++ b/packages/mdcp-core/src/compile/assemble.ts
@@ -15,7 +15,7 @@ import {
 import { buildGuideLinkIndex, type GuideLinkIndex } from './guide-link-index.js';
 import { sectionFiles } from './section-manifest.js';
 import type { GuideConfig, GuideConfigInput, MdcpConfigInput } from '../config/schema.js';
-import { resolveGuideLinkBase } from '../config/load.js';
+import { resolveGuideLinkBase, resolveGuideOutputPath } from '../config/load.js';
 import type { PublishPathRewriteOptions } from './publish-links.js';
 
 export { sectionFiles, type SectionFilesOptions } from './section-manifest.js';
@@ -268,7 +268,8 @@ export function writeCompiledGuides(
 
   for (const r of results) {
     if (!r.outputFile) continue;
-    const outPath = resolve(cwd, r.outputFile);
+    const outputDir = options.config?.outputDir ?? '.';
+    const outPath = resolveGuideOutputPath(cwd, outputDir, r.outputFile);
     let text = r.text;
     if (options.banner && r.includeBanner) text = options.banner + text;
     mkdirSync(dirname(outPath), { recursive: true });

--- a/packages/mdcp-core/src/config/load.ts
+++ b/packages/mdcp-core/src/config/load.ts
@@ -1,7 +1,9 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { MdcpConfigSchema, type MdcpConfig, type GuideConfig } from './schema.js';
-import { resolveUnderOutputDir } from './paths.js';
+import { resolveUnderOutputDir, resolveGuideOutputPath } from './paths.js';
+
+export { resolveGuideOutputPath } from './paths.js';
 
 export function loadConfig(configPath: string, configBase: string): MdcpConfig {
   const abs = resolve(configBase, configPath);
@@ -36,7 +38,10 @@ export function resolveGuideLinkBase(
   cwd: string,
   compile?: { outputFile?: string },
 ): string {
-  if (compile?.outputFile) return resolve(cwd, compile.outputFile);
+  if (compile?.outputFile) {
+    const outputDir = config.outputDir ?? '.';
+    return resolveGuideOutputPath(cwd, outputDir, compile.outputFile);
+  }
   const outputDir = config.outputDir ?? '.';
   const outputFile = config.outputFile ?? 'guides.md';
   return resolveUnderOutputDir(cwd, outputDir, outputFile);

--- a/packages/mdcp-core/src/config/paths.ts
+++ b/packages/mdcp-core/src/config/paths.ts
@@ -5,6 +5,22 @@ function isUnder(parent: string, child: string): boolean {
   return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
 }
 
+/** True when outputFile targets outside the docs tree (repo publish via `..`). */
+export function isPublishEscapePath(file: string): boolean {
+  if (isAbsolute(file)) return false;
+  return file.startsWith('..') || file.includes('/..') || file.includes('\\..');
+}
+
+/**
+ * Resolve per-guide `compile.outputFile` under docs root `cwd`.
+ * Publish paths with `..` resolve from `cwd`; other paths join under `outputDir`.
+ */
+export function resolveGuideOutputPath(cwd: string, outputDir: string, outputFile: string): string {
+  if (isAbsolute(outputFile)) return outputFile;
+  if (isPublishEscapePath(outputFile)) return resolve(cwd, outputFile);
+  return resolveUnderOutputDir(cwd, outputDir, outputFile);
+}
+
 /**
  * Resolve `file` under `outputDir` (both relative to docs root `cwd`).
  * When `file` is accidentally cwd-relative but already under `outputDir`, use the cwd-relative path.

--- a/packages/mdcp-core/src/config/schema.ts
+++ b/packages/mdcp-core/src/config/schema.ts
@@ -38,7 +38,7 @@ const GuideSchema = z.object({
       /** Injected compile title as ## heading, followed by a blank line before the first section. */
       title: z.string().optional(),
       scopeRoot: z.string().optional(),
-      /** Per-guide output path relative to --cwd (excluded from monolith). */
+      /** Per-guide output path; joins under outputDir unless the path uses `..` (publish). */
       outputFile: z.string().optional(),
       /** Apply global banner to this guide's output (default: true for monolith, false when outputFile is set). */
       includeBanner: z.boolean().optional(),

--- a/packages/mdcp-core/src/index.ts
+++ b/packages/mdcp-core/src/index.ts
@@ -16,6 +16,7 @@ export {
   guideScanDirs,
   shardLintPaths,
   xrefScanDirs,
+  resolveGuideOutputPath,
 } from './config/load.js';
 export {
   demoteHeadings,

--- a/packages/mdcp-core/test/code-evidence.test.ts
+++ b/packages/mdcp-core/test/code-evidence.test.ts
@@ -151,7 +151,7 @@ describe('codeEvidence — path rewrite for rendered output', () => {
         resolveGuideLinkBase({ outputDir: 'docs', outputFile: 'guides.md' }, work.path, {
           outputFile: 'architecture-review.md',
         }),
-      ).toBe(join(work.path, 'architecture-review.md'));
+      ).toBe(join(work.path, 'docs', 'architecture-review.md'));
     });
   });
 

--- a/packages/mdcp-core/test/guide-output-path.test.ts
+++ b/packages/mdcp-core/test/guide-output-path.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { writeFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { resolveGuideOutputPath } from '../src/config/paths.js';
+import { resolveGuideLinkBase } from '../src/config/load.js';
+import { writeCompiledGuides } from '../src/compile/assemble.js';
+import { withTmpDir } from './helpers/tmp-dir.js';
 
 describe('resolveGuideOutputPath (#18)', () => {
   const cwd = '/docs';
@@ -27,5 +32,47 @@ describe('resolveGuideOutputPath (#18)', () => {
 
   it('resolves simple paths under outputDir when outputDir is "."', () => {
     expect(resolveGuideOutputPath(cwd, '.', 'out/README.md')).toBe('/docs/out/README.md');
+  });
+});
+
+describe('resolveGuideLinkBase with per-guide output (#18)', () => {
+  it('uses outputDir join for bare compile.outputFile', () => {
+    expect(
+      resolveGuideLinkBase({ outputDir: '_build/compiled', outputFile: 'guides.md' }, '/docs', {
+        outputFile: 'glossary.md',
+      }),
+    ).toBe('/docs/_build/compiled/glossary.md');
+  });
+});
+
+describe('writeCompiledGuides per-guide path (#18)', () => {
+  it('writes bare outputFile under nested outputDir', () => {
+    withTmpDir('mdcp-guide-out-', (work) => {
+      const guideDir = join(work, '_build', 'compiled', 'glossary');
+      mkdirSync(guideDir, { recursive: true });
+      writeFileSync(join(guideDir, 'index.md'), '# Guide\n\n- [intro](intro.md)\n');
+      writeFileSync(join(guideDir, 'intro.md'), '# Guide\n\n## Hello\n');
+
+      const expected = join(work, '_build', 'compiled', 'glossary.md');
+      const opts = {
+        guidesRoot: join(work, '_build', 'compiled'),
+        compileOrder: ['glossary'],
+        cwd: work,
+        config: {
+          outputDir: '_build/compiled',
+          outputFile: 'guides.md',
+          compileOrder: ['glossary'],
+        },
+        guides: [
+          {
+            name: 'glossary',
+            compile: { outputFile: 'glossary.md', manifest: 'index.md' },
+          },
+        ],
+      };
+
+      writeCompiledGuides(opts, join(work, '_build', 'compiled', 'guides.md'));
+      expect(readFileSync(expected, 'utf-8')).toContain('## Hello');
+    });
   });
 });

--- a/packages/mdcp-core/test/guide-output-path.test.ts
+++ b/packages/mdcp-core/test/guide-output-path.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { resolveGuideOutputPath } from '../src/config/paths.js';
+
+describe('resolveGuideOutputPath (#18)', () => {
+  const cwd = '/docs';
+
+  it('joins bare outputFile under nested outputDir', () => {
+    expect(resolveGuideOutputPath(cwd, '_build/compiled', 'glossary.md')).toBe(
+      '/docs/_build/compiled/glossary.md',
+    );
+  });
+
+  it('normalizes cwd-relative path already under outputDir', () => {
+    expect(resolveGuideOutputPath(cwd, '_build/compiled', '_build/compiled/glossary.md')).toBe(
+      '/docs/_build/compiled/glossary.md',
+    );
+  });
+
+  it('keeps publish paths with .. relative to cwd', () => {
+    expect(resolveGuideOutputPath(cwd, '_build/compiled', '../DEVELOPERS.md')).toBe(
+      '/DEVELOPERS.md',
+    );
+    expect(resolveGuideOutputPath(cwd, '.', '../packages/foo/README.md')).toBe(
+      '/packages/foo/README.md',
+    );
+  });
+
+  it('resolves simple paths under outputDir when outputDir is "."', () => {
+    expect(resolveGuideOutputPath(cwd, '.', 'out/README.md')).toBe('/docs/out/README.md');
+  });
+});


### PR DESCRIPTION
## Summary

- Document path bases for monolith `outputFile`, `refs.registryFile`, and per-guide `compile.outputFile` in config essentials, API config, legacy migration, and feature catalog.
- Add `resolveGuideOutputPath`: bare `compile.outputFile` values join under `outputDir` (with the same normalization as monolith paths); paths containing `..` still resolve from `--cwd` for repo publish targets.
- Wire the resolver through `writeCompiledGuides`, `resolveGuideLinkBase`, and export it from `@bwilliamson/mdcp-core`.

Fixes #18

## Behavior change

| Config | Before | After |
| ------ | ------ | ----- |
| `outputDir: "_build/compiled"`, `compile.outputFile: "glossary.md"` | `<cwd>/glossary.md` | `<cwd>/_build/compiled/glossary.md` |
| `compile.outputFile: "../DEVELOPERS.md"` | unchanged | unchanged |
| `compile.outputFile: "_build/compiled/glossary.md"` | unchanged (cwd path) | normalizes to same as bare `"glossary.md"` |

## Commits

1. **docs** — path-base spec and migration guidance
2. **test** — `resolveGuideOutputPath` unit specs
3. **feat** — join under `outputDir` + integration/CLI smoke tests
4. **refactor** — sync examples and regenerated publish READMEs
5. **changeset** — patch release notes

## Test plan

- [x] `pnpm test` (mdcp-core + mdcp-cli)
- [x] `pnpm run docs:check:repo`
- [x] CLI smoke: nested `outputDir` + bare `compile.outputFile` writes under `_build/compiled/`


Made with [Cursor](https://cursor.com)