### PR TITLE
ci: automate changesets for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    labels:
+      - dependencies
     groups:
       dev-dependencies:
         dependency-type: development
@@ -11,3 +13,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    labels:
+      - dependencies

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -1,0 +1,39 @@
+name: Dependabot changeset
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  changeset:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.DEPENDENCY_UPDATE_GITHUB_TOKEN }}
+
+      - name: Generate changeset
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/dependabot-changeset.mjs
+
+      - name: Commit and push
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .changeset/
+          if git diff --cached --quiet; then
+            echo "Nothing to commit."
+            exit 0
+          fi
+          git commit -m "chore(deps): add changeset [dependabot-skip]"
+          git push origin "HEAD:$HEAD_REF"

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -371,6 +371,19 @@ Run `pnpm changeset` and commit the generated file under `.changeset/` when a PR
 
 CI on pull requests runs `pnpm changeset:status` to catch missing changesets when package code changed.
 
+### Dependabot
+
+Dependabot does not add changesets. [`.github/workflows/dependabot-changeset.yml`](.github/workflows/dependabot-changeset.yml) runs on Dependabot PRs and commits a **patch** changeset for all three fixed packages when a published package's production dependencies change (`dependencies`, `peerDependencies`, `optionalDependencies`).
+
+| Dependabot PR type                                      | Changeset                                                  |
+| ------------------------------------------------------- | ---------------------------------------------------------- |
+| Production dependency bump in `packages/*/package.json` | Auto **patch** changeset (`.changeset/dependabot-<pr>.md`) |
+| Root dev-dependencies (grouped) or GitHub Actions only  | No changeset (workflow no-ops; CI passes)                  |
+
+**One-time setup:** add repository secret `DEPENDENCY_UPDATE_GITHUB_TOKEN` — a fine-grained or classic PAT with **Contents: read/write** on this repo. The default `GITHUB_TOKEN` cannot push in a way that re-triggers CI on Dependabot branches; the PAT does.
+
+**Timing:** the first CI run on a new Dependabot PR may fail the `changeset` job briefly. After the workflow commits the changeset (usually within 1–2 minutes), CI re-runs and should pass.
+
 ### Bump selection guide
 
 When **adding** a changeset in a PR, pick the bump that best describes your change (the maintainer confirms the final bump at release):

--- a/docs/developer/versioning-and-releases.md
+++ b/docs/developer/versioning-and-releases.md
@@ -94,6 +94,19 @@ Run `pnpm changeset` and commit the generated file under `.changeset/` when a PR
 
 CI on pull requests runs `pnpm changeset:status` to catch missing changesets when package code changed.
 
+## Dependabot
+
+Dependabot does not add changesets. [`.github/workflows/dependabot-changeset.yml`](../../.github/workflows/dependabot-changeset.yml) runs on Dependabot PRs and commits a **patch** changeset for all three fixed packages when a published package's production dependencies change (`dependencies`, `peerDependencies`, `optionalDependencies`).
+
+| Dependabot PR type                                      | Changeset                                                  |
+| ------------------------------------------------------- | ---------------------------------------------------------- |
+| Production dependency bump in `packages/*/package.json` | Auto **patch** changeset (`.changeset/dependabot-<pr>.md`) |
+| Root dev-dependencies (grouped) or GitHub Actions only  | No changeset (workflow no-ops; CI passes)                  |
+
+**One-time setup:** add repository secret `DEPENDENCY_UPDATE_GITHUB_TOKEN` — a fine-grained or classic PAT with **Contents: read/write** on this repo. The default `GITHUB_TOKEN` cannot push in a way that re-triggers CI on Dependabot branches; the PAT does.
+
+**Timing:** the first CI run on a new Dependabot PR may fail the `changeset` job briefly. After the workflow commits the changeset (usually within 1–2 minutes), CI re-runs and should pass.
+
 ## Bump selection guide
 
 When **adding** a changeset in a PR, pick the bump that best describes your change (the maintainer confirms the final bump at release):

