### PR TITLE
docs(skills): reinforce QA principles (small batches, stale removal, no code in docs)

### DIFF
--- a/.agents/skills/mdcp-design-architecture/SKILL.md
+++ b/.agents/skills/mdcp-design-architecture/SKILL.md
@@ -17,7 +17,10 @@ metadata:
 
 # Design Architecture Helper
 
-> **PREREQUISITE:** This is a helper skill. The `mdcp` parent skill provides the core documentation system. Ensure the `mdcp` CLI is installed.
+> **PREREQUISITE:** This is a helper skill. Follow the `mdcp` parent skill
+> first — especially **Quality Assurance (QA) Principles** (small batches,
+> current docs only, no code in docs) and **What belongs where**. Ensure the
+> `mdcp` CLI is installed.
 
 Act as an expert Systems Architect to draft and design system architecture using MDCP shards.
 

--- a/.agents/skills/mdcp-doc-only/SKILL.md
+++ b/.agents/skills/mdcp-doc-only/SKILL.md
@@ -17,7 +17,10 @@ metadata:
 
 # Doc-Only Helper
 
-> **PREREQUISITE:** This is a helper skill. The `mdcp` parent skill provides the core documentation system. Ensure the `mdcp` CLI is installed.
+> **PREREQUISITE:** This is a helper skill. Follow the `mdcp` parent skill
+> first — especially **Quality Assurance (QA) Principles** (small batches,
+> current docs only, no code in docs) and **What belongs where**. Ensure the
+> `mdcp` CLI is installed.
 
 Act as an expert Technical Writer to author or refactor documentation using MDCP shards.
 

--- a/.agents/skills/mdcp-feature-level/SKILL.md
+++ b/.agents/skills/mdcp-feature-level/SKILL.md
@@ -17,7 +17,10 @@ metadata:
 
 # Feature-Level Helper
 
-> **PREREQUISITE:** This is a helper skill. The `mdcp` parent skill provides the core documentation system. Ensure the `mdcp` CLI is installed.
+> **PREREQUISITE:** This is a helper skill. Follow the `mdcp` parent skill
+> first — especially **Quality Assurance (QA) Principles** (small batches,
+> current docs only, no code in docs) and **What belongs where**. Ensure the
+> `mdcp` CLI is installed.
 
 Act as an expert Software Engineer to implement and document new features using MDCP shards.
 
@@ -60,7 +63,7 @@ Collect these via intake (or from the conversation if already stated):
 
 ### Step 3: Docs First
 
-1. Add or update shards under `docs/features/` (capabilities, design, API surface, acceptance criteria) and `docs/client/` (end-user value and how to use the feature).
+1. Add or update shards under `docs/features/` (capabilities, design, contracts, and acceptance criteria — not implementation code) and `docs/client/` (end-user value and how to use the feature).
 2. Update each guide's `index.md`.
 3. Validate cross-links with `mdcp check`.
 

--- a/.agents/skills/mdcp-getting-started/SKILL.md
+++ b/.agents/skills/mdcp-getting-started/SKILL.md
@@ -18,7 +18,10 @@ metadata:
 
 # Getting Started Helper
 
-> **PREREQUISITE:** This is a helper skill. The `mdcp` parent skill provides the core documentation system. Ensure the `mdcp` CLI is installed.
+> **PREREQUISITE:** This is a helper skill. Follow the `mdcp` parent skill
+> first — especially **Quality Assurance (QA) Principles** (small batches,
+> current docs only, no code in docs) and **What belongs where**. Ensure the
+> `mdcp` CLI is installed.
 
 Set up a sharded documentation pipeline using MDCP for a new repository or feature.
 
