### PR TITLE
ci: run checks on PRs to any target branch

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -26,7 +26,7 @@ Full policy: [docs/developer/versioning-and-releases.md](../docs/developer/versi
 pnpm changeset:status
 ```
 
-Fails if you changed package code since `origin/main` without a changeset.
+Fails if you changed package code since the PR/upstream base (fallback: `origin/main`) without a changeset.
 
 ## Release
 

--- a/.changeset/ci-pr-any-base.md
+++ b/.changeset/ci-pr-any-base.md
@@ -1,0 +1,5 @@
+---
+'@bwilliamson/mdcp-core': patch
+---
+
+CI runs on pull requests to any target branch; dogfood tests no longer require the full glossary TOC in lean npm package READMEs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # Any target branch (stacked feature PRs, not only main).
+    # Changeset checks use github.event.pull_request.base.sha — never a hardcoded branch name.
 
 jobs:
   check:
@@ -61,7 +62,9 @@ jobs:
 
       - name: Require changeset when packages change
         run: |
+          # Compare against this PR's base commit (works for any target branch).
           BASE="${{ github.event.pull_request.base.sha }}"
+          echo "Changeset since PR base: $BASE (${{ github.event.pull_request.base.ref }})"
           set +e
           pnpm exec changeset status --since="$BASE"
           STATUS=$?

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -491,7 +491,7 @@ pnpm changeset          # interactive; commit the new .changeset/*.md file
 #### Verify locally (optional)
 
 ```bash
-pnpm changeset:status   # fails if package changes since origin/main lack a changeset
+pnpm changeset:status   # fails if package changes since the PR/upstream base lack a changeset
 ```
 
 #### Tag and publish (maintainers)
@@ -691,7 +691,7 @@ When a glossary grows beyond a comfortable manifest size, group entries in sub-i
 | `index-protocol.md` | Example sub-index — protocol-related terms only                                          |
 | `index-format.md`   | Example sub-index — format and compile terms                                             |
 
-**Stitched into other guides:** link `../glossary/index.md` from each guide `index.md`. Set `compile.scopeRoot` to `glossary` on those guides so transitive `.md` links from the glossary tree pull term shards into compile output without listing every term in the parent manifest.
+**Stitched into other guides:** link `../glossary/index.md` from each guide that should publish the full glossary TOC (typically maintainer guides). Lean consumer READMEs may omit the TOC and link individual terms instead. Set `compile.scopeRoot` to `glossary` on those guides so transitive `.md` links from the glossary tree pull term shards into compile output without listing every term in the parent manifest.
 
 **Standalone glossary output:** add `glossary` to `compileOrder` with `compile.outputFile` and optionally `compile.manifest: index-protocol.md` (or another sub-index) when you want a separate compiled glossary per group.
 

--- a/docs/developer/versioning-and-releases.md
+++ b/docs/developer/versioning-and-releases.md
@@ -127,7 +127,7 @@ pnpm changeset          # interactive; commit the new .changeset/*.md file
 ### Verify locally (optional)
 
 ```bash
-pnpm changeset:status   # fails if package changes since origin/main lack a changeset
+pnpm changeset:status   # fails if package changes since the PR/upstream base lack a changeset
 ```
 
 ### Tag and publish (maintainers)

--- a/docs/glossary/domain-glossary.md
+++ b/docs/glossary/domain-glossary.md
@@ -16,6 +16,6 @@ When a glossary grows beyond a comfortable manifest size, group entries in sub-i
 | `index-protocol.md` | Example sub-index — protocol-related terms only                                          |
 | `index-format.md`   | Example sub-index — format and compile terms                                             |
 
-**Stitched into other guides:** link `../glossary/index.md` from each guide `index.md`. Set `compile.scopeRoot` to `glossary` on those guides so transitive `.md` links from the glossary tree pull term shards into compile output without listing every term in the parent manifest.
+**Stitched into other guides:** link `../glossary/index.md` from each guide that should publish the full glossary TOC (typically maintainer guides). Lean consumer READMEs may omit the TOC and link individual terms instead. Set `compile.scopeRoot` to `glossary` on those guides so transitive `.md` links from the glossary tree pull term shards into compile output without listing every term in the parent manifest.
 
 **Standalone glossary output:** add `glossary` to `compileOrder` with `compile.outputFile` and optionally `compile.manifest: index-protocol.md` (or another sub-index) when you want a separate compiled glossary per group.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "presentation:verify": "pnpm run presentation:compile && slidev export presentations/la-devops-2026.md --format png --output .tmp/slides/",
     "check": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run build && pnpm run test && pnpm run skill:lint && pnpm run skill:validate && pnpm run docs:check",
     "changeset": "changeset",
-    "changeset:status": "changeset status --since=origin/main",
+    "changeset:status": "node scripts/changeset-status.mjs",
     "release:tag": "node scripts/release-tag.mjs",
     "release:tag:push": "node scripts/release-tag.mjs --push",
     "prepare": "husky",

--- a/packages/mdcp-core/test/design-scope-doc.test.ts
+++ b/packages/mdcp-core/test/design-scope-doc.test.ts
@@ -14,18 +14,11 @@ const PREPROCESSOR_SLUG = 'preprocessor--templating-out-of-scope';
 const PREPROCESSOR_SHARD = 'docs/features/design-constraints/preprocessor-templating.md';
 const GLOSSARY_MANIFEST = '../glossary/index.md';
 
-const GUIDE_INDEXES = [
-  'docs/features/index.md',
-  'docs/developer/index.md',
-  'docs/client-cli/index.md',
-  'docs/client-core/index.md',
-] as const;
+/** Guides that own the full glossary TOC (not lean npm package READMEs). */
+const GLOSSARY_TOC_GUIDE_INDEXES = ['docs/features/index.md', 'docs/developer/index.md'] as const;
 
-const COMPILED_GUIDES = [
-  'DEVELOPERS.md',
-  'packages/mdcp-cli/README.md',
-  'packages/mdcp-core/README.md',
-] as const;
+/** Compiled outputs expected to stitch the shared glossary. */
+const GLOSSARY_COMPILED_GUIDES = ['DEVELOPERS.md'] as const;
 
 describe('design scope documentation (#26)', () => {
   const designConstraintsIndex = readRepoDoc('docs/features/design-constraints/index.md');
@@ -79,16 +72,20 @@ describe('design scope documentation (#26)', () => {
     expect(gfmScopeShard).toContain('[GFM](../../glossary/gfm.md)');
   });
 
-  it('lists glossary in every guide manifest', () => {
-    for (const indexPath of GUIDE_INDEXES) {
+  it('lists glossary in maintainer guide manifests', () => {
+    for (const indexPath of GLOSSARY_TOC_GUIDE_INDEXES) {
       expect(readRepoDoc(indexPath)).toContain(GLOSSARY_MANIFEST);
     }
     expect(glossaryIndex).toContain('index-protocol.md');
     expect(glossaryIndex).toContain('index-format.md');
+    // Lean npm package guides may link individual terms transitively — they must
+    // not be required to dump the full glossary TOC into consumer READMEs.
+    expect(readRepoDoc('docs/client-cli/index.md')).not.toContain(GLOSSARY_MANIFEST);
+    expect(readRepoDoc('docs/client-core/index.md')).not.toContain(GLOSSARY_MANIFEST);
   });
 
-  it('stitches glossary into every compiled guide output', () => {
-    for (const outputPath of COMPILED_GUIDES) {
+  it('stitches glossary into maintainer compiled guide output', () => {
+    for (const outputPath of GLOSSARY_COMPILED_GUIDES) {
       const compiled = readRepoDoc(outputPath);
       expect(compiled).toContain('## GFM');
       expect(compiled).toContain('## Authored GFM');

--- a/scripts/changeset-status.mjs
+++ b/scripts/changeset-status.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Run `changeset status` against a merge-base ref for the current branch.
+ *
+ * Resolution order:
+ * 1. CHANGESET_SINCE (explicit)
+ * 2. GITHUB_BASE_REF → origin/<ref> (PR workflows)
+ * 3. tracked upstream of HEAD
+ * 4. origin/main (release default only — not the only supported merge target)
+ */
+import { spawnSync, execSync } from 'node:child_process';
+
+function tryExec(cmd) {
+  try {
+    return execSync(cmd, { encoding: 'utf8' }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function resolveSince() {
+  if (process.env.CHANGESET_SINCE) {
+    return process.env.CHANGESET_SINCE;
+  }
+  const baseRef = process.env.GITHUB_BASE_REF;
+  if (baseRef) {
+    return `origin/${baseRef}`;
+  }
+  const upstream = tryExec('git rev-parse --abbrev-ref --symbolic-full-name @{upstream}');
+  if (upstream && upstream !== 'HEAD') {
+    return upstream;
+  }
+  return 'origin/main';
+}
+
+const since = resolveSince();
+console.log(`changeset status --since=${since}`);
+const result = spawnSync('pnpm', ['exec', 'changeset', 'status', `--since=${since}`], {
+  stdio: 'inherit',
+});
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- Remove the `pull_request.branches: [main]` filter so CI runs for stacked PRs (e.g. into `feature/la-devops-presentation`).
- Keep changeset validation on `github.event.pull_request.base.sha` / base ref (not a hardcoded branch name); local `pnpm changeset:status` follows the same rule.
- Update dogfood tests so lean CLI/core READMEs are not required to stitch the full glossary TOC (fixes the CI failure after #109).

## Test plan
- [x] `vitest run test/design-scope-doc.test.ts`
- [x] `pnpm docs:check:repo`
- [ ] Confirm CI `check` + `changeset` jobs run on this PR (base ≠ main)
- [ ] Confirm [PR #96](https://github.com/betsalel-williamson/mdcp/pull/96) goes green after merge


Made with [Cursor](https://cursor.com)