### PR TITLE
fix: add GitHub issue templates for adoption stories and bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Something broke — CLI, compile, check, or docs tooling
+title: '[Bug] '
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Include steps to reproduce and the `mdcp-cli` version if you can.
+
+  - type: input
+    id: mdcp-version
+    attributes:
+      label: mdcp-cli version
+      placeholder: '0.4.1'
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `mdcp check` in ...
+        2. See error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Paste error output or screenshots in a follow-up comment if needed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version, package manager — whatever seems relevant.
+      placeholder: macOS 15, Node 22, pnpm 9
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/02-feedback.yml
@@ -1,0 +1,26 @@
+name: Feedback or question
+description: Ideas, docs gaps, or how-to questions
+title: '[Feedback] '
+labels:
+  - feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Questions and suggestions are welcome. For real-world outcomes, prefer the **Adoption story** template instead.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What are you trying to do, or what would you like to see improved?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to shards, repos, or prior issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/adoption-story.yml
+++ b/.github/ISSUE_TEMPLATE/adoption-story.yml
@@ -1,0 +1,77 @@
+name: Adoption story
+description: Share how mdcp worked in a real repo — qualitative outcomes for other adopters
+title: '[Adoption] '
+labels:
+  - adoption-story
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing a real-world mdcp adoption story. These reports back [Tier C benefit claims](https://github.com/betsalel-williamson/mdcp/blob/main/docs/features/protocol/benefit-claims-and-evidence.md) — outcomes we do not put on the README without evidence.
+
+        Please describe what you tried and what changed. Rough notes are fine.
+
+  - type: dropdown
+    id: archetype
+    attributes:
+      label: Adoption archetype
+      description: Which goal best matches your experience? See [personas](https://github.com/betsalel-williamson/mdcp/blob/main/docs/features/personas-and-priority-tiers.md#adoption-archetypes).
+      options:
+        - Builder — integrated mdcp into repo scripts or CI
+        - Learner — tried mdcp with agent help first
+        - Author — wrote shards; delegated CLI setup
+        - Champion — evaluated or sponsored adoption
+        - Other / mixed
+    validations:
+      required: true
+
+  - type: input
+    id: mdcp-version
+    attributes:
+      label: mdcp-cli version
+      description: e.g. 0.4.1 (from package.json or `mdcp --version`)
+      placeholder: '0.4.1'
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Repo type, team size, docs stack before mdcp — whatever helps readers relate.
+      placeholder: e.g. Open-source library, ~20 feature shards, previously one giant CONTRIBUTING.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-you-tried
+    attributes:
+      label: What you tried
+      description: Setup path (paste prompt, `mdcp init`, manual config), commands, CI wiring, agent workflow.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: What changed? Include qualitative benefits (speed, review time, agent behavior) and any friction.
+    validations:
+      required: true
+
+  - type: input
+    id: repo-link
+    attributes:
+      label: Public repo link (optional)
+      description: Link if the adoption is visible publicly.
+      placeholder: https://github.com/org/repo
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: Consent
+      options:
+        - label: I am okay with maintainers quoting or summarizing this story in docs (with attribution if you provide a handle).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Code of Conduct reports
+    url: https://github.com/betsalel-williamson/mdcp/issues/new
+    about: For CoC enforcement, open an issue or contact repository owners privately on GitHub.


### PR DESCRIPTION
## Summary
- Add `.github/ISSUE_TEMPLATE/` so `?template=adoption-story.yml` links in README and docs work
- Include bug report and feedback forms plus chooser config (blank issues stay enabled for CoC reports)

## Test plan
- [ ] After merge, open https://github.com/betsalel-williamson/mdcp/issues/new?template=adoption-story.yml and confirm the adoption story form loads
- [ ] Open https://github.com/betsalel-williamson/mdcp/issues/new and confirm the template chooser lists all three forms
- [ ] Submit a test adoption story issue (optional) and verify labels apply


Made with [Cursor](https://cursor.com)