--- a/scripts/dependabot-changeset.mjs
+++ b/scripts/dependabot-changeset.mjs
@@ -1,0 +1,92 @@
+// Writes a patch changeset for Dependabot PRs so the CI `changeset` job passes.
+// Invoked by .github/workflows/dependabot-changeset.yml — see versioning-and-releases.md.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const FIXED_PACKAGES = [
+  '@bwilliamson/mdcp-core',
+  '@bwilliamson/mdcp-cli',
+  '@bwilliamson/mdcp-presets',
+];
+
+const PRODUCTION_DEP_KEYS = ['dependencies', 'peerDependencies', 'optionalDependencies'];
+
+const baseRef = process.env.BASE_REF;
+const prNumber = process.env.PR_NUMBER;
+const prTitle = process.env.PR_TITLE ?? 'dependabot dependency update';
+
+if (!baseRef || !prNumber) {
+  throw new Error('BASE_REF and PR_NUMBER must be set');
+}
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim();
+
+function hasExistingChangeset() {
+  const dir = '.changeset';
+  if (!existsSync(dir)) return false;
+  return readdirSync(dir).some(
+    (name) => name.endsWith('.md') && name !== 'README.md' && !name.startsWith('_'),
+  );
+}
+
+function readJsonAtRef(ref, filePath) {
+  try {
+    return JSON.parse(git('show', `${ref}:${filePath}`));
+  } catch {
+    return null;
+  }
+}
+
+function productionDeps(pkg) {
+  if (!pkg) return {};
+  const out = {};
+  for (const key of PRODUCTION_DEP_KEYS) {
+    if (pkg[key]) out[key] = pkg[key];
+  }
+  return out;
+}
+
+function productionDepsChanged(filePath) {
+  const basePkg = readJsonAtRef(`origin/${baseRef}`, filePath);
+  const headPkg = JSON.parse(readFileSync(filePath, 'utf8'));
+  return JSON.stringify(productionDeps(basePkg)) !== JSON.stringify(productionDeps(headPkg));
+}
+
+if (hasExistingChangeset()) {
+  console.log('Changeset already present; skipping.');
+  process.exit(0);
+}
+
+const changed = git(
+  'diff',
+  '--name-only',
+  `origin/${baseRef}...HEAD`,
+  '--',
+  'package.json',
+  '**/package.json',
+)
+  .split('\n')
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+const publishedPackageChanged = changed.some((path) => {
+  if (path === 'package.json') return false;
+  if (!path.startsWith('packages/') || !path.endsWith('/package.json')) return false;
+  return productionDepsChanged(path);
+});
+
+if (!publishedPackageChanged) {
+  console.log('No published-package production dependency changes; no changeset needed.');
+  process.exit(0);
+}
+
+const summary = prTitle.replace(/\s+/g, ' ').trim();
+const frontmatter = FIXED_PACKAGES.map((name) => `'${name}': patch`).join('\n');
+const contents = `---\n${frontmatter}\n---\n\n${summary}\n`;
+
+const file = join('.changeset', `dependabot-${prNumber}.md`);
+writeFileSync(file, contents);
+
+console.log(`Wrote ${file} for fixed packages: ${FIXED_PACKAGES.join(', ')}`);


### PR DESCRIPTION
## Summary

- Add `scripts/dependabot-changeset.mjs` to write a patch changeset for all three fixed `@bwilliamson/mdcp-*` packages when Dependabot bumps production dependencies in `packages/*/package.json`
- Add `.github/workflows/dependabot-changeset.yml` (`pull_request_target`) to commit the changeset back to Dependabot branches with `[dependabot-skip]`
- Document one-time `DEPENDENCY_UPDATE_GITHUB_TOKEN` PAT setup and Dependabot behavior in versioning-and-releases docs
- Label Dependabot PRs with `dependencies` for triage

Infra scope — no changeset required for this PR.

## Test plan

- [ ] Maintainer added `DEPENDENCY_UPDATE_GITHUB_TOKEN` repo secret (contents read/write) **before or immediately after merge**
- [ ] CI passes on this PR (no changeset required)
- [ ] After merge: next Dependabot production-dep PR gets `.changeset/dependabot-<n>.md` bot commit and `changeset` job passes on re-run
- [ ] GitHub Actions-only and root dev-dep Dependabot PRs do not get spurious changesets


Made with [Cursor](https://cursor.com)