### PR TITLE
docs: remove out-of-date open alpha references and add npm badges

### DIFF
--- a/.changeset/standalone-skill-docs.md
+++ b/.changeset/standalone-skill-docs.md
@@ -1,0 +1,5 @@
+---
+'@bwilliamson/mdcp-cli': patch
+---
+
+Remove monorepo-only commands and package paths from the parent skill docs so install/usage guidance stands alone for consumers.

--- a/.changeset/update-docs-stability.md
+++ b/.changeset/update-docs-stability.md
@@ -1,0 +1,6 @@
+---
+'@bwilliamson/mdcp-cli': patch
+'@bwilliamson/mdcp-core': patch
+---
+
+Remove out-of-date references to Open alpha (0.4.0) and use NPM badges for latest release version.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 ### Status
 
-**Open alpha (0.5.x).** Pin `@bwilliamson/mdcp-cli@0.5.0`. There is **no API stability guarantee** until npm 1.0.
+**Pre-1.0:** There is **no API stability guarantee** until npm 1.0.
 
 **Get involved:** [GitHub Issues](https://github.com/betsalel-williamson/mdcp/issues) for feedback and bugs; [adoption stories](https://github.com/betsalel-williamson/mdcp/issues/new?template=adoption-story.yml) for real-world use.
 

--- a/docs/client-cli/install-and-quick-start.md
+++ b/docs/client-cli/install-and-quick-start.md
@@ -1,5 +1,7 @@
 # Install and quick start
 
+[![npm version](https://img.shields.io/npm/v/@bwilliamson/mdcp-cli.svg)](https://www.npmjs.com/package/@bwilliamson/mdcp-cli)
+
 This package installs the **`mdcp` CLI** for use in your repo or CI. It works in **any** codebase — language, framework, and repo layout do not matter; mdcp only manages your documentation shards and compile pipeline.
 
 This is **not** the Agent Skill. For skill install (`npx skills add`, `/mdcp help me get started`), see [root README](../../README.md) or [Agent Skill (related)](./agent-skill.md).
@@ -22,12 +24,6 @@ npm install -g @bwilliamson/mdcp-cli
 ```
 
 ## Stability
-
-**Open alpha (0.4.0).** MDCP is moving fast — this release is a working foundation for early adopters. Tooling and the draft protocol profile may change in 0.5+. Pin a specific version:
-
-```bash
-npm install -D @bwilliamson/mdcp-cli@0.5.0
-```
 
 **Pre-1.0:** There is **no API stability guarantee** until **1.0.0**. CLI commands, flags, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read package changelogs before upgrading.
 

--- a/docs/client-core/overview.md
+++ b/docs/client-core/overview.md
@@ -1,5 +1,7 @@
 # Overview
 
+[![npm version](https://img.shields.io/npm/v/@bwilliamson/mdcp-core.svg)](https://www.npmjs.com/package/@bwilliamson/mdcp-core)
+
 Core library for **mdcp** — compile sharded Markdown guides, build section link registries, validate structure, and export LLM-friendly output.
 
 Use this package when you need mdcp behavior in scripts, CI pipelines, editors, or other tools without shelling out to the CLI. For the Agent Skill (host instructions), see [root README](../../README.md) — that is a separate install.
@@ -18,4 +20,4 @@ The CLI (`@bwilliamson/mdcp-cli`) depends on this package. Install `@bwilliamson
 
 ## Stability
 
-**Pre-1.0 / open alpha (0.5.x):** There is **no API stability guarantee** until **1.0.0**. Exported functions, types, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Pin `@bwilliamson/mdcp-core@0.5.0` and read package changelogs before upgrading.
+**Pre-1.0:** There is **no API stability guarantee** until **1.0.0**. Exported functions, types, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read package changelogs before upgrading.

--- a/docs/repo-readme/this-repository.md
+++ b/docs/repo-readme/this-repository.md
@@ -13,7 +13,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 ## Status
 
-**Open alpha (0.5.x).** Pin `@bwilliamson/mdcp-cli@0.5.0`. There is **no API stability guarantee** until npm 1.0.
+**Pre-1.0:** There is **no API stability guarantee** until npm 1.0.
 
 **Get involved:** [GitHub Issues](https://github.com/betsalel-williamson/mdcp/issues) for feedback and bugs; [adoption stories](https://github.com/betsalel-williamson/mdcp/issues/new?template=adoption-story.yml) for real-world use.
 

--- a/packages/mdcp-cli/README.md
+++ b/packages/mdcp-cli/README.md
@@ -18,6 +18,8 @@ Slash `/mdcp` in an agent host loads the **skill**. The shell command `mdcp` run
 
 ## Install and quick start
 
+[![npm version](https://img.shields.io/npm/v/@bwilliamson/mdcp-cli.svg)](https://www.npmjs.com/package/@bwilliamson/mdcp-cli)
+
 This package installs the **`mdcp` CLI** for use in your repo or CI. It works in **any** codebase — language, framework, and repo layout do not matter; mdcp only manages your documentation shards and compile pipeline.
 
 This is **not** the Agent Skill. For skill install (`npx skills add`, `/mdcp help me get started`), see [root README](../../README.md) or [Agent Skill (related)](#agent-skill-related).
@@ -40,12 +42,6 @@ npm install -g @bwilliamson/mdcp-cli
 ```
 
 ### Stability
-
-**Open alpha (0.4.0).** MDCP is moving fast — this release is a working foundation for early adopters. Tooling and the draft protocol profile may change in 0.5+. Pin a specific version:
-
-```bash
-npm install -D @bwilliamson/mdcp-cli@0.5.0
-```
 
 **Pre-1.0:** There is **no API stability guarantee** until **1.0.0**. CLI commands, flags, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read package changelogs before upgrading.
 

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -16,6 +16,8 @@ Use this package when you need compile, validation, refs, and export APIs in scr
 
 ## Overview
 
+[![npm version](https://img.shields.io/npm/v/@bwilliamson/mdcp-core.svg)](https://www.npmjs.com/package/@bwilliamson/mdcp-core)
+
 Core library for **mdcp** — compile sharded Markdown guides, build section link registries, validate structure, and export LLM-friendly output.
 
 Use this package when you need mdcp behavior in scripts, CI pipelines, editors, or other tools without shelling out to the CLI. For the Agent Skill (host instructions), see [root README](../../README.md) — that is a separate install.
@@ -34,7 +36,7 @@ The CLI (`@bwilliamson/mdcp-cli`) depends on this package. Install `@bwilliamson
 
 ### Stability
 
-**Pre-1.0 / open alpha (0.5.x):** There is **no API stability guarantee** until **1.0.0**. Exported functions, types, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Pin `@bwilliamson/mdcp-core@0.5.0` and read package changelogs before upgrading.
+**Pre-1.0:** There is **no API stability guarantee** until **1.0.0**. Exported functions, types, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read package changelogs before upgrading.
 
 ## Quick example
 

--- a/skills/mdcp/SKILL.md
+++ b/skills/mdcp/SKILL.md
@@ -118,8 +118,6 @@ resort.
 ./.agents/skills/mdcp/scripts/check.sh
 ```
 
-In this monorepo: `pnpm docs:compile:repo` and `pnpm docs:check`.
-
 ### 4. Code Formatting and Linting
 
 If the user asks to set up formatting or linting, run:

--- a/skills/mdcp/references/cli-and-scripts.md
+++ b/skills/mdcp/references/cli-and-scripts.md
@@ -12,13 +12,13 @@ Skill `scripts/*.sh` are **thin entrypoints**. They call `@bwilliamson/mdcp-cli`
 
 ## Why wrappers instead of self-contained skill engines
 
-Compile, check, refs, and doc lint/prose are one **shared system** in `@bwilliamson/mdcp-core`, exposed by `@bwilliamson/mdcp-cli`. Putting that logic in skill bash would fork the pipeline and drift from CI and `pnpm docs:check`. The skill teaches **workflow**; the packages are the **engine**. Extra dependency complexity is the cost of one pipeline for agents, humans, and CI.
+Compile, check, refs, and doc lint/prose are one **shared system** in `@bwilliamson/mdcp-core`, exposed by `@bwilliamson/mdcp-cli`. Putting that logic in skill bash would fork the pipeline and drift from CI validation. The skill teaches **workflow**; the packages are the **engine**. Extra dependency complexity is the cost of one pipeline for agents, humans, and CI.
 
-Upstream implementation (this monorepo):
+The core packages are:
 
-- `packages/mdcp-cli` — CLI commands
-- `packages/mdcp-core` — compile / check / refs / lint / prose engine
-- `packages/mdcp-presets` — shared markdownlint / Prettier / Vale wiring
+- `@bwilliamson/mdcp-cli` — CLI commands
+- `@bwilliamson/mdcp-core` — compile / check / refs / lint / prose engine
+- `@bwilliamson/mdcp-presets` — shared markdownlint / Prettier / Vale wiring
 
 ## Dependencies
 

--- a/skills/mdcp/references/install.md
+++ b/skills/mdcp/references/install.md
@@ -7,10 +7,10 @@ npx skills add betsalel-williamson/mdcp --skill mdcp
 ```
 
 That copies the skill into your repo under `.agents/skills/mdcp/` (the install
-target). Upstream source of truth in this repository is `skills/mdcp/`.
+target).
 
-Zero-install: copy `skills/mdcp/` from this repository into
-`.agents/skills/mdcp/` in the consumer repository.
+Zero-install: copy the `mdcp` skill folder into
+`.agents/skills/mdcp/` in your repository.
 
 Prefer `.agents/skills/` as the portable install path. Some hosts also discover
 `.github/skills/` or `.claude/skills/`.


### PR DESCRIPTION
## Summary
* Removes hardcoded references to Open alpha (0.4.0) and 0.5.x from documentation.
* Adds standard NPM version badges to the top of client documentation.
* Updates stability sections to reflect pre-1.0 status dynamically.

## Test plan
* `pnpm docs:compile` runs without errors and generates updated README files.
* `pnpm docs:check` passes without any broken links or linting errors.

Made with [Cursor](https://cursor.com)