### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **mdcp monorepo** — a documentation-system Agent Skill plus a
+TypeScript toolchain (pnpm workspaces). There is **no web app or long-running
+server**; the "application" is the `mdcp` CLI (`packages/mdcp-cli`) built on
+`packages/mdcp-core`, driven through `pnpm` scripts. Standard contributor
+commands live in `DEVELOPERS.md` ("Daily commands") and root `package.json`
+scripts — use those rather than duplicating them here.
+
+### Environment already provisioned (do not re-run in normal sessions)
+
+- Node deps: `pnpm install` runs automatically on VM startup (the update
+  script). Package manager is pinned via `packageManager` in `package.json`.
+- **Vale** (prose linter) is a **peer binary**, not an npm dependency. Version
+  **3.15.1** is installed at `/usr/local/bin/vale` and persists in the VM
+  snapshot. `pnpm run docs:check` / `pnpm run check` invoke Vale with
+  `--require-vale`, so it must stay on `PATH`. If it ever goes missing, reinstall
+  from the GitHub release (`vale-cli/vale`, `v3.15.1`, `Linux_64-bit`) — the
+  exact command is in `.github/workflows/ci.yml`.
+
+### Non-obvious gotchas
+
+- **Build before running the CLI or docs scripts.** The `docs:*` scripts and the
+  `mdcp` binary run `node packages/mdcp-cli/dist/cli.js`, so `dist/` must exist.
+  Run `pnpm build` after a fresh checkout or after editing `packages/*/src`
+  before `pnpm docs:check` / `pnpm docs:compile` / invoking the CLI. `dist/` is
+  gitignored and is **not** produced by the startup update script.
+- **Run `pnpm vale:sync` before the first `docs:check`** on a fresh clone (or
+  after `.vale.ini` changes). It downloads Vale style packages (network
+  required) into gitignored `styles/` dirs; synced styles persist in the
+  snapshot.
+- `pnpm docs:check` regenerates and diffs compiled outputs. Committed compiled
+  files (`README.md`, `DEVELOPERS.md`, package `README.md`s) are derived from
+  `docs/` shards — edit the shards and run `pnpm docs:compile:repo`, never hand-
+  edit the compiled files. CI fails on `git diff` if they are stale.
+- Node on this VM is v22 (satisfies `engines >=18`); CI uses Node 24. Do not
+  switch Node via nvm/`.nvmrc` unless a version-specific issue appears.
+- `gitleaks` is not installed; the pre-commit hook prints a warning and
+  continues (CI runs the real scan).
+
+### Full verification gate
+
+`pnpm run check` runs typecheck → lint → format:check → build → test →
+skill:lint → skill:validate → docs:check (mirrors CI). Vale must be on `PATH`
+for the docs portion.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Cloud Agent development environment for the mdcp monorepo, and documents durable startup caveats for future agents.

The only code change is a new `AGENTS.md` capturing non-obvious setup notes (Vale peer binary, build-before-CLI/docs requirement, `vale:sync`, compiled-output diff gate). The environment update script is configured separately as `pnpm install`.

## Environment setup verified

All CI gates were run successfully in the Cloud VM:

- `pnpm install`, `pnpm build`
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check`
- `pnpm run test` (229 tests pass)
- `pnpm run skill:lint`, `pnpm run skill:validate`
- `pnpm run docs:check` (markdownlint + Vale 3.15.1)

## Hello-world

Created a fresh MDCP project and ran the `mdcp` CLI end-to-end — `compile` stitched shards into one guide (heading demotion + cross-link rewrite to compiled slug) and `mdcp check passed`.

[mdcp_cli_hello_world.log](https://cursor.com/agents/bc-9a414640-2b08-44e2-b202-02c6e6e5ab20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmdcp_cli_hello_world.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a414640-2b08-44e2-b202-02c6e6e5ab20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a414640-2b08-44e2-b202-02c6e6e5ab20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

