### PR TITLE
docs(skill): remove monorepo references for standalone adoption

### DIFF
--- a/.changeset/standalone-skill-docs.md
+++ b/.changeset/standalone-skill-docs.md
@@ -1,0 +1,5 @@
+---
+'@bwilliamson/mdcp-cli': patch
+---
+
+Remove monorepo-only commands and package paths from the parent skill docs so install/usage guidance stands alone for consumers.

--- a/skills/mdcp/SKILL.md
+++ b/skills/mdcp/SKILL.md
@@ -118,8 +118,6 @@ resort.
 ./.agents/skills/mdcp/scripts/check.sh
 ```
 
-In this monorepo: `pnpm docs:compile:repo` and `pnpm docs:check`.
-
 ### 4. Code Formatting and Linting
 
 If the user asks to set up formatting or linting, run:

--- a/skills/mdcp/references/cli-and-scripts.md
+++ b/skills/mdcp/references/cli-and-scripts.md
@@ -12,13 +12,13 @@ Skill `scripts/*.sh` are **thin entrypoints**. They call `@bwilliamson/mdcp-cli`
 
 ## Why wrappers instead of self-contained skill engines
 
-Compile, check, refs, and doc lint/prose are one **shared system** in `@bwilliamson/mdcp-core`, exposed by `@bwilliamson/mdcp-cli`. Putting that logic in skill bash would fork the pipeline and drift from CI and `pnpm docs:check`. The skill teaches **workflow**; the packages are the **engine**. Extra dependency complexity is the cost of one pipeline for agents, humans, and CI.
+Compile, check, refs, and doc lint/prose are one **shared system** in `@bwilliamson/mdcp-core`, exposed by `@bwilliamson/mdcp-cli`. Putting that logic in skill bash would fork the pipeline and drift from CI validation. The skill teaches **workflow**; the packages are the **engine**. Extra dependency complexity is the cost of one pipeline for agents, humans, and CI.
 
-Upstream implementation (this monorepo):
+The core packages are:
 
-- `packages/mdcp-cli` — CLI commands
-- `packages/mdcp-core` — compile / check / refs / lint / prose engine
-- `packages/mdcp-presets` — shared markdownlint / Prettier / Vale wiring
+- `@bwilliamson/mdcp-cli` — CLI commands
+- `@bwilliamson/mdcp-core` — compile / check / refs / lint / prose engine
+- `@bwilliamson/mdcp-presets` — shared markdownlint / Prettier / Vale wiring
 
 ## Dependencies
 

--- a/skills/mdcp/references/install.md
+++ b/skills/mdcp/references/install.md
@@ -7,10 +7,10 @@ npx skills add betsalel-williamson/mdcp --skill mdcp
 ```
 
 That copies the skill into your repo under `.agents/skills/mdcp/` (the install
-target). Upstream source of truth in this repository is `skills/mdcp/`.
+target).
 
-Zero-install: copy `skills/mdcp/` from this repository into
-`.agents/skills/mdcp/` in the consumer repository.
+Zero-install: copy the `mdcp` skill folder into
+`.agents/skills/mdcp/` in your repository.
 
 Prefer `.agents/skills/` as the portable install path. Some hosts also discover
 `.github/skills/` or `.claude/skills/`.


### PR DESCRIPTION
## Summary
- Remove monorepo-only `pnpm docs:*` commands from the parent skill so consumer install guidance stands alone.
- Point skill CLI docs at published package names (`@bwilliamson/mdcp-*`) instead of `packages/` paths.
- Generalize install/zero-install wording so it no longer assumes the mdcp repository layout.

## Test plan
- [ ] Review `skills/mdcp/SKILL.md`, `references/cli-and-scripts.md`, and `references/install.md` for remaining monorepo-only wording
- [ ] `pnpm run skill:lint` and `pnpm run skill:validate`
- [ ] `pnpm run docs:check` and `pnpm run check`


Made with [Cursor](https://cursor.com)