### PR TITLE
fix(cli): write refs registry under outputDir during compile

### DIFF
--- a/.changeset/compile-refs-registry-path.md
+++ b/.changeset/compile-refs-registry-path.md
@@ -1,0 +1,7 @@
+---
+'@bwilliamson/mdcp-cli': patch
+---
+
+Fix `mdcp compile` so it writes `refs.json` under `outputDir` (via `refs.registryFile`) instead of omitting the registry when guides use nested `compile.outputFile` paths. `mdcp refs list` now works immediately after compile.
+
+Closes #62

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - run: pnpm run lint
       - run: pnpm run format:check
       - run: pnpm run build
+      - run: pnpm run spec:check-llms-index
       - run: pnpm run test
       - run: pnpm run prepare:docs
       - run: pnpm run docs:check

--- a/docs/client-cli/commands-reference.md
+++ b/docs/client-cli/commands-reference.md
@@ -32,18 +32,18 @@ mdcp check
 
 ## Command summary
 
-| Command                    | When you need it                                                           |
-| -------------------------- | -------------------------------------------------------------------------- |
-| `mdcp compile`             | Regenerate the monolith from shards (exits 1 on broken links by default)   |
-| `mdcp check`               | Full gate: orphans → compile → refs → links → xrefs; optional peer linters |
-| `mdcp shard`               | Split a monolith into shards (requires `config.source`)                    |
-| `mdcp refs list`           | List heading slugs from `refs.json` as JSON                                |
-| `mdcp refs lookup <query>` | Search compiled section titles while writing cross-links                   |
-| `mdcp export --llm`        | Token-stripped compiled output for LLM context                             |
-| `mdcp lint`                | markdownlint-cli2 on shards and compiled output (peer, if installed)       |
-| `mdcp prose`               | Vale prose lint (peer, if installed)                                       |
-| `mdcp links`               | markdown-link-check on compiled output (peer, if installed)                |
-| `mdcp fix`                 | Prettier + markdownlint `--fix` (install peers in host repo first)         |
+| Command                    | When you need it                                                                                   |
+| -------------------------- | -------------------------------------------------------------------------------------------------- |
+| `mdcp compile`             | Regenerate compiled outputs and `refs.json` under `outputDir` (exits 1 on broken links by default) |
+| `mdcp check`               | Full gate: orphans → compile → refs → links → xrefs; optional peer linters                         |
+| `mdcp shard`               | Split a monolith into shards (requires `config.source`)                                            |
+| `mdcp refs list`           | List heading slugs from `refs.json` as JSON                                                        |
+| `mdcp refs lookup <query>` | Search compiled section titles while writing cross-links                                           |
+| `mdcp export --llm`        | Token-stripped compiled output for LLM context                                                     |
+| `mdcp lint`                | markdownlint-cli2 on shards and compiled output (peer, if installed)                               |
+| `mdcp prose`               | Vale prose lint (peer, if installed)                                                               |
+| `mdcp links`               | markdown-link-check on compiled output (peer, if installed)                                        |
+| `mdcp fix`                 | Prettier + markdownlint `--fix` (install peers in host repo first)                                 |
 
 ## Refs subcommands
 