@@ -91,4 +94,4 @@ Each guide must have an `index.md` and topic shards. Shards are the source of tr
 ### Step 7: Write and Validate
 
 1. After shards exist, compile and run the full documentation check until xref, orphan, and lint errors are resolved (use this repo's documented commands).
-2. After inserting cross-links, run `mdcp check`. Fragments must match **compiled** output; inspect with `mdcp refs list` if needed.
+2. After inserting cross-links, run `mdcp check`. Fragments must match **compiled** output; inspect with `mdcp refs-list` if needed.

--- a/.agents/skills/mdcp-getting-started/SKILL.md
+++ b/.agents/skills/mdcp-getting-started/SKILL.md
@@ -94,4 +94,4 @@ Each guide must have an `index.md` and topic shards. Shards are the source of tr
 ### Step 7: Write and Validate
 
 1. After shards exist, compile and run the full documentation check until xref, orphan, and lint errors are resolved (use this repo's documented commands).
-2. After inserting cross-links, run `mdcp check`. Fragments must match **compiled** output; inspect with `mdcp refs-list` if needed.
+2. After inserting cross-links, run `mdcp check`. Fragments must match **compiled** output; inspect with `mdcp refs list` if needed.

--- a/.agents/skills/mdcp-ux/SKILL.md
+++ b/.agents/skills/mdcp-ux/SKILL.md
@@ -17,7 +17,10 @@ metadata:
 
 # UX Helper
 
-> **PREREQUISITE:** This is a helper skill. The `mdcp` parent skill provides the core documentation system. Ensure the `mdcp` CLI is installed.
+> **PREREQUISITE:** This is a helper skill. Follow the `mdcp` parent skill
+> first — especially **Quality Assurance (QA) Principles** (small batches,
+> current docs only, no code in docs) and **What belongs where**. Ensure the
+> `mdcp` CLI is installed.
 
 Act as an expert UX Designer and Frontend Engineer to design and implement user experiences using MDCP shards.
 

--- a/scripts/mdcp-skill-content-lint/required-phrases.json
+++ b/scripts/mdcp-skill-content-lint/required-phrases.json
@@ -47,6 +47,14 @@
     {
       "id": "current-docs-only",
       "patterns": ["Current docs only", "as it works now", "changeset", "Git history"]
+    },
+    {
+      "id": "small-batches",
+      "patterns": ["Small batches", "one focused feature", "split the request"]
+    },
+    {
+      "id": "no-code-in-docs",
+      "patterns": ["No code in docs", "intent", "contracts", "implementation"]
     }
   ],
   "phraseScenarios": [
@@ -84,6 +92,16 @@
       "id": "current-docs-stale",
       "prompt": "Behavior changed — should we keep the old docs section for history?",
       "mustMention": ["Current docs only", "changeset", "Git history"]
+    },
+    {
+      "id": "small-batches-scope",
+      "prompt": "User asked for five unrelated features in one branch — how should we scope the work?",
+      "mustMention": ["Small batches", "one focused feature", "split the request"]
+    },
+    {
+      "id": "no-code-in-shards",
+      "prompt": "Should we paste the implementation into the feature shard?",
+      "mustMention": ["No code in docs", "intent", "contracts"]
     }
   ]
 }

--- a/skills/mdcp-design-architecture/SKILL.md
+++ b/skills/mdcp-design-architecture/SKILL.md
@@ -17,7 +17,10 @@ metadata:
 
 # Design Architecture Helper
 
-> **PREREQUISITE:** This is a helper skill. The `mdcp` parent skill provides the core documentation system. Ensure the `mdcp` CLI is installed.
+> **PREREQUISITE:** This is a helper skill. Follow the `mdcp` parent skill
+> first — especially **Quality Assurance (QA) Principles** (small batches,
+> current docs only, no code in docs) and **What belongs where**. Ensure the
+> `mdcp` CLI is installed.
 
 Act as an expert Systems Architect to draft and design system architecture using MDCP shards.
 

--- a/skills/mdcp-doc-only/SKILL.md
+++ b/skills/mdcp-doc-only/SKILL.md
@@ -17,7 +17,10 @@ metadata:
 
 # Doc-Only Helper
 
