### PR TITLE
docs: Champion onboarding and persona validation

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -93,8 +93,11 @@ Configure an equivalent shard in consumer repos during [local setup](#local-setu
 ```text
 Host=GitHub (betsalel-williamson/mdcp)
 Issue base URL=https://github.com/betsalel-williamson/mdcp/issues/
+Project board=https://github.com/users/betsalel-williamson/projects/4
 WORK_ITEM=issue number (e.g. 39) or full issue URL
 ```
+
+All repo issues live on the public [MarkDown Context Protocol project board](https://github.com/users/betsalel-williamson/projects/4). **Status** tracks delivery (Todo / In Progress / Done); **Track** groups work by roadmap area (0.5 Spec & adoption, 1.0 Formalization, Maintenance, Performance, Future V2+). Move items to **In Progress** when you start a branch; set **Done** when the issue closes.
 
 ### Load scope (pick what your agent has)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **mdcp** is an open protocol for **technical documentation context** — sharded intent and design in Markdown, validated compile output for agents, CI, and human readers. Software repositories are the most common adoption path; the same shard model applies to factory procedures, equipment manuals, training curricula, and other durable technical knowledge.
 
+New to MDCP? Read [Vision and roadmap](docs/features/protocol/00-vision-and-roadmap.md) for problem, principles, and phased delivery.
+
 ## What's in it for you
 
 Pick the goal that matches you — not a job title:
@@ -52,13 +54,16 @@ Details: [Install and quick start](docs/client-cli/install-and-quick-start.md).
 
 ### Pick your path
 
-| Archetype                                     | Suits Path |
-| --------------------------------------------- | ---------- |
-| **Builder** — integrate mdcp into a repo      | A or B     |
-| **Learner** — try mdcp with agent help first  | A          |
-| **Author** — write shards; delegate CLI setup | A          |
+| Archetype                                     | Suits Path / start here                          |
+| --------------------------------------------- | ------------------------------------------------ |
+| **Builder** — integrate mdcp into a repo      | A or B                                           |
+| **Learner** — try mdcp with agent help first  | A                                                |
+| **Author** — write shards; delegate CLI setup | A                                                |
+| **Champion** — evaluate or sponsor adoption   | Vision and roadmap → Benefit claims and evidence |
 
-**Champion** (evaluate or sponsor adoption)? See [Learn more](#want-to-know-more).
+**Champion start:** [Vision and roadmap](docs/features/protocol/00-vision-and-roadmap.md) → [Benefit claims and evidence](docs/features/protocol/benefit-claims-and-evidence.md).
+
+More depth per archetype: [Learn more](#want-to-know-more).
 
 ## Want to know more
 
@@ -91,11 +96,11 @@ Depth lives in linked shards — not on this page.
 
 **Goal:** evaluate or sponsor org adoption.
 
-- [Why MDCP](docs/client-cli/why-mdcp-overview.md)
 - [Vision and roadmap](docs/features/protocol/00-vision-and-roadmap.md)
+- [Benefit claims and evidence](docs/features/protocol/benefit-claims-and-evidence.md)
+- [Why MDCP](docs/client-cli/why-mdcp-overview.md)
 - [Scope and positioning](docs/features/protocol/01-scope-and-positioning.md)
 - [MDCP 1.0 spec (draft)](docs/features/protocol/mdcp-1.0-spec.md)
-- [Benefit claims and evidence](docs/features/protocol/benefit-claims-and-evidence.md)
 
 ## This repository
 

--- a/docs/developer/agent-work-item-tracking.md
+++ b/docs/developer/agent-work-item-tracking.md
@@ -9,8 +9,11 @@ Configure an equivalent shard in consumer repos during [local setup](./local-set
 ```text
 Host=GitHub (betsalel-williamson/mdcp)
 Issue base URL=https://github.com/betsalel-williamson/mdcp/issues/
+Project board=https://github.com/users/betsalel-williamson/projects/4
 WORK_ITEM=issue number (e.g. 39) or full issue URL
 ```
+
+All repo issues live on the public [MarkDown Context Protocol project board](https://github.com/users/betsalel-williamson/projects/4). **Status** tracks delivery (Todo / In Progress / Done); **Track** groups work by roadmap area (0.5 Spec & adoption, 1.0 Formalization, Maintenance, Performance, Future V2+). Move items to **In Progress** when you start a branch; set **Done** when the issue closes.
 
 ## Load scope (pick what your agent has)
 

--- a/docs/features/personas-and-priority-tiers.md
+++ b/docs/features/personas-and-priority-tiers.md
@@ -17,6 +17,16 @@ Paths: [CLI README](../../packages/mdcp-cli/README.md), [getting started prompt]
 
 Once a pipeline exists, adoption archetypes map to **tool operator personas** below (for example Author → LLM doc author; Builder → wires CI `check`).
 
+### Archetype signals (non-landing)
+
+Anonymous goal patterns — do not copy job titles onto landing pages:
+
+- **Champion** — CPTO/CTO or platform lead assessing whether MDCP's shard contract fits agentic delivery governance; reads vision and claims shards before CLI setup. First external Champion validation (2026-06, anonymous) confirmed [Vision and roadmap](./protocol/00-vision-and-roadmap.md) was sufficient for onboarding; the landing one-liner alone was not.
+- **Builder** — wires `mdcp check` into CI after Champion sign-off.
+- **Author / Learner** — unchanged from the table above.
+
+Maintainers dogfooding the mdcp monorepo are **not** an adoption archetype — see [This repository](../repo-readme/this-repository.md) and [DEVELOPERS.md](../../DEVELOPERS.md).
+
 ### Messaging guardrails
 
 Public copy uses [Benefit claims and evidence](./protocol/benefit-claims-and-evidence.md) tiers only. Landing pages (root [README](../../README.md)) allow Tier A/B claims — never Tier C without adoption-story evidence.
@@ -25,8 +35,9 @@ Public copy uses [Benefit claims and evidence](./protocol/benefit-claims-and-evi
 
 Reference: [`docs/repo-readme/`](../repo-readme/index.md) → `README.md`.
 
-- What this tool is, then [WIIFM](../glossary/wiifm.md); four archetypes max
-- Dual equal get-started paths; routing explains fit, not priority
+- What this tool is (one-liner + vision link for evaluators), then [WIIFM](../glossary/wiifm.md); four archetypes max
+- WIIFM table does not replace the vision shard for Champions
+- Dual equal get-started paths (A/B); Champion eval path in get-started; routing explains fit, not priority
 - Want to know more = archetype link hub; no mermaid on landing output
 
 ## Tool operator personas
@@ -37,6 +48,15 @@ Reference: [`docs/repo-readme/`](../repo-readme/index.md) → `README.md`.
 | **LLM feature agent**  | Read doc context while coding   | `refs lookup`, shard read, `export --llm`  |
 | **Human doc reviewer** | PR quality gate                 | `check`, `prose`, `lint`, `xrefs`, `links` |
 | **End-user reader**    | Read glossary, guides, reviews  | `compile` output                           |
+
+## P0 adoption — evaluator onboarding (validated 2026-06)
+
+| Need                                           | Evidence                                   | Action                                                       |
+| ---------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------ |
+| Champion can understand MDCP without prior use | First external Champion review (anonymous) | Vision link on landing; Champion eval path in get-started    |
+| Landing blurb alone insufficient               | Same                                       | Do not revert WIIFM order; augment with vision link and path |
+
+Aligns with GitHub project **Track: 0.5 Spec & adoption** — see [Agent work item tracking](../developer/agent-work-item-tracking.md).
 
 ## P0 — LLM can read docs and write correct links
 

--- a/docs/features/protocol/benefit-claims-and-evidence.md
+++ b/docs/features/protocol/benefit-claims-and-evidence.md
@@ -47,3 +47,5 @@ On this repository, the median `docs/features/` shard is **~4.4%** of the compil
 ## Adoption anecdotes
 
 Qualitative outcomes belong in [GitHub adoption stories](https://github.com/betsalel-williamson/mdcp/issues/new?template=adoption-story.yml) — not unverified bullets on the README.
+
+**First external Champion validation (2026-06, anonymous):** A technical evaluator with no prior MDCP use reported that [Vision and roadmap](./00-vision-and-roadmap.md) explained what the tool is and why well enough to proceed; the README landing one-liner alone was not sufficient. This backs the P0 adoption onboarding work in [Personas and priority tiers](../personas-and-priority-tiers.md#p0-adoption--evaluator-onboarding-validated-2026-06) — vision link on landing and Champion eval path in get-started.

--- a/docs/repo-readme/get-started.md
+++ b/docs/repo-readme/get-started.md
@@ -33,10 +33,13 @@ Details: [Install and quick start](../client-cli/install-and-quick-start.md).
 
 ## Pick your path
 
-| Archetype                                     | Suits Path |
-| --------------------------------------------- | ---------- |
-| **Builder** — integrate mdcp into a repo      | A or B     |
-| **Learner** — try mdcp with agent help first  | A          |
-| **Author** — write shards; delegate CLI setup | A          |
+| Archetype                                     | Suits Path / start here                          |
+| --------------------------------------------- | ------------------------------------------------ |
+| **Builder** — integrate mdcp into a repo      | A or B                                           |
+| **Learner** — try mdcp with agent help first  | A                                                |
+| **Author** — write shards; delegate CLI setup | A                                                |
+| **Champion** — evaluate or sponsor adoption   | Vision and roadmap → Benefit claims and evidence |
 
-**Champion** (evaluate or sponsor adoption)? See [Learn more](./learn-more.md).
+**Champion start:** [Vision and roadmap](../features/protocol/00-vision-and-roadmap.md) → [Benefit claims and evidence](../features/protocol/benefit-claims-and-evidence.md).
+
+More depth per archetype: [Learn more](./learn-more.md).

--- a/docs/repo-readme/learn-more.md
+++ b/docs/repo-readme/learn-more.md
@@ -29,8 +29,8 @@ Depth lives in linked shards — not on this page.
 
 **Goal:** evaluate or sponsor org adoption.
 
-- [Why MDCP](../client-cli/why-mdcp-overview.md)
 - [Vision and roadmap](../features/protocol/00-vision-and-roadmap.md)
+- [Benefit claims and evidence](../features/protocol/benefit-claims-and-evidence.md)
+- [Why MDCP](../client-cli/why-mdcp-overview.md)
 - [Scope and positioning](../features/protocol/01-scope-and-positioning.md)
 - [MDCP 1.0 spec (draft)](../features/protocol/mdcp-1.0-spec.md)
-- [Benefit claims and evidence](../features/protocol/benefit-claims-and-evidence.md)

--- a/docs/repo-readme/what-this-tool-is.md
+++ b/docs/repo-readme/what-this-tool-is.md
@@ -1,3 +1,5 @@
 # What this tool is
 
 **mdcp** is an open protocol for **technical documentation context** — sharded intent and design in Markdown, validated compile output for agents, CI, and human readers. Software repositories are the most common adoption path; the same shard model applies to factory procedures, equipment manuals, training curricula, and other durable technical knowledge.
+
+New to MDCP? Read [Vision and roadmap](../features/protocol/00-vision-and-roadmap.md) for problem, principles, and phased delivery.


### PR DESCRIPTION
## Summary

- Add anonymous Champion persona signals, P0 adoption evaluator onboarding priority, and Tier C validation anecdote after first external review.
- Route Champions to the vision shard earlier on the landing README (vision link for newcomers, eval path in get-started, reordered learn-more links).
- Document GitHub project board #4 in agent work item tracking.

## Test plan

- [x] `pnpm docs:compile:repo && pnpm docs:check`
- [ ] Spot-check compiled README: vision link under "What this tool is", Champion path in get-started, no new personal attributions


Made with [Cursor](https://cursor.com)