--- a/docs/client-cli/compile-refs-registry.md
+++ b/docs/client-cli/compile-refs-registry.md
@@ -1,0 +1,34 @@
+# Compile and the refs registry
+
+## End-user value
+
+When you organize compiled outputs in subdirectories (`compile.outputFile: "compiled/guide-a.md"`), `mdcp compile` still keeps the refs registry at the documented cache path under `outputDir`. You can run `mdcp refs list` right after compile when writing cross-links — no manual move and no extra `mdcp refs gen` step.
+
+## Path layout
+
+`refs.registryFile` is always relative to `outputDir`, not to each guide's `compile.outputFile`. See [Config essentials — path layout](./config-essentials.md#path-layout).
+
+Example:
+
+```json
+{
+  "outputDir": "_build",
+  "refs": { "registryFile": ".caches/refs.json" },
+  "guides": [{ "name": "guide-a", "compile": { "outputFile": "compiled/guide-a.md" } }]
+}
+```
+
+| Artifact       | Path                              |
+| -------------- | --------------------------------- |
+| Compiled guide | `docs/_build/compiled/guide-a.md` |
+| Refs registry  | `docs/_build/.caches/refs.json`   |
+
+## Workflow
+
+```bash
+mdcp compile --config docs/mdcp.config.json --docs-root docs
+mdcp refs list --config docs/mdcp.config.json --docs-root docs
+mdcp refs lookup "section title" --config docs/mdcp.config.json --docs-root docs
+```
+
+`mdcp refs lookup` compiles fresh in memory; `mdcp refs list` reads the registry file that `compile` just wrote.

--- a/docs/client-cli/index.md
+++ b/docs/client-cli/index.md
@@ -9,6 +9,7 @@
   - [Project layout](./project-layout.md)
   - [Config essentials](./config-essentials.md)
   - [Commands reference](./commands-reference.md)
+  - [Compile and the refs registry](./compile-refs-registry.md)
   - [Cross-links and refs](./cross-links-and-refs.md)
   - [Consumer migration](./consumer-migration.md)
   - [Optional linters](./optional-linters.md)

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -15,6 +15,7 @@ Product documentation for **what mdcp is designed to do** — the problems it so
   - [Default compile hooks](./default-compile-hooks.md)
   - [Compile output backup](./compile-output-backup.md)
   - [Link validation](./link-validation.md)
+  - [Refs registry path](./refs-registry-path.md)
   - [Design constraints](./design-constraints/index.md)
   - [Protocol](./protocol/00-vision-and-roadmap.md)
     - [Vision and roadmap](./protocol/00-vision-and-roadmap.md)

--- a/docs/features/refs-registry-path.md
+++ b/docs/features/refs-registry-path.md
@@ -1,0 +1,26 @@
+# Refs registry path
+
+Specification for where `mdcp compile` writes the heading-slug registry (`refs.json`). Regression tests live in `packages/mdcp-cli/test/cli.smoke.test.ts`.
+
+## Purpose
+
+The refs registry is derived state under `outputDir`, not co-located with per-guide publish outputs. Consumers run `mdcp compile` then `mdcp refs list` or `mdcp refs lookup` while editing cross-links. Both commands must agree on the on-disk registry path.
+
+## Path resolution
+
+`refs.registryFile` resolves relative to **`outputDir`** only — the same rule as `resolveRefsPath` in `@bwilliamson/mdcp-core`. Per-guide `compile.outputFile` values (including subdirectory prefixes such as `compiled/guide-a.md`) do not change the registry base.
+
+| Config                                                                   | Resolved path (`--docs-root docs`)                |
+| ------------------------------------------------------------------------ | ------------------------------------------------- |
+| `outputDir: "_build"`, `refs.registryFile: ".caches/refs.json"`          | `docs/_build/.caches/refs.json`                   |
+| `outputDir: "_build"`, guide `compile.outputFile: "compiled/guide-a.md"` | Registry still at `docs/_build/.caches/refs.json` |
+
+## Compile behaviour
+
+`mdcp compile` regenerates the refs registry after writing compiled guide outputs, using the same compiled text as `mdcp check` and `mdcp refs gen`.
+
+## Acceptance criteria
+
+1. After `mdcp compile` with nested `compile.outputFile` paths, `refs.json` exists at `{docsRoot}/{outputDir}/{registryFile}`.
+2. The registry is **not** written beside per-guide outputs (for example `docs/_build/compiled/refs.json`).
+3. `mdcp refs list` succeeds immediately after `mdcp compile` without `mdcp refs gen`.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepare:docs": "pnpm run verify:peers && pnpm run vale:sync",
     "docs:compile:repo": "node packages/mdcp-cli/dist/cli.js compile --config docs/mdcp.config.json --docs-root docs --warn-broken-links && node packages/mdcp-cli/dist/cli.js export --llms-index --config docs/mdcp.config.json --docs-root docs",
     "spec:sync-llms-index": "node scripts/sync-llms-index-spec.mjs",