-> **PREREQUISITE:** This is a helper skill. The `mdcp` parent skill provides the core documentation system. Ensure the `mdcp` CLI is installed.
+> **PREREQUISITE:** This is a helper skill. Follow the `mdcp` parent skill
+> first — especially **Quality Assurance (QA) Principles** (small batches,
+> current docs only, no code in docs) and **What belongs where**. Ensure the
+> `mdcp` CLI is installed.
 
 Act as an expert Technical Writer to author or refactor documentation using MDCP shards.
 

--- a/skills/mdcp-feature-level/SKILL.md
+++ b/skills/mdcp-feature-level/SKILL.md
@@ -17,7 +17,10 @@ metadata:
 
 # Feature-Level Helper
 
-> **PREREQUISITE:** This is a helper skill. The `mdcp` parent skill provides the core documentation system. Ensure the `mdcp` CLI is installed.
+> **PREREQUISITE:** This is a helper skill. Follow the `mdcp` parent skill
+> first — especially **Quality Assurance (QA) Principles** (small batches,
+> current docs only, no code in docs) and **What belongs where**. Ensure the
+> `mdcp` CLI is installed.
 
 Act as an expert Software Engineer to implement and document new features using MDCP shards.
 
@@ -60,7 +63,7 @@ Collect these via intake (or from the conversation if already stated):
 
 ### Step 3: Docs First
 
-1. Add or update shards under `docs/features/` (capabilities, design, API surface, acceptance criteria) and `docs/client/` (end-user value and how to use the feature).
+1. Add or update shards under `docs/features/` (capabilities, design, contracts, and acceptance criteria — not implementation code) and `docs/client/` (end-user value and how to use the feature).
 2. Update each guide's `index.md`.
 3. Validate cross-links with `mdcp check`.
 

