### PR TITLE
Enable compile hooks by default with opt-out config

### DIFF
--- a/.changeset/issue-29-default-compile-hooks.md
+++ b/.changeset/issue-29-default-compile-hooks.md
@@ -1,0 +1,7 @@
+---
+'@bwilliamson/mdcp-core': minor
+'@bwilliamson/mdcp-cli': minor
+'@bwilliamson/mdcp-presets': minor
+---
+
+Enable built-in compile hooks by default (`stripAnchors`, `codeEvidence`, `inlineInserts`, `reviewLinks`). Omit `guides[].compile.hooks` for the common case; opt out per hook with an object (`{ "codeEvidence": false }`) or replace the pipeline with a string array. Previously, every hook had to be listed explicitly on each guide.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -102,17 +102,27 @@ If none of the above apply, inspect enabled MCP tool descriptors or run `gh --he
 
 ```text
 Integration branch=main (pull before branching)
-Feature branches=descriptive (e.g. docs/issue-39-llm-prompt-templates)
+Feature branches=descriptive (e.g. feature/issue-29-default-compile-hooks)
+One branch per WORK_ITEM=do not mix unrelated features, designs, or doc scopes in one PR
+Branch before work=create the feature branch before shards, tests, or code
 Commits=conventional; atomic and logically grouped
 Release notes=changeset in .changeset/ for user-facing doc changes