+    "spec:check-llms-index": "node scripts/sync-llms-index-spec.mjs && git diff --exit-code spec/llms-index/",
     "docs:check:repo": "node packages/mdcp-cli/dist/cli.js check --config docs/mdcp.config.json --docs-root docs --require-lint --require-vale",
     "docs:context": "node packages/mdcp-cli/dist/cli.js export --llm --stdout --config docs/mdcp.config.json --docs-root docs",
     "docs:lint": "node packages/mdcp-cli/dist/cli.js lint --config examples/sample-guides/mdcp.config.json --docs-root examples/sample-guides --require-lint",

--- a/packages/mdcp-cli/README.md
+++ b/packages/mdcp-cli/README.md
@@ -628,18 +628,18 @@ mdcp check
 
 ### Command summary
 
-| Command                    | When you need it                                                           |
-| -------------------------- | -------------------------------------------------------------------------- |
-| `mdcp compile`             | Regenerate the monolith from shards (exits 1 on broken links by default)   |
-| `mdcp check`               | Full gate: orphans → compile → refs → links → xrefs; optional peer linters |
-| `mdcp shard`               | Split a monolith into shards (requires `config.source`)                    |
-| `mdcp refs list`           | List heading slugs from `refs.json` as JSON                                |
-| `mdcp refs lookup <query>` | Search compiled section titles while writing cross-links                   |
-| `mdcp export --llm`        | Token-stripped compiled output for LLM context                             |
-| `mdcp lint`                | markdownlint-cli2 on shards and compiled output (peer, if installed)       |
-| `mdcp prose`               | Vale prose lint (peer, if installed)                                       |
-| `mdcp links`               | markdown-link-check on compiled output (peer, if installed)                |
-| `mdcp fix`                 | Prettier + markdownlint `--fix` (install peers in host repo first)         |
+| Command                    | When you need it                                                                                   |
+| -------------------------- | -------------------------------------------------------------------------------------------------- |
+| `mdcp compile`             | Regenerate compiled outputs and `refs.json` under `outputDir` (exits 1 on broken links by default) |
+| `mdcp check`               | Full gate: orphans → compile → refs → links → xrefs; optional peer linters                         |
+| `mdcp shard`               | Split a monolith into shards (requires `config.source`)                                            |
+| `mdcp refs list`           | List heading slugs from `refs.json` as JSON                                                        |
+| `mdcp refs lookup <query>` | Search compiled section titles while writing cross-links                                           |
+| `mdcp export --llm`        | Token-stripped compiled output for LLM context                                                     |
+| `mdcp lint`                | markdownlint-cli2 on shards and compiled output (peer, if installed)                               |
+| `mdcp prose`               | Vale prose lint (peer, if installed)                                                               |
+| `mdcp links`               | markdown-link-check on compiled output (peer, if installed)                                        |
+| `mdcp fix`                 | Prettier + markdownlint `--fix` (install peers in host repo first)                                 |
 
 ### Refs subcommands
 