--- a/skills/mdcp-getting-started/SKILL.md
+++ b/skills/mdcp-getting-started/SKILL.md
@@ -94,4 +94,4 @@ Each guide must have an `index.md` and topic shards. Shards are the source of tr
 ### Step 7: Write and Validate
 
 1. After shards exist, compile and run the full documentation check until xref, orphan, and lint errors are resolved (use this repo's documented commands).
-2. After inserting cross-links, run `mdcp check`. Fragments must match **compiled** output; inspect with `mdcp refs-list` if needed.
+2. After inserting cross-links, run `mdcp check`. Fragments must match **compiled** output; inspect with `mdcp refs list` if needed.

--- a/skills/mdcp-getting-started/SKILL.md
+++ b/skills/mdcp-getting-started/SKILL.md
@@ -18,7 +18,10 @@ metadata:
 
 # Getting Started Helper
 
-> **PREREQUISITE:** This is a helper skill. The `mdcp` parent skill provides the core documentation system. Ensure the `mdcp` CLI is installed.
+> **PREREQUISITE:** This is a helper skill. Follow the `mdcp` parent skill
+> first — especially **Quality Assurance (QA) Principles** (small batches,
+> current docs only, no code in docs) and **What belongs where**. Ensure the
+> `mdcp` CLI is installed.
 
 Set up a sharded documentation pipeline using MDCP for a new repository or feature.
 

--- a/skills/mdcp-ux/SKILL.md
+++ b/skills/mdcp-ux/SKILL.md
@@ -17,7 +17,10 @@ metadata:
 
 # UX Helper
 
-> **PREREQUISITE:** This is a helper skill. The `mdcp` parent skill provides the core documentation system. Ensure the `mdcp` CLI is installed.
+> **PREREQUISITE:** This is a helper skill. Follow the `mdcp` parent skill
+> first — especially **Quality Assurance (QA) Principles** (small batches,
+> current docs only, no code in docs) and **What belongs where**. Ensure the
+> `mdcp` CLI is installed.
 
 Act as an expert UX Designer and Frontend Engineer to design and implement user experiences using MDCP shards.
 

--- a/skills/mdcp/SKILL.md
+++ b/skills/mdcp/SKILL.md
@@ -55,16 +55,42 @@ What compile / check / refs mean and CLI commands:
 
 ## Quality Assurance (QA) Principles
 
-When applying MDCP, you must act as a complementary partner to other skills and systems, enforcing docs-as-code hygiene:
+When applying MDCP, act as a complementary partner to other skills and systems.
+These habits keep docs trustworthy while the product keeps changing:
 
-- **Always reference doc shards:** Insert yourself into the process to ensure the current task references the correct documentation shards.
-- **Update as you go:** Continuously update documentation as work progresses.
-- **Current docs only:** Shards must describe the product **as it works now**. When behavior or guidance changes, remove superseded or stale text from durable docs — do not leave “old way” sections for archaeology. Git history preserves prior wording; consumer notice of breaking or removed behavior belongs in the **changeset** (folded into package CHANGELOGs at release), not in feature/client/developer shards. Never link durable shards or ADRs to pending `.changeset/*.md` files — those notes are temporary.
-- **Capture ambiguity:** Identify ambiguous terms or language and write down the clarified details into specific shards.
-- **Break it down:** Organize information into the smallest possible pieces (shards).
-- **No code in docs:** Never include implementation code or examples in the documentation shards; code belongs in the codebase.
-- **No temp info or backlogs:** Do not record temporary project information, tickets, incident logs, or migration backlogs and planning in the durable documentation. That information belongs in issue tracking and project planning tools. Pending `.changeset/*.md` files are temporary release notes — write them for the release pipeline; do not link them from ADRs or other durable docs.
-- **Record planning locations:** Make sure to record where planning documents and architectural decisions are placed.
+- **Always reference doc shards:** Insert yourself into the process so the
+  current task points at the correct documentation shards before work spreads.
+- **Update as you go:** Continuously update documentation as work progresses so
+  shards and code do not drift apart mid-change.
+- **Small batches / one focused feature:** Prefer one shippable slice per branch
+  or session. Oversized requests produce tangled diffs and half-updated docs;
+  split the request (and the shards) before coding so each change stays
+  reviewable and documentation can stay current with it.
+- **Current docs only:** Shards must describe the product **as it works now**.
+  When behavior or guidance changes, remove superseded or stale text from
+  durable docs — do not leave “old way” sections for archaeology. Git history
+  preserves prior wording; consumer notice of breaking or removed behavior
+  belongs in the **changeset** (folded into package CHANGELOGs at release),
+  not in feature/client/developer shards. Never link durable shards or ADRs to
+  pending `.changeset/*.md` files — those notes are temporary.
+- **Capture ambiguity:** Identify ambiguous terms or language and write the
+  clarified details into specific shards.
+- **Break it down:** Organize information into the smallest useful pieces
+  (shards) so agents can load one shard at a time instead of drowning in
+  monoliths.
+- **No code in docs:** Put intent, contracts, and acceptance criteria in
+  shards — not implementation. Code samples and internals drift; the codebase
+  is the source of truth for how something is built. This matches
+  **What belongs where** below.
+- **No temp info or backlogs:** Do not record temporary project information,
+  tickets, incident logs, or migration backlogs and planning in the durable
+  documentation. That information belongs in issue tracking and project
+  planning tools. Pending `.changeset/*.md` files are temporary release notes —
+  write them for the release pipeline; do not link them from ADRs or other
+  durable docs.
+- **Record planning locations:** Record where planning documents and
+  architectural decisions live so agents can find them without stuffing plans
+  into durable product shards.
 
 ## What belongs where
 

--- a/skills/mdcp/SKILL.md
+++ b/skills/mdcp/SKILL.md
@@ -112,7 +112,7 @@ _(Note: The MDCP engine itself is domain-agnostic. Non-code projects can define 
 - Shards under `docs/**/` are the source of truth.
 - Use `#` headings in shards; mdcp demotes them during compile.
 - After changing a guide's link order (e.g., in `index.md`), run `mdcp compile` — there is no separate manifest sync step.
-- After inserting `[text](#slug)` cross-links, run `mdcp check` so fragments match **compiled** slugs (use `mdcp refs-list` if you need to inspect the registry).
+- After inserting `[text](#slug)` cross-links, run `mdcp check` so fragments match **compiled** slugs (use `mdcp refs list` if you need to inspect the registry).
 
 ## When to use
 

--- a/skills/mdcp/references/cli-and-scripts.md
+++ b/skills/mdcp/references/cli-and-scripts.md
@@ -8,7 +8,7 @@ MDCP relies on the `@bwilliamson/mdcp-cli` package to perform documentation oper
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `mdcp compile` | **Build the docs.** Merge Markdown shards into compiled guide outputs (for example under `docs/_build/`) using `mdcp.config.json` and `compileOrder`. Shards are the source of truth; compiled files are generated. |
 | `mdcp check`   | **Validate the documentation tree.** Run structural checks (cross-links, orphans, and optional lint/prose gates) so shards and compiled output stay trustworthy. Prefer this before trusting compiled docs.         |
-| `mdcp refs`    | **Cross-link registry tools** (`refs-list`, `refs gen`, …). Inspect or regenerate the fragment/slug registry (for example `refs.json`) so `#` links match **compiled** headings, not hand-guessed shard titles.     |
+| `mdcp refs`    | **Cross-link registry tools** (`refs list`, `refs gen`, …). Inspect or regenerate the fragment/slug registry (for example `refs.json`) so `#` links match **compiled** headings, not hand-guessed shard titles.     |
 
 ## Why an installed CLI instead of self-contained skill engines
 

--- a/skills/mdcp/references/install.md
+++ b/skills/mdcp/references/install.md
@@ -53,7 +53,7 @@ This provides the `mdcp` commands for:
 ```bash
 mdcp compile --config <config> --docs-root <docs-root>
 mdcp check --config <config> --docs-root <docs-root>
-mdcp refs-list --config <config> --docs-root <docs-root>
+mdcp refs list --config <config> --docs-root <docs-root>
 ```
 
 Details: `cli-and-scripts.md` in this folder (linked from `SKILL.md`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reinforces parent `mdcp` **Quality Assurance (QA) Principles** so agents consistently practice small batches, prune stale docs, and keep implementation out of shards. Helpers inherit via a lean PREREQUISITE pointer (plus a feature-level Docs First echo).

Closes #122

## Changes

1. **Parent QA** — Added **Small batches / one focused feature**; sharpened **Current docs only** and **No code in docs** with clear why (skill-creator style, no new ALL-CAPS MUST spam).
2. **Helpers** — Point `mdcp-getting-started`, `mdcp-doc-only`, `mdcp-design-architecture`, `mdcp-feature-level`, and `mdcp-ux` at parent QA + What belongs where; feature-level Docs First says contracts/acceptance criteria, not implementation code.
3. **Sync** — Committed `.agents/skills/mdcp-*` helpers match `skills/`.
4. **Lint** — `skill:lint` fixtures for small batches and no-code-in-docs.
5. **Fix** — Prefer documented CLI form `mdcp refs list` (not `refs-list`) across the skill pack. The hyphenated form is only the internal cac registration; spaced `refs <subcommand>` is the public alias. This undoes a mistaken sync that had overwritten correct `.agents` wording.

Dogfood parent install (gitignored): `pnpm skill:install`.

## Sequencing

Built on `main` after #121 (Mermaid helper routing) merged.

## Validation

- [x] `pnpm skill:lint` (56 passed)
- [x] `pnpm skill:validate`
- [x] Helper `skills/` ↔ `.agents/skills/` diffs empty
- [x] No `refs-list` left under `skills/mdcp*` / synced getting-started helper

## Out of scope

- Broader repo docs still mixing `refs-list` vs `refs list` outside the skill pack (follow-up if desired)
- Mirrored QA lists in `docs/developer/agent-skill.md`, `docs/features/agent-skill.md`, `DEVELOPERS.md`
- Live skill evals (#123+)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1f5646b-0ed5-4e48-9c7a-53fd50628e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1f5646b-0ed5-4e48-9c7a-53fd50628e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