+Docs=describe current behavior only; removed or breaking behavior belongs in changeset release notes, not feature/client shards
 Code review=gh pr create; link WORK_ITEM in PR body (Closes #N when appropriate)
 ```
+
+### Workflow best practices
+
+1. **Load scope** — fetch WORK_ITEM (title, body, acceptance criteria) before planning or editing.
+2. **Branch first** — `git checkout main`, pull, then `git checkout -b feature/...` tied to the issue. Never start on `main`.
+3. **Stay focused** — one feature or design at a time. Treat acceptance criteria as the boundary unless WORK_ITEM explicitly expands scope.
+4. **Docs describe now** — update shards to match as-built behavior. Do not document superseded workflows in `docs/features/` or `docs/client/`; record that in the changeset instead.
 
 ### Example prompt header
 
 ```text
 WORK_ITEM=39
-WORK_ITEM_LOOKUP=Branch from main (pull first). Load WORK_ITEM per docs/developer/agent-work-item-tracking.md.
+WORK_ITEM_LOOKUP=Branch from main (pull first). One issue per branch. Load WORK_ITEM per docs/developer/agent-work-item-tracking.md.
 ```
 
 For task-type prompt templates, read [LLM collaboration](README.md#llm-collaboration).

--- a/docs/client-cli/consumer-migration.md
+++ b/docs/client-cli/consumer-migration.md
@@ -32,7 +32,7 @@ Path resolution details: [Config essentials — path layout](./config-essentials
 
 ## Compile hooks
 
-Register hooks per guide in `guides[].compile.hooks`:
+Built-in hooks run **by default** on every guide — omit `compile.hooks` for the common case. See [Default compile hooks](../features/default-compile-hooks.md).
 
 | Hook            | Purpose                                                               |
 | --------------- | --------------------------------------------------------------------- |
@@ -41,11 +41,13 @@ Register hooks per guide in `guides[].compile.hooks`:
 | `codeEvidence`  | Resolve evidence links to GitHub line-number fragments                |
 | `reviewLinks`   | Rewrite review links; optional hooksConfig.reviewLinks.targetMonolith |
 
+Opt out per hook: `"hooks": { "codeEvidence": false }`. Replace the pipeline entirely with a string array when needed.
+
 Cross-guide `.md` links rewrite automatically from `compileOrder` and per-guide `compile.outputFile`. Hook specs: [Compile hooks](../client-core/compile-hooks/index.md). Cross-monolith rewriting: [Cross-guide links](../client-core/compile-hooks/cross-guide-links.md).
 
 ## Multi-guide config
 
-Multi-guide repos typically set per-guide publish targets, `sectionsHeading`, and hooks:
+Multi-guide repos typically set per-guide publish targets and `sectionsHeading` — hooks need not be listed:
 
 ```json
 {
@@ -56,8 +58,7 @@ Multi-guide repos typically set per-guide publish targets, `sectionsHeading`, an
       "name": "glossary",
       "compile": {
         "outputFile": "glossary.md",
-        "sectionsHeading": "Sections",
-        "hooks": ["stripAnchors", "inlineInserts", "reviewLinks"]
+        "sectionsHeading": "Sections"
       }
     },
     {
@@ -68,7 +69,6 @@ Multi-guide repos typically set per-guide publish targets, `sectionsHeading`, an
         "outputFile": "architecture-review.md",
         "sectionsHeading": "Sections",
         "scopeRoot": ".",
-        "hooks": ["stripAnchors", "codeEvidence", "inlineInserts", "reviewLinks"],
         "hooksConfig": {
           "reviewLinks": { "targetMonolith": "architecture-review.md" }
         }

--- a/docs/client-cli/llm-collaboration.md
+++ b/docs/client-cli/llm-collaboration.md
@@ -51,6 +51,12 @@ I updated `index.md` in guide `{{GUIDE_NAME}}`. Run mdcp compile and check using
 
 Load scope from the tracker via `WORK_ITEM_LOOKUP` (GitHub MCP, `gh issue view`, Linear MCP, or your repo's documented integration). Then document before you implement — use [feature-level-task.prompt.md](../../examples/prompts/feature-level-task.prompt.md).
 
+### Workflow best practices
+
+- **Branch first** — create a feature branch from updated `main` before shards, tests, or code (see [Agent work-item tracking](../developer/agent-work-item-tracking.md))
+- **One issue per branch** — stay focused on a single feature, design, or doc scope; do not mix unrelated work in one PR
+- **Current behavior in docs** — shards describe the product as it works now; removed or breaking behavior belongs in the **changeset**, not `docs/features/` or `docs/client/`
+
 | Phase     | Where            | Holds                                                  |
 | --------- | ---------------- | ------------------------------------------------------ |
 | Document  | `docs/features/` | Capabilities, design, API surface, acceptance criteria |
@@ -141,6 +147,8 @@ When reviewing an agent's documentation PR:
 - Cross-links use slugs from `mdcp refs lookup`, not guessed anchors
 - Client guide opens with persona context in `about-this-guide.md`
 - Task prompts use only the top replace block — fill in `WORK_ITEM` and `WORK_ITEM_LOOKUP` before sending
+- One WORK_ITEM per PR — branch and scope match a single feature or design
+- Shards describe current behavior; breaking or removed behavior is in the changeset, not feature/client guides
 
 ## See also
 

--- a/docs/client-core/api-config.md
+++ b/docs/client-core/api-config.md
@@ -6,6 +6,7 @@
 | `resolveOutputPath`, `resolveRefsPath`, `resolveGuideDir`, `defaultGuideOutputFile`    | Path resolvers for docs root and `outputDir`                                |
 | `getGuideConfig`, `guideScanDirs`, `shardLintPaths`, `xrefScanDirs`                    | In-scope guide fileset and xref scan helpers                                |
 | `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput` | Zod schema and types                                                        |
+| `DEFAULT_COMPILE_HOOKS`, `resolveCompileHooks`                                         | Default built-in hook pipeline and guide-level resolution                   |
 
 ## Path resolution: `configBase` vs docs root
 
@@ -36,3 +37,13 @@ Consumer path table: [Config essentials — path layout](../client-cli/config-es
 `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` for per-guide outputs).
 
 `compile.publishPathRewrite` rewrites shard-relative repo paths in publish outputs. Intra-guide `./section.md` links rewrite to `#anchor` on every compile.
+
+## `compile.hooks`
+
+Built-in hooks run by default when `compile.hooks` is omitted. See [Default compile hooks](../features/default-compile-hooks.md).
+
+- **Omitted** — run `DEFAULT_COMPILE_HOOKS` in order: `stripAnchors`, `codeEvidence`, `inlineInserts`, `reviewLinks`
+- **`string[]`** — explicit override; replaces defaults entirely (backward compatible)
+- **`Record<string, boolean>`** — opt out; keys with `false` remove that hook from defaults
+
+Optional per-hook settings: `compile.hooksConfig` (`reviewLinks.targetMonolith`, `inlineInserts.searchRoots`). Post-stitch anchor stripping: `compile.stripAnchors` (default `true`), independent of the per-shard `stripAnchors` hook unless opted out.

--- a/docs/client-core/compile-hooks/code-evidence.md
+++ b/docs/client-core/compile-hooks/code-evidence.md
@@ -62,18 +62,16 @@ The hook **does not** transform:
 - Markdown shard links (`.md`)
 - External URLs
 - Source links when the file cannot be resolved and no line range appears in label or path
-- Body text when `codeEvidence` is not in `compile.hooks`
+- Body text when `codeEvidence` is disabled via `compile.hooks: { "codeEvidence": false }` or an explicit hook override that omits it
 
 ## codeEvidence config
 
-Minimal setup — add the hook name. Path rewriting uses the monolith or per-guide output path automatically:
+Runs by default — no hook list required. Path rewriting uses the monolith or per-guide output path automatically:
 
 ```json
 {
   "name": "architecture-review",
-  "compile": {
-    "hooks": ["stripAnchors", "codeEvidence"]
-  }
+  "compile": {}
 }
 ```
 
@@ -84,11 +82,12 @@ When the guide publishes to its own file instead of the monolith, set `compile.o
   "name": "architecture-review",
   "compile": {
     "scopeRoot": ".",
-    "outputFile": "architecture-review.md",
-    "hooks": ["stripAnchors", "codeEvidence"]
+    "outputFile": "architecture-review.md"
   }
 }
 ```
+
+Opt out: `"hooks": { "codeEvidence": false }`. See [Default compile hooks](../../features/default-compile-hooks.md).
 
 ## codeEvidence compile example
 

--- a/docs/client-core/compile-hooks/index.md
+++ b/docs/client-core/compile-hooks/index.md
@@ -35,11 +35,13 @@ registerCompileHook('myHook', (ctx) => {
 });
 ```
 
-List hook names in `mdcp.config.json` under `guides[].compile.hooks` (order matters). Optional per-hook config lives under `guides[].compile.hooksConfig`.
+Custom hooks are **not** in the default pipeline — list them explicitly in `compile.hooks` when needed.
 
 Hook implementations should be **pure on `ctx.body`** except when intentionally using shared `hookState`. Leave unmatched links unchanged. Prefer docs-first specs with tests mapped to spec sections (see each hook shard below).
 
 ## Configuration
+
+Built-in hooks run **by default**. Omit `compile.hooks` for the common case. Optional per-hook config lives under `guides[].compile.hooksConfig`.
 
 ```json
 {
@@ -47,7 +49,6 @@ Hook implementations should be **pure on `ctx.body`** except when intentionally 
   "compile": {
     "scopeRoot": ".",
     "outputFile": "architecture-review.md",
-    "hooks": ["stripAnchors", "codeEvidence", "inlineInserts"],
     "hooksConfig": {
       "inlineInserts": { "searchRoots": ["diagrams"] },
       "reviewLinks": { "targetMonolith": "architecture-review.md" }
@@ -55,6 +56,32 @@ Hook implementations should be **pure on `ctx.body`** except when intentionally 
   }
 }
 ```
+
+### Opt out per hook
+
+Disable specific defaults with an object on `compile.hooks` (`false` removes a hook):
+
+```json
+{
+  "compile": {
+    "hooks": { "inlineInserts": false }
+  }
+}
+```
+
+### Explicit override
+
+Replace the entire default pipeline with a string array (backward compatible):
+
+```json
+{
+  "compile": {
+    "hooks": ["stripAnchors", "codeEvidence"]
+  }
+}
+```
+
+Default hook order and behavior: [Default compile hooks](../../features/default-compile-hooks.md). Config API: [API — Config](../api-config.md).
 
 For manifest compile order and `compile.sectionsHeading`, see [Manifest compile order](../../features/manifest-compile-order.md).
 
@@ -64,6 +91,6 @@ For manifest compile order and `compile.sectionsHeading`, see [Manifest compile 
 - **`codeEvidence`** — per shard. [codeEvidence](./code-evidence.md): repo source links → `#L` fragments.
 - **`inlineInserts`** — per shard. [inlineInserts](./inline-inserts.md): inline captioned insert libraries.
 - **Cross-guide rewrite** _(assembly)_ — per shard + post-stitch. [Cross-guide links](./cross-guide-links.md): automatic from `compileOrder`.
-- **`reviewLinks`** — per shard (optional). [reviewLinks](./review-links.md): `targetMonolith` override for cross-guide targets.
+- **`reviewLinks`** — per shard. [reviewLinks](./review-links.md): `targetMonolith` override for cross-guide targets.
 
-`stripAnchors` is also controlled by `compile.stripAnchors` (default `true`) after assembly. Cross-guide rewrite runs automatically for multi-output layouts; add `reviewLinks` only when forcing all cross-links onto one output file.
+`stripAnchors` is also controlled by `compile.stripAnchors` (default `true`) after assembly. Cross-guide rewrite runs automatically for multi-output layouts; `reviewLinks` applies `targetMonolith` when set in `hooksConfig`.

--- a/docs/client-core/compile-hooks/inline-inserts.md
+++ b/docs/client-core/compile-hooks/inline-inserts.md
@@ -46,7 +46,7 @@ The hook **does not** transform:
 - Direct links to binary assets (for example `../figures/architecture.png`, `../figures/demo.mp4`) — use a captioned `.md` insert shard that embeds the media instead
 - External URLs, even when the path contains `diagrams/`
 - Links to missing insert files (left unchanged)
-- Body text when `inlineInserts` is not in `compile.hooks`
+- Body text when `inlineInserts` is disabled via `compile.hooks: { "inlineInserts": false }` or an explicit hook override that omits it
 
 ## inlineInserts first inline
 
@@ -102,17 +102,20 @@ Lookup order for insert shard paths:
 
 ## inlineInserts config
 
+Runs by default. Optional search roots:
+
 ```json
 {
   "name": "architecture-review",
   "compile": {
-    "hooks": ["stripAnchors", "inlineInserts", "reviewLinks"],
     "hooksConfig": {
       "inlineInserts": { "searchRoots": ["diagrams"] }
     }
   }
 }
 ```
+
+Opt out: `"hooks": { "inlineInserts": false }`. See [Default compile hooks](../../features/default-compile-hooks.md).
 
 ## inlineInserts compile example
 

--- a/docs/client-core/compile-hooks/review-links.md
+++ b/docs/client-core/compile-hooks/review-links.md
@@ -1,14 +1,13 @@
 # reviewLinks
 
-Optional compile hook that delegates to the same cross-guide rewrite engine as the automatic assembly pass. Tests in `packages/mdcp-core/test/builtin-hooks.test.ts` cover the `targetMonolith` override.
+Compile hook that delegates to the same cross-guide rewrite engine as the automatic assembly pass. Tests in `packages/mdcp-core/test/builtin-hooks.test.ts` cover the `targetMonolith` override.
 
-Add to `compile.hooks` when you need **`hooksConfig.reviewLinks.targetMonolith`** to force all resolved cross-guide links onto one output file (legacy consumer monoliths).
+Runs by default. Set **`hooksConfig.reviewLinks.targetMonolith`** to force all resolved cross-guide links onto one output file (legacy consumer monoliths):
 
 ```json
 {
   "name": "glossary",
   "compile": {
-    "hooks": ["stripAnchors", "reviewLinks"],
     "hooksConfig": {
       "reviewLinks": { "targetMonolith": "architecture-review.md" }
     }
@@ -17,5 +16,7 @@ Add to `compile.hooks` when you need **`hooksConfig.reviewLinks.targetMonolith`*
 ```
 
 When `targetMonolith` is set, indexed targets in other outputs are rewritten to `{targetMonolith}#slug` instead of their native `outputFile`. When omitted, the hook uses the guide link index (same behavior as the automatic per-shard pass).
+
+Opt out: `"hooks": { "reviewLinks": false }`. See [Default compile hooks](../../features/default-compile-hooks.md).
 
 For index building, resolution rules, and multi-output layouts, see [Cross-guide link rewriting](./cross-guide-links.md).

--- a/docs/developer/agent-work-item-tracking.md
+++ b/docs/developer/agent-work-item-tracking.md
@@ -28,17 +28,27 @@ If none of the above apply, inspect enabled MCP tool descriptors or run `gh --he
 
 ```text
 Integration branch=main (pull before branching)
-Feature branches=descriptive (e.g. docs/issue-39-llm-prompt-templates)
+Feature branches=descriptive (e.g. feature/issue-29-default-compile-hooks)
+One branch per WORK_ITEM=do not mix unrelated features, designs, or doc scopes in one PR
+Branch before work=create the feature branch before shards, tests, or code
 Commits=conventional; atomic and logically grouped
 Release notes=changeset in .changeset/ for user-facing doc changes
+Docs=describe current behavior only; removed or breaking behavior belongs in changeset release notes, not feature/client shards
 Code review=gh pr create; link WORK_ITEM in PR body (Closes #N when appropriate)
 ```
+
+## Workflow best practices
+
+1. **Load scope** — fetch WORK_ITEM (title, body, acceptance criteria) before planning or editing.
+2. **Branch first** — `git checkout main`, pull, then `git checkout -b feature/...` tied to the issue. Never start on `main`.
+3. **Stay focused** — one feature or design at a time. Treat acceptance criteria as the boundary unless WORK_ITEM explicitly expands scope.
+4. **Docs describe now** — update shards to match as-built behavior. Do not document superseded workflows in `docs/features/` or `docs/client/`; record that in the changeset instead.
 
 ## Example prompt header
 
 ```text
 WORK_ITEM=39
-WORK_ITEM_LOOKUP=Branch from main (pull first). Load WORK_ITEM per docs/developer/agent-work-item-tracking.md.
+WORK_ITEM_LOOKUP=Branch from main (pull first). One issue per branch. Load WORK_ITEM per docs/developer/agent-work-item-tracking.md.
 ```
 
 For task-type prompt templates, read [LLM collaboration](../client-cli/llm-collaboration.md).

--- a/docs/features/default-compile-hooks.md
+++ b/docs/features/default-compile-hooks.md
@@ -1,0 +1,84 @@
+# Default compile hooks
+
+Built-in compile hooks run on every guide compile **without** listing hook names in config. Authors express intent in shard markdown (evidence links, insert libraries, cross-guide links); hook enablement is not a second manifest.
+
+## Problem
+
+Consumer configs repeat the same hook array on every guide:
+
+```json
+"hooks": ["stripAnchors", "codeEvidence", "inlineInserts", "reviewLinks"]
+```
+
+New hooks require doc churn and config edits across all guides. Most guides want the same defaults.
+
+## Default hook pipeline
+
+When `guides[].compile.hooks` is omitted, mdcp runs these hooks **in order** on each shard (after heading demotion and preamble stripping):
+
+| Hook            | Purpose                                                                                                          |
+| --------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `stripAnchors`  | Remove explicit heading anchor markers per shard; post-stitch strip uses `compile.stripAnchors` (default `true`) |
+| `codeEvidence`  | Rewrite repo source links to `#L` line fragments                                                                 |
+| `inlineInserts` | Inline captioned insert-library shards on first link                                                             |
+| `reviewLinks`   | Cross-guide link rewrite; honors `hooksConfig.reviewLinks.targetMonolith` when set                               |
+
+Hooks are no-ops when shard content does not match (no evidence links, no insert links, etc.). Cross-guide rewrite also runs automatically at assembly time; default-on `reviewLinks` ensures monolith override works without listing the hook when `targetMonolith` is configured.
+
+Custom hooks registered via `registerCompileHook` are **not** included in defaults — only built-in names above.
+
+## Configuration
+
+### Minimal (common case)
+
+Omit `compile.hooks`. Optional per-hook config still lives under `hooksConfig`:
+
+```json
+{
+  "name": "architecture-review",
+  "compile": {
+    "outputFile": "architecture-review.md",
+    "hooksConfig": {
+      "reviewLinks": { "targetMonolith": "architecture-review.md" }
+    }
+  }
+}
+```
+
+### Opt out per hook
+
+Set `compile.hooks` to an object. Keys with `false` disable that hook; other keys are ignored:
+
+```json
+{
+  "compile": {
+    "hooks": { "inlineInserts": false, "codeEvidence": false }
+  }
+}
+```
+
+### Explicit override (backward compatible)
+
+Set `compile.hooks` to a string array to replace the default pipeline entirely (existing behavior):
+
+```json
+{
+  "compile": {
+    "hooks": ["stripAnchors"]
+  }
+}
+```
+
+## Acceptance criteria
+
+- [x] Default hook pipeline runs without `compile.hooks` when not specified
+- [x] Documented opt-out mechanism (object form on `compile.hooks`)
+- [x] Existing explicit `compile.hooks` string arrays continue to work
+- [x] Tests for default-on behavior and selective disable
+- [x] Client docs show minimal config first, opt-out second
+
+## Implementation
+
+`resolveCompileHooks` in `packages/mdcp-core/src/config/resolve-compile-hooks.ts` merges guide config into an effective hook name list before `assembleGuide` calls `applyCompileHooks`. Constant `DEFAULT_COMPILE_HOOKS` documents the default order.
+
+Hook specs: [Compile hooks — overview](../client-core/compile-hooks/index.md).

--- a/docs/features/feature-catalog.md
+++ b/docs/features/feature-catalog.md
@@ -62,7 +62,7 @@ Orchestrate markdownlint-cli2, Vale, Prettier, markdown-link-check from host rep
 
 ## Compile hooks (P2.2)
 
-Per-shard assembly via `guides[].compile.hooks` on [authored GFM](../glossary/index.md#gfm). Not a preprocessor or template engine — see [Preprocessor / templating (out of scope)](./design-constraints/preprocessor-templating.md#preprocessor-templating-out-of-scope).
+Per-shard assembly via built-in compile hooks on [authored GFM](../glossary/index.md#gfm). Hooks run by default; opt out per hook when needed. See [Default compile hooks](./default-compile-hooks.md). Not a preprocessor or template engine — see [Preprocessor / templating (out of scope)](./design-constraints/preprocessor-templating.md#preprocessor-templating-out-of-scope).
 
 Built-in hooks:
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -11,5 +11,6 @@ Product documentation for **what mdcp is designed to do** — the problems it so
   - [Personas and priority tiers](./personas-and-priority-tiers.md)
   - [Feature catalog](./feature-catalog.md)
   - [Manifest compile order](./manifest-compile-order.md)
+  - [Default compile hooks](./default-compile-hooks.md)
   - [Design constraints](./design-constraints/index.md)
   - [Legacy migration](./legacy-migration.md)

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -122,7 +122,7 @@ Understanding this sequence explains why most commands exist:
 For each guide in `compileOrder`, core:
 
 1. **Reads section files** — from link order in the manifest (`index.md` / `shards.md`). See [Manifest compile order](./manifest-compile-order.md) when the manifest mixes preamble example links with a `## Sections` list (`compile.sectionsHeading`).
-2. **Transforms each shard** — demotes headings to fit the guide level; strips `about-this-guide` preamble; runs named **compile hooks** (`stripAnchors`, `codeEvidence`, `inlineInserts`, `reviewLinks`, …).
+2. **Transforms each shard** — demotes headings to fit the guide level; strips `about-this-guide` preamble; runs **compile hooks** (`stripAnchors`, `codeEvidence`, `inlineInserts`, `reviewLinks`) by default — see [Default compile hooks](./default-compile-hooks.md).
 3. **Assembles the guide body** — injects optional `compile.title` as a `##` heading followed by a blank line, then concatenates sections in order. When the first shard’s top heading matches the title, that duplicate heading is stripped.
 4. **Rewrites links** — same-guide `./section.md` → in-document `#anchor`; optional `publishPathRewrite` for repo-root paths on publish outputs.
 5. **Writes outputs** — monolith file and/or per-guide `compile.outputFile`.

--- a/examples/prompts/README.md
+++ b/examples/prompts/README.md
@@ -4,6 +4,16 @@ Copy-paste prompts for agents working with mdcp. Fill in the **Replace before se
 
 Each prompt assumes the agent can **plan from repo context** — inspect developer docs, scripts, and configuration rather than rely on vendor-specific commands baked into the template.
 
+## Workflow best practices
+
+Task-type prompts (`WORK_ITEM` + `WORK_ITEM_LOOKUP`) share these conventions:
+
+- **Branch first** — create a feature branch from updated `main` before shards, tests, or code
+- **One issue per branch** — stay focused on a single feature, design, or doc scope; do not mix unrelated work in one PR
+- **Current behavior in docs** — shards describe the product as it works now; removed or breaking behavior belongs in the **changeset**, not feature or client guides
+
+Point `WORK_ITEM_LOOKUP` at your repo's agent work-item tracking shard (this repo: [Agent work-item tracking](../../docs/developer/agent-work-item-tracking.md)).
+
 | Prompt                                                                       | Use when                                                     |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | [getting-started-with-mdcp.prompt.md](./getting-started-with-mdcp.prompt.md) | Bootstrapping a sharded docs pipeline in a consumer repo     |

--- a/examples/prompts/design-architecture-task.prompt.md
+++ b/examples/prompts/design-architecture-task.prompt.md
@@ -13,7 +13,7 @@ WORK_ITEM_LOOKUP=
 
 **Role:** Act as an expert Systems Architect.
 
-**Setup:** Follow WORK_ITEM_LOOKUP above. Inspect the repository for scope, acceptance criteria, validation commands, and delivery conventions before editing. Treat acceptance criteria as the scope boundary.
+**Setup:** Follow WORK_ITEM_LOOKUP above. Inspect the repository for scope, acceptance criteria, validation commands, and delivery conventions before editing. Treat acceptance criteria as the scope boundary — one design or RFC at a time; do not expand into adjacent issues unless WORK_ITEM explicitly includes them.
 
 **Plan:** Outline steps from WORK_ITEM and repo context. Pull only the shards, docs, and code paths needed for this task.
 
@@ -21,10 +21,11 @@ WORK_ITEM_LOOKUP=
 
 **Workflow:**
 
+- **Branch first:** Create a feature branch for this WORK_ITEM from updated `main` before design shards or code. One branch per issue — do not mix unrelated designs.
 - Make logically grouped commits per this repo's conventions.
 - **Design first:** Draft the architecture (system diagrams, API contracts, data models) as shards under `docs/features/`. Focus on how the design enables the desired end-user experience.
 - **Review:** Check the proposed architecture for bottlenecks and fit with the as-built system.
-- **Refactor & clean:** Retire superseded design shards or ADRs. Ensure docs reflect the intended as-built architecture.
+- **Refactor & clean:** Retire superseded design shards or ADRs. Document the intended as-built architecture only — not deprecated constraints.
 - **Validate:** Run this repo's documentation validation commands until they pass (discover from developer docs or package scripts).
-- **Wrap-up:** Record architectural changes per this repo's release and communication conventions. Document old behaviors or constraints that no longer apply.
+- **Wrap-up:** Record architectural changes per this repo's release and communication conventions. DO NOT detail any old behavior that no longer works in our docs. That belongs in our changeset.
 - **Finalize:** Submit work for review and link WORK_ITEM.

--- a/examples/prompts/doc-only-task.prompt.md
+++ b/examples/prompts/doc-only-task.prompt.md
@@ -13,7 +13,7 @@ WORK_ITEM_LOOKUP=
 
 **Role:** Act as an expert Technical Writer.
 
-**Setup:** Follow WORK_ITEM_LOOKUP above. Inspect the repository for scope, acceptance criteria, validation commands, and delivery conventions before editing. Treat acceptance criteria as the scope boundary.
+**Setup:** Follow WORK_ITEM_LOOKUP above. Inspect the repository for scope, acceptance criteria, validation commands, and delivery conventions before editing. Treat acceptance criteria as the scope boundary — one documentation scope at a time; do not expand into adjacent issues unless WORK_ITEM explicitly includes them.
 
 **Plan:** Outline steps from WORK_ITEM and repo context. Pull only the shards, docs, and code paths needed for this task.
 
@@ -21,10 +21,11 @@ WORK_ITEM_LOOKUP=
 
 **Workflow:**
 
+- **Branch first:** Create a feature branch for this WORK_ITEM from updated `main` before editing shards. One branch per issue — do not mix unrelated doc work.
 - Make logically grouped commits per this repo's conventions.
 - **Revise & write:** Add or revise mdcp shards under the appropriate guide (`docs/features/`, `docs/developer/`, `docs/client/`). Update each guide's `index.md` for compile order. Use `mdcp refs lookup` for every cross-link — do not edit generated compile output or `refs.json` by hand.
 - **Review:** Check shards against the as-built software.
-- **Refactor & clean:** Remove deprecated references. Ensure docs reflect the current product, not old workflows.
+- **Refactor & clean:** Remove deprecated references. Document current product behavior only — not superseded workflows.
 - **Validate:** Run this repo's documentation validation commands until they pass (discover from developer docs or package scripts).
-- **Wrap-up:** Record what changed per this repo's release and communication conventions. Note old workflows that are no longer recommended.
+- **Wrap-up:** Record what changed per this repo's release and communication conventions. DO NOT detail any old behavior that no longer works in our docs. That belongs in our changeset.
 - **Finalize:** Submit work for review and link WORK_ITEM.

--- a/examples/prompts/feature-level-task.prompt.md
+++ b/examples/prompts/feature-level-task.prompt.md
@@ -13,7 +13,7 @@ WORK_ITEM_LOOKUP=
 
 **Role:** Act as an expert Software Engineer.
 
-**Setup:** Follow WORK_ITEM_LOOKUP above. Inspect the repository for scope, acceptance criteria, validation commands, and delivery conventions before editing. Treat acceptance criteria as the scope boundary.
+**Setup:** Follow WORK_ITEM_LOOKUP above. Inspect the repository for scope, acceptance criteria, validation commands, and delivery conventions before editing. Treat acceptance criteria as the scope boundary — one feature or design at a time; do not expand into adjacent issues unless WORK_ITEM explicitly includes them.
 
 **Plan:** Outline steps from WORK_ITEM and repo context. Pull only the shards, docs, and code paths needed for this task.
 
@@ -21,7 +21,7 @@ WORK_ITEM_LOOKUP=
 
 **Workflow:**
 
-- Create a feature branch for this issue from updated `main` before docs, tests, or code.
+- **Branch first:** Create a feature branch for this WORK_ITEM from updated `main` before docs, tests, or code. One branch per issue — do not mix unrelated features or designs.
 - Make logically grouped commits per this repo's conventions.
 - **Docs first:** Add or update shards under `docs/features/` (capabilities, design, API surface, acceptance criteria) and `docs/client/` (end-user value and how to use the feature). Update each guide's `index.md`. Use `mdcp refs lookup` for cross-links.
 - **TDD:** Implement against the documented contract — write failing tests first where the repo already uses tests, then make them pass, then refactor.

--- a/examples/prompts/feature-level-task.prompt.md
+++ b/examples/prompts/feature-level-task.prompt.md
@@ -21,11 +21,12 @@ WORK_ITEM_LOOKUP=
 
 **Workflow:**
 
+- Create a feature branch for this issue from updated `main` before docs, tests, or code.
 - Make logically grouped commits per this repo's conventions.
 - **Docs first:** Add or update shards under `docs/features/` (capabilities, design, API surface, acceptance criteria) and `docs/client/` (end-user value and how to use the feature). Update each guide's `index.md`. Use `mdcp refs lookup` for cross-links.
 - **TDD:** Implement against the documented contract — write failing tests first where the repo already uses tests, then make them pass, then refactor.
 - **Review:** Check implementation for edge cases, performance, and alignment with the design.
 - **Refactor & clean:** Refactor code, pay down relevant tech debt, update shards to match as-built behavior, and remove stale references.
 - **Validate:** Run this repo's test and documentation validation commands until they pass (discover from developer docs or package scripts).
-- **Wrap-up:** Record what changed per this repo's release and communication conventions. Detail any old behavior that no longer works.
+- **Wrap-up:** Record what changed per this repo's release and communication conventions. DO NOT detail any old behavior that no longer works in our docs. That belongs in our changeset.
 - **Finalize:** Submit work for review and link WORK_ITEM.

--- a/examples/prompts/getting-started-with-mdcp.prompt.md
+++ b/examples/prompts/getting-started-with-mdcp.prompt.md
@@ -52,4 +52,4 @@ Use mdcp commands only — do not create custom compile or lint scripts.
 
 **Cross-links:** Run `mdcp refs lookup "<topic>" --format json` before inserting `[text](#slug)`. The slug must match **compiled** output, not the shard alone.
 
-**Next steps:** After the pipeline exists, use task-type prompts from [examples/prompts/README.md](./README.md). Document work-item tracking once per repo under `docs/developer/` so agents know how to load tracker issues (see [Agent work-item tracking](../../docs/developer/agent-work-item-tracking.md) in the mdcp repo).
+**Next steps:** After the pipeline exists, use task-type prompts from [examples/prompts/README.md](./README.md). Each task uses one WORK_ITEM per branch — branch from updated `main` before editing. Document work-item tracking once per repo under `docs/developer/` so agents know how to load tracker issues (see [Agent work-item tracking](../../docs/developer/agent-work-item-tracking.md) in the mdcp repo).

--- a/examples/prompts/ux-task.prompt.md
+++ b/examples/prompts/ux-task.prompt.md
@@ -13,7 +13,7 @@ WORK_ITEM_LOOKUP=
 
 **Role:** Act as an expert UX Designer and Frontend Engineer.
 
-**Setup:** Follow WORK_ITEM_LOOKUP above. Inspect the repository for scope, acceptance criteria, validation commands, and delivery conventions before editing. Treat acceptance criteria as the scope boundary.
+**Setup:** Follow WORK_ITEM_LOOKUP above. Inspect the repository for scope, acceptance criteria, validation commands, and delivery conventions before editing. Treat acceptance criteria as the scope boundary — one UX scope at a time; do not expand into adjacent issues unless WORK_ITEM explicitly includes them.
 
 **Plan:** Outline steps from WORK_ITEM and repo context. Pull only the shards, docs, and code paths needed for this task.
 
@@ -21,10 +21,11 @@ WORK_ITEM_LOOKUP=
 
 **Workflow:**
 
+- **Branch first:** Create a feature branch for this WORK_ITEM from updated `main` before client shards, UI code, or tests. One branch per issue — do not mix unrelated UX work.
 - Make logically grouped commits per this repo's conventions.
 - **Design & implement:** Map the ideal user flow in shards under `docs/client/` (docs/specs first). Implement UI using this repo's existing patterns and test approach.
 - **Review:** Check code and user flows against acceptance criteria and the as-built interface.
-- **Refactor & clean:** Consolidate UI patterns. Update client-guide shards to match the as-built interface; remove references to old UI patterns.
+- **Refactor & clean:** Consolidate UI patterns. Update client-guide shards to match the as-built interface; remove references to superseded UI patterns.
 - **Validate:** Run this repo's test and documentation validation commands until they pass (discover from developer docs or package scripts).
-- **Wrap-up:** Record visual and interactive changes per this repo's release and communication conventions. Highlight old UI behaviors or workflows that no longer exist.
+- **Wrap-up:** Record visual and interactive changes per this repo's release and communication conventions. DO NOT detail any old behavior that no longer works in our docs. That belongs in our changeset.
 - **Finalize:** Submit work for review and link WORK_ITEM.

--- a/packages/mdcp-cli/README.md
+++ b/packages/mdcp-cli/README.md
@@ -82,6 +82,12 @@ I updated `index.md` in guide `{{GUIDE_NAME}}`. Run mdcp compile and check using
 
 Load scope from the tracker via `WORK_ITEM_LOOKUP` (GitHub MCP, `gh issue view`, Linear MCP, or your repo's documented integration). Then document before you implement — use [feature-level-task.prompt.md](#feature-level-task-prompt-mdcp).
 
+#### Workflow best practices
+
+- **Branch first** — create a feature branch from updated `main` before shards, tests, or code (see [Agent work-item tracking](#agent-work-item-tracking))
+- **One issue per branch** — stay focused on a single feature, design, or doc scope; do not mix unrelated work in one PR
+- **Current behavior in docs** — shards describe the product as it works now; removed or breaking behavior belongs in the **changeset**, not `docs/features/` or `docs/client/`
+
 | Phase     | Where            | Holds                                                  |
 | --------- | ---------------- | ------------------------------------------------------ |
 | Document  | `docs/features/` | Capabilities, design, API surface, acceptance criteria |
@@ -172,6 +178,8 @@ When reviewing an agent's documentation PR:
 - Cross-links use slugs from `mdcp refs lookup`, not guessed anchors
 - Client guide opens with persona context in `about-this-guide.md`
 - Task prompts use only the top replace block — fill in `WORK_ITEM` and `WORK_ITEM_LOOKUP` before sending
+- One WORK_ITEM per PR — branch and scope match a single feature or design
+- Shards describe current behavior; breaking or removed behavior is in the changeset, not feature/client guides
 
 ### See also
 

--- a/packages/mdcp-cli/README.md
+++ b/packages/mdcp-cli/README.md
@@ -583,7 +583,7 @@ Path resolution details: [Config essentials — path layout](#path-layout).
 
 ### Compile hooks
 
-Register hooks per guide in `guides[].compile.hooks`:
+Built-in hooks run **by default** on every guide — omit `compile.hooks` for the common case. See [Default compile hooks](#default-compile-hooks).
 
 | Hook            | Purpose                                                               |
 | --------------- | --------------------------------------------------------------------- |
@@ -592,11 +592,13 @@ Register hooks per guide in `guides[].compile.hooks`:
 | `codeEvidence`  | Resolve evidence links to GitHub line-number fragments                |
 | `reviewLinks`   | Rewrite review links; optional hooksConfig.reviewLinks.targetMonolith |
 
+Opt out per hook: `"hooks": { "codeEvidence": false }`. Replace the pipeline entirely with a string array when needed.
+
 Cross-guide `.md` links rewrite automatically from `compileOrder` and per-guide `compile.outputFile`. Hook specs: [Compile hooks](#developer-guide-1). Cross-monolith rewriting: [Cross-guide links](#cross-guide-link-rewriting).
 
 ### Multi-guide config
 
-Multi-guide repos typically set per-guide publish targets, `sectionsHeading`, and hooks:
+Multi-guide repos typically set per-guide publish targets and `sectionsHeading` — hooks need not be listed:
 
 ```json
 {
@@ -607,8 +609,7 @@ Multi-guide repos typically set per-guide publish targets, `sectionsHeading`, an
       "name": "glossary",
       "compile": {
         "outputFile": "glossary.md",
-        "sectionsHeading": "Sections",
-        "hooks": ["stripAnchors", "inlineInserts", "reviewLinks"]
+        "sectionsHeading": "Sections"
       }
     },
     {
@@ -619,7 +620,6 @@ Multi-guide repos typically set per-guide publish targets, `sectionsHeading`, an
         "outputFile": "architecture-review.md",
         "sectionsHeading": "Sections",
         "scopeRoot": ".",
-        "hooks": ["stripAnchors", "codeEvidence", "inlineInserts", "reviewLinks"],
         "hooksConfig": {
           "reviewLinks": { "targetMonolith": "architecture-review.md" }
         }

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -80,6 +80,7 @@ Use `writeCompiledGuides` when you need to write the monolith and per-guide publ
 | `resolveOutputPath`, `resolveRefsPath`, `resolveGuideDir`, `defaultGuideOutputFile`    | Path resolvers for docs root and `outputDir`                                |
 | `getGuideConfig`, `guideScanDirs`, `shardLintPaths`, `xrefScanDirs`                    | In-scope guide fileset and xref scan helpers                                |
 | `MdcpConfigSchema`, `MdcpConfig`, `MdcpConfigInput`, `GuideConfig`, `GuideConfigInput` | Zod schema and types                                                        |
+| `DEFAULT_COMPILE_HOOKS`, `resolveCompileHooks`                                         | Default built-in hook pipeline and guide-level resolution                   |
 
 ### Path resolution: `configBase` vs docs root
 
@@ -110,6 +111,16 @@ Consumer path table: [Config essentials — path layout](#path-layout).
 `compile.includeBanner` controls whether the global banner is prepended (defaults to `false` for per-guide outputs).
 
 `compile.publishPathRewrite` rewrites shard-relative repo paths in publish outputs. Intra-guide `./section.md` links rewrite to `#anchor` on every compile.
+
+### `compile.hooks`
+
+Built-in hooks run by default when `compile.hooks` is omitted. See [Default compile hooks](#default-compile-hooks).
+
+- **Omitted** — run `DEFAULT_COMPILE_HOOKS` in order: `stripAnchors`, `codeEvidence`, `inlineInserts`, `reviewLinks`
+- **`string[]`** — explicit override; replaces defaults entirely (backward compatible)
+- **`Record<string, boolean>`** — opt out; keys with `false` remove that hook from defaults
+
+Optional per-hook settings: `compile.hooksConfig` (`reviewLinks.targetMonolith`, `inlineInserts.searchRoots`). Post-stitch anchor stripping: `compile.stripAnchors` (default `true`), independent of the per-shard `stripAnchors` hook unless opted out.
 
 ## API — Compile
 
@@ -225,11 +236,13 @@ registerCompileHook('myHook', (ctx) => {
 });
 ```
 
-List hook names in `mdcp.config.json` under `guides[].compile.hooks` (order matters). Optional per-hook config lives under `guides[].compile.hooksConfig`.
+Custom hooks are **not** in the default pipeline — list them explicitly in `compile.hooks` when needed.
 
 Hook implementations should be **pure on `ctx.body`** except when intentionally using shared `hookState`. Leave unmatched links unchanged. Prefer docs-first specs with tests mapped to spec sections (see each hook shard below).
 
 ### Configuration
+
+Built-in hooks run **by default**. Omit `compile.hooks` for the common case. Optional per-hook config lives under `guides[].compile.hooksConfig`.
 
 ```json
 {
@@ -237,7 +250,6 @@ Hook implementations should be **pure on `ctx.body`** except when intentionally 
   "compile": {
     "scopeRoot": ".",
     "outputFile": "architecture-review.md",
-    "hooks": ["stripAnchors", "codeEvidence", "inlineInserts"],
     "hooksConfig": {
       "inlineInserts": { "searchRoots": ["diagrams"] },
       "reviewLinks": { "targetMonolith": "architecture-review.md" }
@@ -245,6 +257,32 @@ Hook implementations should be **pure on `ctx.body`** except when intentionally 
   }
 }
 ```
+
+#### Opt out per hook
+
+Disable specific defaults with an object on `compile.hooks` (`false` removes a hook):
+
+```json
+{
+  "compile": {
+    "hooks": { "inlineInserts": false }
+  }
+}
+```
+
+#### Explicit override
+
+Replace the entire default pipeline with a string array (backward compatible):
+
+```json
+{
+  "compile": {
+    "hooks": ["stripAnchors", "codeEvidence"]
+  }
+}
+```
+
+Default hook order and behavior: [Default compile hooks](#default-compile-hooks). Config API: [API — Config](#api-config).
 
 For manifest compile order and `compile.sectionsHeading`, see [Manifest compile order](#manifest-compile-order).
 
@@ -254,9 +292,9 @@ For manifest compile order and `compile.sectionsHeading`, see [Manifest compile 
 - **`codeEvidence`** — per shard. [codeEvidence](#codeevidence): repo source links → `#L` fragments.
 - **`inlineInserts`** — per shard. [inlineInserts](#inlineinserts): inline captioned insert libraries.
 - **Cross-guide rewrite** _(assembly)_ — per shard + post-stitch. [Cross-guide links](#cross-guide-link-rewriting): automatic from `compileOrder`.
-- **`reviewLinks`** — per shard (optional). [reviewLinks](#reviewlinks): `targetMonolith` override for cross-guide targets.
+- **`reviewLinks`** — per shard. [reviewLinks](#reviewlinks): `targetMonolith` override for cross-guide targets.
 
-`stripAnchors` is also controlled by `compile.stripAnchors` (default `true`) after assembly. Cross-guide rewrite runs automatically for multi-output layouts; add `reviewLinks` only when forcing all cross-links onto one output file.
+`stripAnchors` is also controlled by `compile.stripAnchors` (default `true`) after assembly. Cross-guide rewrite runs automatically for multi-output layouts; `reviewLinks` applies `targetMonolith` when set in `hooksConfig`.
 
 ## codeEvidence
 
@@ -322,18 +360,16 @@ The hook **does not** transform:
 - Markdown shard links (`.md`)
 - External URLs
 - Source links when the file cannot be resolved and no line range appears in label or path
-- Body text when `codeEvidence` is not in `compile.hooks`
+- Body text when `codeEvidence` is disabled via `compile.hooks: { "codeEvidence": false }` or an explicit hook override that omits it
 
 ### codeEvidence config
 
-Minimal setup — add the hook name. Path rewriting uses the monolith or per-guide output path automatically:
+Runs by default — no hook list required. Path rewriting uses the monolith or per-guide output path automatically:
 
 ```json
 {
   "name": "architecture-review",
-  "compile": {
-    "hooks": ["stripAnchors", "codeEvidence"]
-  }
+  "compile": {}
 }
 ```
 
@@ -344,11 +380,12 @@ When the guide publishes to its own file instead of the monolith, set `compile.o
   "name": "architecture-review",
   "compile": {
     "scopeRoot": ".",
-    "outputFile": "architecture-review.md",
-    "hooks": ["stripAnchors", "codeEvidence"]
+    "outputFile": "architecture-review.md"
   }
 }
 ```
+
+Opt out: `"hooks": { "codeEvidence": false }`. See [Default compile hooks](#default-compile-hooks).
 
 ### codeEvidence compile example
 
@@ -357,7 +394,7 @@ Shard input (under `review/claim.md`):
 ```markdown
 Evidence: [`orgCount`](../../functions/src/foo.ts)
 
-See [firestore.rules L6-L8](../../firestore.rules).
+See [firestore.rules L6-L8](../../firestore.rules#L6-L8).
 ```
 
 Compiled output (when `functions/src/foo.ts` defines `orgCount` on line 6 and output is `architecture-review.md` at repo root):
@@ -416,7 +453,7 @@ The hook **does not** transform:
 - Direct links to binary assets (for example `../figures/architecture.png`, `../figures/demo.mp4`) — use a captioned `.md` insert shard that embeds the media instead
 - External URLs, even when the path contains `diagrams/`
 - Links to missing insert files (left unchanged)
-- Body text when `inlineInserts` is not in `compile.hooks`
+- Body text when `inlineInserts` is disabled via `compile.hooks: { "inlineInserts": false }` or an explicit hook override that omits it
 
 ### inlineInserts first inline
 
@@ -472,17 +509,20 @@ Lookup order for insert shard paths:
 
 ### inlineInserts config
 
+Runs by default. Optional search roots:
+
 ```json
 {
   "name": "architecture-review",
   "compile": {
-    "hooks": ["stripAnchors", "inlineInserts", "reviewLinks"],
     "hooksConfig": {
       "inlineInserts": { "searchRoots": ["diagrams"] }
     }
   }
 }
 ```
+
+Opt out: `"hooks": { "inlineInserts": false }`. See [Default compile hooks](#default-compile-hooks).
 
 ### inlineInserts compile example
 
@@ -644,15 +684,14 @@ See [FIND-004](architecture-review.md#find-004) in the architecture review.
 
 ## reviewLinks
 
-Optional compile hook that delegates to the same cross-guide rewrite engine as the automatic assembly pass. Tests in `packages/mdcp-core/test/builtin-hooks.test.ts` cover the `targetMonolith` override.
+Compile hook that delegates to the same cross-guide rewrite engine as the automatic assembly pass. Tests in `packages/mdcp-core/test/builtin-hooks.test.ts` cover the `targetMonolith` override.
 
-Add to `compile.hooks` when you need **`hooksConfig.reviewLinks.targetMonolith`** to force all resolved cross-guide links onto one output file (legacy consumer monoliths).
+Runs by default. Set **`hooksConfig.reviewLinks.targetMonolith`** to force all resolved cross-guide links onto one output file (legacy consumer monoliths):
 
 ```json
 {
   "name": "glossary",
   "compile": {
-    "hooks": ["stripAnchors", "reviewLinks"],
     "hooksConfig": {
       "reviewLinks": { "targetMonolith": "architecture-review.md" }
     }
@@ -661,6 +700,8 @@ Add to `compile.hooks` when you need **`hooksConfig.reviewLinks.targetMonolith`*
 ```
 
 When `targetMonolith` is set, indexed targets in other outputs are rewritten to `{targetMonolith}#slug` instead of their native `outputFile`. When omitted, the hook uses the guide link index (same behavior as the automatic per-shard pass).
+
+Opt out: `"hooks": { "reviewLinks": false }`. See [Default compile hooks](#default-compile-hooks).
 
 For index building, resolution rules, and multi-output layouts, see [Cross-guide link rewriting](#cross-guide-link-rewriting).
 

--- a/packages/mdcp-core/src/compile/assemble.ts
+++ b/packages/mdcp-core/src/compile/assemble.ts
@@ -20,6 +20,7 @@ import {
   resolveUnderOutputDir,
   effectiveGuideOutputFile,
 } from '../config/load.js';
+import { resolveCompileHooks } from '../config/resolve-compile-hooks.js';
 import type { PublishPathRewriteOptions } from './publish-links.js';
 
 export { sectionFiles, type SectionFilesOptions } from './section-manifest.js';
@@ -201,7 +202,7 @@ export function compileGuideResults(options: CompileOptions): CompileGuideResult
       sectionsHeading: compile?.sectionsHeading,
       preambleSection: compile?.preambleSection,
       title: compile?.title,
-      hooks: compile?.hooks,
+      hooks: resolveCompileHooks(compile),
       stripAnchors: compile?.stripAnchors,
       outputBasename,
       outputFile: linkBase,

--- a/packages/mdcp-core/src/compile/hooks/inline-inserts.ts
+++ b/packages/mdcp-core/src/compile/hooks/inline-inserts.ts
@@ -5,11 +5,10 @@ import type { CompileHook, CompileHookState, InlineInsertsHookState } from '../h
 import { hookSearchRoots, resolveRelativeFile } from './path-resolve.js';
 
 /** Paths under shared insert libraries: diagrams/, tables/, figures/, media/, inserts/, etc. */
-const INSERT_LIBRARY_SEGMENT =
-  '(?:diagram|diagrams|table|tables|figure|figures|media|insert|inserts)';
+const INSERT_LIBRARY_DIR = '(?:diagrams?|tables?|figures?|media|inserts?)';
 
 const INSERT_LINK_RE = new RegExp(
-  `\\[([^\\]]*)\\]\\((\\.\\/)?([^)]*${INSERT_LIBRARY_SEGMENT}[^)]*\\.md)(?:#[^)]+)?\\)`,
+  `\\[([^\\]]*)\\]\\((?!https?:)((?:(?:\\.\\./)+|\\./)?${INSERT_LIBRARY_DIR}/[^)#\\s][^)]*\\.md(?:#[^)]+)?)\\)`,
   'gi',
 );
 
@@ -152,7 +151,7 @@ function findInsertLinks(body: string): InsertLinkRef[] {
       start: index,
       end: index + raw.length,
       label: match[1],
-      relPath: match[3],
+      relPath: match[2],
     });
   }
   return refs;

--- a/packages/mdcp-core/src/config/resolve-compile-hooks.ts
+++ b/packages/mdcp-core/src/config/resolve-compile-hooks.ts
@@ -1,0 +1,28 @@
+import type { GuideConfigInput } from './schema.js';
+
+/** Built-in compile hooks run when `compile.hooks` is omitted. */
+export const DEFAULT_COMPILE_HOOKS = [
+  'stripAnchors',
+  'codeEvidence',
+  'inlineInserts',
+  'reviewLinks',
+] as const;
+
+export type DefaultCompileHook = (typeof DEFAULT_COMPILE_HOOKS)[number];
+
+type CompileHooksInput = NonNullable<GuideConfigInput['compile']>;
+
+/** Resolve the effective hook pipeline for a guide compile config. */
+export function resolveCompileHooks(compile?: CompileHooksInput): string[] {
+  const hooks = compile?.hooks;
+
+  if (hooks === undefined) {
+    return [...DEFAULT_COMPILE_HOOKS];
+  }
+
+  if (Array.isArray(hooks)) {
+    return hooks;
+  }
+
+  return DEFAULT_COMPILE_HOOKS.filter((name) => hooks[name] !== false);
+}

--- a/packages/mdcp-core/src/config/schema.ts
+++ b/packages/mdcp-core/src/config/schema.ts
@@ -42,8 +42,8 @@ const GuideSchema = z.object({
       outputFile: z.string().optional(),
       /** Apply global banner to this guide's output (default: true for monolith, false when outputFile is set). */
       includeBanner: z.boolean().optional(),
-      /** Named compile hooks (see compile/hooks.ts). */
-      hooks: z.array(z.string()).optional(),
+      /** Named compile hooks (see compile/hooks.ts). String array replaces defaults; object opts out. */
+      hooks: z.union([z.array(z.string()), z.record(z.string(), z.boolean())]).optional(),
       hooksConfig: z
         .object({
           reviewLinks: z

--- a/packages/mdcp-core/src/index.ts
+++ b/packages/mdcp-core/src/index.ts
@@ -21,6 +21,11 @@ export {
   resolveUnderOutputDir,
 } from './config/load.js';
 export {
+  DEFAULT_COMPILE_HOOKS,
+  resolveCompileHooks,
+  type DefaultCompileHook,
+} from './config/resolve-compile-hooks.js';
+export {
   demoteHeadings,
   demoteExceptFirstH1,
   stripAboutThisGuideHeading,

--- a/packages/mdcp-core/test/config.test.ts
+++ b/packages/mdcp-core/test/config.test.ts
@@ -35,6 +35,22 @@ describe('MdcpConfigSchema', () => {
     expect(cfg.guides?.[0].compile?.hooks).toContain('stripAnchors');
   });
 
+  it('parses object-form hook opt-out', () => {
+    const cfg = MdcpConfigSchema.parse({
+      compileOrder: ['glossary'],
+      guides: [
+        {
+          name: 'glossary',
+          compile: {
+            hooks: { codeEvidence: false, inlineInserts: false },
+          },
+        },
+      ],
+    });
+    const hooks = cfg.guides?.[0].compile?.hooks;
+    expect(hooks).toEqual({ codeEvidence: false, inlineInserts: false });
+  });
+
   it('rejects empty compileOrder', () => {
     expect(() => MdcpConfigSchema.parse({ compileOrder: [] })).toThrow();
   });

--- a/packages/mdcp-core/test/default-hooks.test.ts
+++ b/packages/mdcp-core/test/default-hooks.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_COMPILE_HOOKS, resolveCompileHooks } from '../src/config/resolve-compile-hooks.js';
+
+describe('resolveCompileHooks', () => {
+  it('returns all default hooks when compile.hooks is omitted', () => {
+    expect(resolveCompileHooks(undefined)).toEqual([...DEFAULT_COMPILE_HOOKS]);
+    expect(resolveCompileHooks({})).toEqual([...DEFAULT_COMPILE_HOOKS]);
+  });
+
+  it('returns explicit array override unchanged', () => {
+    expect(resolveCompileHooks({ hooks: ['stripAnchors'] })).toEqual(['stripAnchors']);
+    expect(resolveCompileHooks({ hooks: ['identity'] })).toEqual(['identity']);
+  });
+
+  it('opts out hooks listed as false in object form', () => {
+    expect(
+      resolveCompileHooks({
+        hooks: { codeEvidence: false, inlineInserts: false },
+      }),
+    ).toEqual(['stripAnchors', 'reviewLinks']);
+  });
+
+  it('ignores true values in object form', () => {
+    expect(
+      resolveCompileHooks({
+        hooks: { codeEvidence: true, inlineInserts: false },
+      }),
+    ).toEqual(['stripAnchors', 'codeEvidence', 'reviewLinks']);
+  });
+
+  it('includes reviewLinks in defaults when targetMonolith is set', () => {
+    expect(
+      resolveCompileHooks({
+        hooksConfig: { reviewLinks: { targetMonolith: 'architecture-review.md' } },
+      }),
+    ).toContain('reviewLinks');
+  });
+});
+
+describe('DEFAULT_COMPILE_HOOKS', () => {
+  it('lists built-in hooks in compile order', () => {
+    expect(DEFAULT_COMPILE_HOOKS).toEqual([
+      'stripAnchors',
+      'codeEvidence',
+      'inlineInserts',
+      'reviewLinks',
+    ]);
+  });
+});

--- a/packages/mdcp-core/test/inline-inserts.test.ts
+++ b/packages/mdcp-core/test/inline-inserts.test.ts
@@ -31,6 +31,8 @@ describe('inlineInserts — link matching', () => {
     expect(isInsertLibraryPath('../figures/map.md')).toBe(true);
     expect(isInsertLibraryPath('../media/walkthrough.md')).toBe(true);
     expect(isInsertLibraryPath('../inserts/shared-block.md')).toBe(true);
+    expect(isInsertLibraryPath('./inline-inserts.md')).toBe(false);
+    expect(isInsertLibraryPath('compile-hooks/inline-inserts.md')).toBe(false);
     expect(isInsertLibraryPath('./intro.md')).toBe(false);
     expect(isInsertLibraryPath('../glossary/term.md')).toBe(false);
     expect(isInsertLibraryPath('../diagrams/flow.png')).toBe(false);


### PR DESCRIPTION
## Summary

- Built-in compile hooks (`stripAnchors`, `codeEvidence`, `inlineInserts`, `reviewLinks`) run by default when `guides[].compile.hooks` is omitted
- Opt out per hook with object form: `{ "codeEvidence": false }`; explicit string arrays still replace the pipeline entirely (backward compatible)
- Adds `resolveCompileHooks` / `DEFAULT_COMPILE_HOOKS` in mdcp-core; tightens `inlineInserts` path matching to library directories so default-on does not inline hook spec shards
- Docs-first: feature shard, client-core compile-hooks guides, consumer migration minimal config examples

Closes #29

## Test plan

- [x] `pnpm check` (typecheck, lint, format, build, test, docs:check)
- [x] `pnpm changeset:status`
- [x] Unit tests: `default-hooks.test.ts`, `config.test.ts`, `inline-inserts.test.ts`
- [x] Dogfood compile: `docs/mdcp.config.json` without hook arrays
- [x] Sample fixture: `examples/sample-guides` compile + check


Made with [Cursor](https://cursor.com)