@@ -659,6 +659,41 @@ mdcp export --llm --stdout
 # Find section links while authoring
 mdcp refs lookup "authentication" --format json
 ```
+
+## Compile and the refs registry
+
+### End-user value
+
+When you organize compiled outputs in subdirectories (`compile.outputFile: "compiled/guide-a.md"`), `mdcp compile` still keeps the refs registry at the documented cache path under `outputDir`. You can run `mdcp refs list` right after compile when writing cross-links — no manual move and no extra `mdcp refs gen` step.
+
+### Path layout
+
+`refs.registryFile` is always relative to `outputDir`, not to each guide's `compile.outputFile`. See [Config essentials — path layout](#path-layout).
+
+Example:
+
+```json
+{
+  "outputDir": "_build",
+  "refs": { "registryFile": ".caches/refs.json" },
+  "guides": [{ "name": "guide-a", "compile": { "outputFile": "compiled/guide-a.md" } }]
+}
+```
+
+| Artifact       | Path                              |
+| -------------- | --------------------------------- |
+| Compiled guide | `docs/_build/compiled/guide-a.md` |
+| Refs registry  | `docs/_build/.caches/refs.json`   |
+
+### Workflow
+
+```bash
+mdcp compile --config docs/mdcp.config.json --docs-root docs
+mdcp refs list --config docs/mdcp.config.json --docs-root docs
+mdcp refs lookup "section title" --config docs/mdcp.config.json --docs-root docs
+```
+
+`mdcp refs lookup` compiles fresh in memory; `mdcp refs list` reads the registry file that `compile` just wrote.
 
 ## Cross-links and refs
 

--- a/packages/mdcp-cli/src/cli.ts
+++ b/packages/mdcp-cli/src/cli.ts
@@ -202,8 +202,11 @@ program
   .action((_, cmd) => {
     const opts = cmd.parent.opts() as GlobalOpts;
     const config = getConfig(opts);
-    writeCompiled(config, getDocsRoot(opts), opts);
-    if (runBuiltInLinkLint(config, getDocsRoot(opts), opts)) process.exit(1);
+    const docsRoot = getDocsRoot(opts);
+    const compiled = writeCompiled(config, docsRoot, opts);
+    const refsPath = resolveRefsPath(docsRoot, config.outputDir, config.refs.registryFile);
+    genRefsFromCompiled(compiled, refsPath);
+    if (runBuiltInLinkLint(config, docsRoot, opts)) process.exit(1);
   });
 
 const refs = program.command('refs').description('Heading slug registry (JSON default)');

--- a/packages/mdcp-cli/test/cli.smoke.test.ts
+++ b/packages/mdcp-cli/test/cli.smoke.test.ts
@@ -111,6 +111,43 @@ describe('cli smoke', () => {
     }
   });
 
+  it('writes refs.registryFile under outputDir after compile when guides use nested outputFile (#62)', () => {
+    const docs = mkdtempSync(join(tmpdir(), 'mdcp-smoke-'));
+    try {
+      const guide = join(docs, 'guide-a');
+      mkdirSync(guide, { recursive: true });
+      writeFileSync(join(guide, 'index.md'), '# Guide A\n\n- [Section one](section-1.md)\n');
+      writeFileSync(join(guide, 'section-1.md'), '# Section one\n\nBody text.\n');
+      writeFileSync(
+        join(docs, 'mdcp.config.json'),
+        JSON.stringify({
+          outputDir: '_build',
+          compileOrder: ['guide-a'],
+          guides: [{ name: 'guide-a', compile: { outputFile: 'compiled/guide-a.md' } }],
+          refs: { registryFile: '.caches/refs.json' },
+          lint: { links: { enabled: false }, xrefs: { enabled: false } },
+        }),
+      );
+
+      execFileSync('node', [CLI, 'compile', '--config', 'mdcp.config.json', '--docs-root', docs], {
+        encoding: 'utf-8',
+        cwd: docs,
+      });
+
+      expect(existsSync(join(docs, '_build/.caches/refs.json'))).toBe(true);
+      expect(existsSync(join(docs, '_build/compiled/refs.json'))).toBe(false);
+
+      const listed = execFileSync(
+        'node',
+        [CLI, 'refs', 'list', '--config', 'mdcp.config.json', '--docs-root', docs],
+        { encoding: 'utf-8', cwd: docs },
+      );
+      expect(listed).toContain('section-one');
+    } finally {
+      rmSync(docs, { recursive: true, force: true });
+    }
+  });
+
   it('normalizes cwd-relative refs.registryFile under outputDir (#11)', () => {
     const docs = mkdtempSync(join(tmpdir(), 'mdcp-smoke-'));
     try {

--- a/scripts/sync-llms-index-spec.mjs
+++ b/scripts/sync-llms-index-spec.mjs
@@ -6,6 +6,8 @@ import {
   buildLlmsIndex,
   defaultLlmsIndexFilename,
   LLMS_INDEX_SPEC_DIR,
+  LLMS_INDEX_PROFILE_ALPHA,
+  LLMS_INDEX_PROFILE_DEV,
 } from '../packages/mdcp-core/dist/index.js';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -16,8 +18,17 @@ const canonical = buildLlmsIndex();
 const stableName = defaultLlmsIndexFilename();
 const draftName = defaultLlmsIndexFilename(undefined, { draft: true });
 
+// Named files (versioned artifacts)
 writeFileSync(join(specDir, stableName), canonical);
 writeFileSync(join(specDir, draftName), canonical);
 
+// Profile pointers — written as real files (not symlinks) so that
+// raw.githubusercontent.com serves the content directly when other repos
+// fetch via the profile path (e.g. spec/llms-index/valpha).
+writeFileSync(join(specDir, LLMS_INDEX_PROFILE_ALPHA), canonical);
+writeFileSync(join(specDir, LLMS_INDEX_PROFILE_DEV), canonical);
+
 console.log(`→ ${join(LLMS_INDEX_SPEC_DIR, stableName)}`);
 console.log(`→ ${join(LLMS_INDEX_SPEC_DIR, draftName)}`);
+console.log(`→ ${join(LLMS_INDEX_SPEC_DIR, LLMS_INDEX_PROFILE_ALPHA)}`);
+console.log(`→ ${join(LLMS_INDEX_SPEC_DIR, LLMS_INDEX_PROFILE_DEV)}`);

--- a/spec/llms-index/valpha
+++ b/spec/llms-index/valpha
@@ -1,1 +1,113 @@
-mdcp.v0.4.llms.txt
+mdcp-llms-index: 0.4.0.0
+
+# Sharded docs agent index (v0.4)
+
+## Sharded documentation
+
+**MarkDown Context Protocol (MDCP)** keeps documentation in small **shard** files — one topic per `.md`. Guide manifests (`index.md` or `shards.md`) define compile order. Monoliths and publish outputs are **generated**; shards are the source of truth. Documentation holds context and plan; code holds implementation.
+
+## Getting started
+
+**Bootstrap (two phases until config exists):**
+
+1. **Day zero** — fetch agent index + default extension caches (no config yet):
+   ```bash
+   mdcp export --llms-index --fetch --fetch-profile dev --docs-root <docs-root>
+   ```
+2. **Pin fetch** — add `mdcp.config.json` with the protocol profile and optional branch override:
+   ```json
+   {
+     "protocol": {
+       "profile": "alpha",
+       "ref": "feature/my-branch"
+     }
+   }
+   ```
+   `profile` selects `valpha` (`alpha`) or `vdev` (`dev`). Omit `ref` for `main` or a release tag (`v0.4.0`). Set `ref` only when the symlink is not on `main` yet (dogfood / pre-release). Protocol version is read from the fetched `mdcp-llms-index:` header — no separate pin needed.
+   ```bash
+   mdcp export --llms-index --fetch --config docs/mdcp.config.json --docs-root docs
+   ```
+   Default repo is `betsalel-williamson/mdcp` — override only with care ([SECURITY.md](../../../spec/extensions/SECURITY.md)).
+
+Then:
+
+1. Keep this file in your docs root as the agent entrypoint.
+2. **Glossary first** — `docs/glossary/`, one term per shard; disambiguate legacy names before feature shards.
+3. **Shard your docs** — split monoliths into topic files; list them in each guide manifest.
+4. **Wire `mdcp.config.json`** — `compileOrder`, `extensions` packs, optional per-guide `compile.outputFile`.
+5. **Compile and validate** — `mdcp compile` then `mdcp check`.
+6. **Query on demand** — use the commands below; load one shard at a time, not entire guides.
+
+No tooling yet? Split manually or run `mdcp shard` when a `source` monolith is configured.
+
+## Repo layout (template)
+
+```text
+docs/
+  mdcp.v0.4.llms.txt       # this file — agent entrypoint
+  mdcp.config.json         # compile wiring
+  glossary/
+    index.md               # term manifest
+    *.md                   # one term per shard
+  features/
+    index.md               # guide manifest
+    *.md                   # topic shards
+  client/                  # optional — end-user docs
+  developer/               # optional — repo workflow
+  extensions/              # optional — repo-specific agent rules
+```
+
+## Query context (prefer smallest unit)
+
+When `mdcp` is installed and configured:
+
+1. **Section lookup** — smallest useful hit:
+   ```bash
+   mdcp refs lookup "<topic>" --format json --config <config> --docs-root <docs-root>
+   ```
+2. **Read one shard** — open the `.md` path from lookup or the guide manifest; never read whole monoliths into context.
+3. **Broader export** (last resort):
+   ```bash
+   mdcp export --llm --stdout --config <config> --docs-root <docs-root>
+   ```
+4. **Refresh this index** after `compileOrder` or script changes:
+   ```bash
+   mdcp export --llms-index --config <config> --docs-root <docs-root>
+   ```
+
+Day zero (no local config): `mdcp export --llms-index --fetch --fetch-profile dev --docs-root <docs-root>` — caches default extension packs. After `mdcp.config.json` exists, set `protocol.profile` (and `protocol.ref` when not on `main`), then re-fetch (see **Bootstrap** above).
+
+## Glossary
+
+Maintain `docs/glossary/` for shared vocabulary — one term per shard, grouped by `index.md`. Link `../glossary/index.md` from guide manifests so terms compile into the guides that need them. When a term meant different things in legacy systems, add a disambiguation shard and link it on first use in feature docs.
+
+## Validation
+
+Run `mdcp check` before trusting compiled output. Do not hand-edit generated compile output — fix shards and recompile.
+
+## Task prompts
+
+Versioned **meta-level** authoring instructions (feature, doc-only, design, UX, review, bootstrap). Host agent systems **MAY** replace them with local prompts; written shards **SHOULD** still follow the layout and validation in this index.
+
+After fetch, enabled extension packs from `mdcp.config.json` are cached under each pack's `cacheDir` (default `prompts-mdcp-defaults` → `.caches/mdcp/prompts/`). Default fetch follows `protocol.profile` + optional `protocol.ref`; individual packs **MAY** override `source` — treat third-party repos as untrusted ([SECURITY.md](../../../spec/extensions/SECURITY.md)).
+
+Set `WORK_ITEM` and `WORK_ITEM_LOOKUP` in each prompt header before sending.
+
+| Task | Cached path |
+| ---- | ----------- |
+| Bootstrap sharded docs | `.caches/mdcp/prompts/getting-started-with-mdcp.prompt.md` |
+| Feature (docs + code) | `.caches/mdcp/prompts/feature-level-task.prompt.md` |
+| Documentation only | `.caches/mdcp/prompts/doc-only-task.prompt.md` |
+| Architecture / ADR | `.caches/mdcp/prompts/design-architecture-task.prompt.md` |
+| End-user UX | `.caches/mdcp/prompts/ux-task.prompt.md` |
+| Review | `.caches/mdcp/prompts/review-task.prompt.md` |
+
+Typical flow: read this index → load cached prompt → `refs lookup` for `WORK_ITEM` scope → edit shards under `features/`, `client/`, `developer/`, or `review/` → `mdcp check`.
+
+## Repo-specific guidance
+
+Rules that apply only to your project (formatting quirks, review gates, pointer-shard conventions) belong in `docs/extensions/` shards — not in this bootstrap file.
+
+## Downstream publish
+
+Shards are **GFM**. Compiled output can feed MkDocs, Docusaurus, Pandoc, or other site generators. Keep separate guides when agent-only context and public-site content differ in scope.

--- a/spec/llms-index/vdev
+++ b/spec/llms-index/vdev
@@ -1,1 +1,113 @@
-mdcp.v0.4--draft.llms.txt
+mdcp-llms-index: 0.4.0.0
+
+# Sharded docs agent index (v0.4)
+
+## Sharded documentation
+
+**MarkDown Context Protocol (MDCP)** keeps documentation in small **shard** files — one topic per `.md`. Guide manifests (`index.md` or `shards.md`) define compile order. Monoliths and publish outputs are **generated**; shards are the source of truth. Documentation holds context and plan; code holds implementation.
+
+## Getting started
+
+**Bootstrap (two phases until config exists):**
+
+1. **Day zero** — fetch agent index + default extension caches (no config yet):
+   ```bash
+   mdcp export --llms-index --fetch --fetch-profile dev --docs-root <docs-root>
+   ```
+2. **Pin fetch** — add `mdcp.config.json` with the protocol profile and optional branch override:
+   ```json
+   {
+     "protocol": {
+       "profile": "alpha",
+       "ref": "feature/my-branch"
+     }
+   }
+   ```
+   `profile` selects `valpha` (`alpha`) or `vdev` (`dev`). Omit `ref` for `main` or a release tag (`v0.4.0`). Set `ref` only when the symlink is not on `main` yet (dogfood / pre-release). Protocol version is read from the fetched `mdcp-llms-index:` header — no separate pin needed.
+   ```bash
+   mdcp export --llms-index --fetch --config docs/mdcp.config.json --docs-root docs
+   ```
+   Default repo is `betsalel-williamson/mdcp` — override only with care ([SECURITY.md](../../../spec/extensions/SECURITY.md)).
+
+Then:
+
+1. Keep this file in your docs root as the agent entrypoint.
+2. **Glossary first** — `docs/glossary/`, one term per shard; disambiguate legacy names before feature shards.
+3. **Shard your docs** — split monoliths into topic files; list them in each guide manifest.
+4. **Wire `mdcp.config.json`** — `compileOrder`, `extensions` packs, optional per-guide `compile.outputFile`.
+5. **Compile and validate** — `mdcp compile` then `mdcp check`.
+6. **Query on demand** — use the commands below; load one shard at a time, not entire guides.
+
+No tooling yet? Split manually or run `mdcp shard` when a `source` monolith is configured.
+
+## Repo layout (template)
+
+```text
+docs/
+  mdcp.v0.4.llms.txt       # this file — agent entrypoint
+  mdcp.config.json         # compile wiring
+  glossary/
+    index.md               # term manifest
+    *.md                   # one term per shard
+  features/
+    index.md               # guide manifest
+    *.md                   # topic shards
+  client/                  # optional — end-user docs
+  developer/               # optional — repo workflow
+  extensions/              # optional — repo-specific agent rules
+```
+
+## Query context (prefer smallest unit)
+
+When `mdcp` is installed and configured:
+
+1. **Section lookup** — smallest useful hit:
+   ```bash
+   mdcp refs lookup "<topic>" --format json --config <config> --docs-root <docs-root>
+   ```
+2. **Read one shard** — open the `.md` path from lookup or the guide manifest; never read whole monoliths into context.
+3. **Broader export** (last resort):
+   ```bash
+   mdcp export --llm --stdout --config <config> --docs-root <docs-root>
+   ```
+4. **Refresh this index** after `compileOrder` or script changes:
+   ```bash
+   mdcp export --llms-index --config <config> --docs-root <docs-root>
+   ```
+
+Day zero (no local config): `mdcp export --llms-index --fetch --fetch-profile dev --docs-root <docs-root>` — caches default extension packs. After `mdcp.config.json` exists, set `protocol.profile` (and `protocol.ref` when not on `main`), then re-fetch (see **Bootstrap** above).
+
+## Glossary
+
+Maintain `docs/glossary/` for shared vocabulary — one term per shard, grouped by `index.md`. Link `../glossary/index.md` from guide manifests so terms compile into the guides that need them. When a term meant different things in legacy systems, add a disambiguation shard and link it on first use in feature docs.
+
+## Validation
+
+Run `mdcp check` before trusting compiled output. Do not hand-edit generated compile output — fix shards and recompile.
+
+## Task prompts
+
+Versioned **meta-level** authoring instructions (feature, doc-only, design, UX, review, bootstrap). Host agent systems **MAY** replace them with local prompts; written shards **SHOULD** still follow the layout and validation in this index.
+
+After fetch, enabled extension packs from `mdcp.config.json` are cached under each pack's `cacheDir` (default `prompts-mdcp-defaults` → `.caches/mdcp/prompts/`). Default fetch follows `protocol.profile` + optional `protocol.ref`; individual packs **MAY** override `source` — treat third-party repos as untrusted ([SECURITY.md](../../../spec/extensions/SECURITY.md)).
+
+Set `WORK_ITEM` and `WORK_ITEM_LOOKUP` in each prompt header before sending.
+
+| Task | Cached path |
+| ---- | ----------- |
+| Bootstrap sharded docs | `.caches/mdcp/prompts/getting-started-with-mdcp.prompt.md` |
+| Feature (docs + code) | `.caches/mdcp/prompts/feature-level-task.prompt.md` |
+| Documentation only | `.caches/mdcp/prompts/doc-only-task.prompt.md` |
+| Architecture / ADR | `.caches/mdcp/prompts/design-architecture-task.prompt.md` |
+| End-user UX | `.caches/mdcp/prompts/ux-task.prompt.md` |
+| Review | `.caches/mdcp/prompts/review-task.prompt.md` |
+
+Typical flow: read this index → load cached prompt → `refs lookup` for `WORK_ITEM` scope → edit shards under `features/`, `client/`, `developer/`, or `review/` → `mdcp check`.
+
+## Repo-specific guidance
+
+Rules that apply only to your project (formatting quirks, review gates, pointer-shard conventions) belong in `docs/extensions/` shards — not in this bootstrap file.
+
+## Downstream publish
+
+Shards are **GFM**. Compiled output can feed MkDocs, Docusaurus, Pandoc, or other site generators. Keep separate guides when agent-only context and public-site content differ in scope.


### PR DESCRIPTION
## Summary

- `mdcp compile` now regenerates `refs.json` at `resolveRefsPath(docsRoot, outputDir, registryFile)` after writing compiled outputs, matching `mdcp check` and `mdcp refs gen`.
- Fixes the broken `compile` → `refs list` workflow when guides use nested `compile.outputFile` paths (e.g. `compiled/guide-a.md`).
- Adds feature and client-cli shards documenting the refs registry path contract.

Closes #62

## Test plan

- [x] `pnpm --filter @bwilliamson/mdcp-cli test` — new smoke test for nested `outputFile` + `refs list` after compile
- [x] `pnpm test` — full monorepo suite
- [x] Manual repro: compile with `outputDir: _build`, `compile.outputFile: compiled/guide-a.md` → `docs/_build/.caches/refs.json` (not `compiled/refs.json`); `refs list` succeeds
- [x] Pre-commit `docs:compile:repo` + `docs:check` passed


Made with [Cursor](https://cursor.com)