### PR TITLE
Rename MDCP expansion to MarkDown Context Protocol

### DIFF
--- a/.changeset/issue-41-markdown-context-protocol.md
+++ b/.changeset/issue-41-markdown-context-protocol.md
@@ -1,0 +1,9 @@
+---
+'@bwilliamson/mdcp-cli': patch
+'@bwilliamson/mdcp-core': patch
+'@bwilliamson/mdcp-presets': patch
+---
+
+Rename the MDCP expansion from Markdown Command Line Interface Processor to MarkDown Context Protocol.
+
+User-facing updates include npm package descriptions, `mdcp --help` text, and the compiled CLI README opening. The new name reflects mdcp as a protocol for repository documentation context — not only a CLI wrapper.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -10,6 +10,10 @@ Contributors are expected to follow the [Contributor Covenant Code of Conduct](R
 
 Shared acronyms and terms for all mdcp docs. Spell out on first use in a shard and link the short form here.
 
+### MDCP
+
+**MarkDown Context Protocol** — a protocol for repository documentation context: sharded intent and design in Markdown, validated compile output for agents, CI, and human readers. The CLI is one surface; `compile`, `check`, `refs lookup`, and `export --llm` implement the shared context layer.
+
 ### GFM
 
 **GitHub Flavored Markdown** — standard Markdown plus GitHub extensions (tables, task lists, fenced code). Not Pandoc, LaTeX, or wikilinks.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MDCP — Markdown Command Line Interface Processor
+# MDCP — MarkDown Context Protocol
 
-**mdcp** splits, compiles, validates, and exports sharded Markdown documentation for code repositories. You edit small shard files; mdcp weaves them into compiled output with correct heading levels, working cross-links, and structure checks.
+**mdcp** is a protocol for repository documentation context — sharded intent and design in Markdown, validated compile output for agents, CI, and human readers. You edit small shard files; mdcp weaves them into compiled output with correct heading levels, working cross-links, and structure checks. The CLI is one surface for `compile`, `check`, `refs lookup`, and `export --llm`.
 
 Shards are the **source of truth**. Generated output includes a local `docs/guides.md` (features review — gitignored), `docs/refs.json` (gitignored), [`DEVELOPERS.md`](DEVELOPERS.md) (from `docs/developer/`), and npm package READMEs compiled from `docs/client-cli/` and `docs/client-core/`.
 

--- a/docs/client-cli/why-mdcp-for-agents.md
+++ b/docs/client-cli/why-mdcp-for-agents.md
@@ -1,6 +1,6 @@
 # Why mdcp for coding agents
 
-**mdcp** splits, compiles, validates, and exports sharded Markdown documentation. Shards are the source of truth; compiled output is generated.
+**MDCP** ([MarkDown Context Protocol](../glossary/index.md#mdcp)) splits, compiles, validates, and exports sharded Markdown documentation. Shards are the source of truth; compiled output is generated.
 
 ## The pain
 

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-**mdcp** (Markdown Command Line Interface Processor) helps teams maintain large documentation in **small shard files**, **compile them into canonical outputs**, and **validate before merge**. It is built for LLM-assisted authoring, human review, and compiled output for agents and end-user readers.
+**mdcp** ([MarkDown Context Protocol](../glossary/index.md#mdcp)) helps teams maintain large documentation in **small shard files**, **compile them into canonical outputs**, and **validate before merge**. It is built for LLM-assisted authoring, human review, and compiled output for agents and end-user readers.
 
 This page is the **mental model** for the whole system. Use it to orient yourself before diving into command details, API modules, or config fields.
 

--- a/docs/glossary/index.md
+++ b/docs/glossary/index.md
@@ -2,6 +2,10 @@
 
 Shared acronyms and terms for all mdcp docs. Spell out on first use in a shard and link the short form here.
 
+## MDCP
+
+**MarkDown Context Protocol** — a protocol for repository documentation context: sharded intent and design in Markdown, validated compile output for agents, CI, and human readers. The CLI is one surface; `compile`, `check`, `refs lookup`, and `export --llm` implement the shared context layer.
+
 ## GFM
 
 **GitHub Flavored Markdown** — standard Markdown plus GitHub extensions (tables, task lists, fenced code). Not Pandoc, LaTeX, or wikilinks.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdcp-monorepo",
   "private": true,
-  "description": "MDCP — Markdown Command Line Interface Processor",
+  "description": "MDCP — MarkDown Context Protocol",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/mdcp-cli/README.md
+++ b/packages/mdcp-cli/README.md
@@ -2,7 +2,7 @@
 
 ## Why mdcp for coding agents
 
-**mdcp** splits, compiles, validates, and exports sharded Markdown documentation. Shards are the source of truth; compiled output is generated.
+**MDCP** ([MarkDown Context Protocol](#mdcp)) splits, compiles, validates, and exports sharded Markdown documentation. Shards are the source of truth; compiled output is generated.
 
 ### The pain
 
@@ -718,6 +718,10 @@ The `@bwilliamson/mdcp-presets` shard config supplies **rules and exclusions** (
 ## Glossary
 
 Shared acronyms and terms for all mdcp docs. Spell out on first use in a shard and link the short form here.
+
+### MDCP
+
+**MarkDown Context Protocol** — a protocol for repository documentation context: sharded intent and design in Markdown, validated compile output for agents, CI, and human readers. The CLI is one surface; `compile`, `check`, `refs lookup`, and `export --llm` implement the shared context layer.
 
 ### GFM
 

--- a/packages/mdcp-cli/package.json
+++ b/packages/mdcp-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bwilliamson/mdcp-cli",
   "version": "0.2.0",
-  "description": "MDCP CLI — Markdown Command Line Interface Processor",
+  "description": "MDCP CLI — MarkDown Context Protocol",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/packages/mdcp-cli/src/cli.ts
+++ b/packages/mdcp-cli/src/cli.ts
@@ -106,7 +106,7 @@ const program = new Command();
 
 program
   .name('mdcp')
-  .description('Markdown Command Line Interface Processor')
+  .description('MarkDown Context Protocol')
   .version(pkg.version)
   .option(
     '-c, --config <path>',

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -26,6 +26,10 @@ The CLI (`@bwilliamson/mdcp-cli`) depends on this package. Install `@bwilliamson
 
 Shared acronyms and terms for all mdcp docs. Spell out on first use in a shard and link the short form here.
 
+### MDCP
+
+**MarkDown Context Protocol** — a protocol for repository documentation context: sharded intent and design in Markdown, validated compile output for agents, CI, and human readers. The CLI is one surface; `compile`, `check`, `refs lookup`, and `export --llm` implement the shared context layer.
+
 ### GFM
 
 **GitHub Flavored Markdown** — standard Markdown plus GitHub extensions (tables, task lists, fenced code). Not Pandoc, LaTeX, or wikilinks.

--- a/packages/mdcp-core/package.json
+++ b/packages/mdcp-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bwilliamson/mdcp-core",
   "version": "0.2.0",
-  "description": "MDCP core library — compile, refs, validation",
+  "description": "MDCP core library — MarkDown Context Protocol compile, refs, validation",
   "license": "MIT",
   "type": "module",
   "sideEffects": [

--- a/packages/mdcp-presets/package.json
+++ b/packages/mdcp-presets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bwilliamson/mdcp-presets",
   "version": "0.2.0",
-  "description": "Starter markdownlint configs for MDCP consumers",
+  "description": "Starter markdownlint configs for MarkDown Context Protocol consumers",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

- Rename the MDCP expansion from "Markdown Command Line Interface Processor" to **MarkDown Context Protocol** across the repo — docs shards, package metadata, CLI `--help`, and compiled READMEs.
- Add a glossary entry defining MDCP as a protocol for repository documentation context (sharded intent/design, validated compile output for agents, CI, and humans).
- Frame the root README and client-cli opening around context protocol value, not CLI-as-product.

Closes #41

## Test plan

- [x] Repo-wide grep clean for old expansion (`Markdown Command Line Interface Processor`, `Command Line Interface Processor`)
- [x] `pnpm docs:check:repo` passes after recompile
- [x] `pnpm changeset:status` passes (patch bump on all three packages)
- [x] `pnpm run check` passes (typecheck, lint, test, docs)


Made with [Cursor](https://cursor.com)