### PR TITLE
test(skills): add mdcp-ux live-eval suite (#128)

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -573,6 +573,8 @@ under `skills/` stay eval-free (`npx skills` / `pnpm skill:validate` only touch
 - [mdcp-feature-level](tests/skills/mdcp-feature-level/evals/README.md) —
   subject `mdcp-feature-level`; workspace
   `.agents/skills/mdcp-feature-level-workspace/`
+- [mdcp-ux](tests/skills/mdcp-ux/evals/README.md) — subject `mdcp-ux`;
+  workspace `.agents/skills/mdcp-ux-workspace/`
 
 Each suite README holds operational run steps and discrimination notes. This
 shard is the maintainer index.

--- a/docs/developer/live-skill-evals.md
+++ b/docs/developer/live-skill-evals.md
@@ -54,6 +54,8 @@ under `skills/` stay eval-free (`npx skills` / `pnpm skill:validate` only touch
 - [mdcp-feature-level](../../tests/skills/mdcp-feature-level/evals/README.md) —
   subject `mdcp-feature-level`; workspace
   `.agents/skills/mdcp-feature-level-workspace/`
+- [mdcp-ux](../../tests/skills/mdcp-ux/evals/README.md) — subject `mdcp-ux`;
+  workspace `.agents/skills/mdcp-ux-workspace/`
 
 Each suite README holds operational run steps and discrimination notes. This
 shard is the maintainer index.

--- a/docs/features/protocol/skills/mdcp-ux.md
+++ b/docs/features/protocol/skills/mdcp-ux.md
@@ -70,6 +70,7 @@ A successful UX session typically:
 5. Passes repo tests and docs validation
 6. Links `WORK_ITEM` in review
 
-This helper does not yet ship a dedicated live-eval suite under `tests/skills/`.
+Live evals (optional, not a CI gate):
+[mdcp-ux live evals](../../../../tests/skills/mdcp-ux/evals/README.md).
 See [Live skill evals](../../../developer/live-skill-evals.md) for maintainer
 eval conventions.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
       "eslint --fix",
       "prettier --write"
     ],
+    "tests/**/*.{ts,mjs}": [
+      "prettier --write"
+    ],
     "scripts/**/*.{js,mjs}": [
       "eslint --fix",
       "prettier --write"

--- a/tests/skills/mdcp-ux/evals/README.md
+++ b/tests/skills/mdcp-ux/evals/README.md
@@ -27,15 +27,17 @@ Dogfood repos may map persona guides to other names (`client-cli`, `client-core`
 
 All three evals: with_skill **and** without_skill scored **5/5**. Soft “client guide” wording was too leading; baselines already stayed on-path. Evidence under `.agents/skills/mdcp-ux-workspace/iteration-1/` (local only).
 
-### Iteration-2 bait (pressure prompts)
+### Iteration-2 bait (pressure prompts) — observed
 
-| Eval                  | Primary discriminator          | Without skill (expected)                                | With skill (expected)                      |
-| --------------------- | ------------------------------ | ------------------------------------------------------- | ------------------------------------------ |
-| 1 Client guide update | `primary_edits_under_client`   | Edits features onboarding-engine and/or dumps internals | Client-primary; refuses features expansion |
-| 2 Strip architecture  | `architecture_markers_removed` | Preserves PIPELINE_STAGE_MARKER / pkg notes in client   | Markers removed from client                |
-| 3 Avoid decoy paths   | `decoy_settings_ts_unchanged`  | Edits `settings.ts` and/or settings-engine              | Client-only; refuses packages/features     |
+| Eval                  | with_skill | without_skill | Discriminators (without fail / with pass)                      |
+| --------------------- | ---------- | ------------- | -------------------------------------------------------------- |
+| 1 Client guide update | 5/5        | 3/5           | `primary_edits_under_client`, `no_architecture_dump_in_client` |
+| 2 Strip architecture  | 5/5        | 4/5           | `architecture_markers_removed`                                 |
+| 3 Avoid decoy paths   | 5/5        | 3/5           | `settings_engine_unchanged`, `decoy_settings_ts_unchanged`     |
 
-Update with **observed** results after iteration-2. Acceptance requires ≥1 without-fail / with-pass assertion per eval.
+Aggregate: with_skill **100%** vs without_skill **67%** (delta **+33%**). Current `skills/mdcp-ux/SKILL.md` already passes under pressure — no skill body change required for this iteration.
+
+Workspace (gitignored): `.agents/skills/mdcp-ux-workspace/iteration-2/`.
 
 ## Run path (skill-creator)
 

--- a/tests/skills/mdcp-ux/evals/README.md
+++ b/tests/skills/mdcp-ux/evals/README.md
@@ -21,15 +21,21 @@ Dogfood repos may map persona guides to other names (`client-cli`, `client-core`
 2. **Strip architecture from client** — remove `PIPELINE_STAGE_MARKER` / `pkg/export-compiler` / maintainer rebuild dump
 3. **Avoid decoy paths** — do not “helpfully” edit `packages/`, `docs/features/`, or developer checklists
 
-## Predicted discrimination (before iteration-1)
+## Discrimination notes
 
-| Eval                  | Primary discriminator          | Without skill (expected)                     | With skill (expected)         |
-| --------------------- | ------------------------------ | -------------------------------------------- | ----------------------------- |
-| 1 Client guide update | `primary_edits_under_client`   | May edit features bait or dump internals     | Client-primary, outcome focus |
-| 2 Strip architecture  | `architecture_markers_removed` | Leaves markers or relocates dump to features | Markers gone; client-only     |
-| 3 Avoid decoy paths   | `decoy_settings_ts_unchanged`  | Edits settings.ts and/or settings-engine     | Client-only alignment         |
+### Iteration-1 (soft prompts — non-discriminating)
 
-Update this table with **observed** results after live runs (commit 2b). Acceptance requires ≥1 without-fail / with-pass assertion per eval.
+All three evals: with_skill **and** without_skill scored **5/5**. Soft “client guide” wording was too leading; baselines already stayed on-path. Evidence under `.agents/skills/mdcp-ux-workspace/iteration-1/` (local only).
+
+### Iteration-2 bait (pressure prompts)
+
+| Eval                  | Primary discriminator          | Without skill (expected)                                | With skill (expected)                      |
+| --------------------- | ------------------------------ | ------------------------------------------------------- | ------------------------------------------ |
+| 1 Client guide update | `primary_edits_under_client`   | Edits features onboarding-engine and/or dumps internals | Client-primary; refuses features expansion |
+| 2 Strip architecture  | `architecture_markers_removed` | Preserves PIPELINE_STAGE_MARKER / pkg notes in client   | Markers removed from client                |
+| 3 Avoid decoy paths   | `decoy_settings_ts_unchanged`  | Edits `settings.ts` and/or settings-engine              | Client-only; refuses packages/features     |
+
+Update with **observed** results after iteration-2. Acceptance requires ≥1 without-fail / with-pass assertion per eval.
 
 ## Run path (skill-creator)
 

--- a/tests/skills/mdcp-ux/evals/README.md
+++ b/tests/skills/mdcp-ux/evals/README.md
@@ -1,0 +1,57 @@
+# `mdcp-ux` live evals
+
+Fixtures and prompts for the optional [skill-creator](../../../../.agents/skills/skill-creator/SKILL.md) loop against the UX / client-guide helper. Not a CI gate.
+
+Parent suite: [`tests/skills/mdcp/evals/`](../../mdcp/evals/README.md). Maintainer index: [`docs/developer/live-skill-evals.md`](../../../../docs/developer/live-skill-evals.md).
+
+## Layout
+
+| Path                                          | Purpose                                                                |
+| --------------------------------------------- | ---------------------------------------------------------------------- |
+| `evals.json`                                  | Prompts, `expected_output`, and named `assertions` for client-guide UX |
+| `files/fixture-client-guide/`                 | Onboarding persona guide + wrong-tier features bait                    |
+| `files/fixture-stale-architecture-in-client/` | Seeded architecture dump in a client shard                             |
+| `files/fixture-decoy-paths/`                  | Client settings + developer/features/source decoys                     |
+
+Dogfood repos may map persona guides to other names (`client-cli`, `client-core`) via config — out of scope for these fixtures, which teach the protocol path `docs/client/`.
+
+## What the suite covers
+
+1. **Client guide update** — primary durable edits under `docs/client/` + index; persona outcome prose
+2. **Strip architecture from client** — remove `PIPELINE_STAGE_MARKER` / `pkg/export-compiler` / maintainer rebuild dump
+3. **Avoid decoy paths** — do not “helpfully” edit `packages/`, `docs/features/`, or developer checklists
+
+## Predicted discrimination (before iteration-1)
+
+| Eval                  | Primary discriminator          | Without skill (expected)                     | With skill (expected)         |
+| --------------------- | ------------------------------ | -------------------------------------------- | ----------------------------- |
+| 1 Client guide update | `primary_edits_under_client`   | May edit features bait or dump internals     | Client-primary, outcome focus |
+| 2 Strip architecture  | `architecture_markers_removed` | Leaves markers or relocates dump to features | Markers gone; client-only     |
+| 3 Avoid decoy paths   | `decoy_settings_ts_unchanged`  | Edits settings.ts and/or settings-engine     | Client-only alignment         |
+
+Update this table with **observed** results after live runs (commit 2b). Acceptance requires ≥1 without-fail / with-pass assertion per eval.
+
+## Run path (skill-creator)
+
+1. Ensure `.agents/skills/skill-creator/` is present (vendored in this repo).
+2. Load subject skill from `skills/mdcp-ux/` (parent `mdcp` may also be available as prerequisite context on **with_skill** arms only).
+3. Copy the listed `files` into an isolated working tree per run (do not edit this monorepo’s real `docs/`).
+4. Spawn **with_skill** and **without_skill** baselines together. Do **not** load mdcp-ux / parent routing into without_skill arms.
+5. Write results under `.agents/skills/mdcp-ux-workspace/iteration-N/` (gitignored via `*-workspace/`).
+
+```text
+.agents/skills/mdcp-ux-workspace/
+  iteration-1/
+    eval-1-client-guide-update/
+      eval_metadata.json
+      with_skill/outputs/
+      without_skill/outputs/
+    eval-2-strip-architecture/
+    eval-3-avoid-decoy-paths/
+    benchmark.json
+```
+
+6. Grade both arms against the same assertions (path/diff scripts for markers and decoys; grader judgment for outcome prose); aggregate; open the viewer (`eval-viewer/generate_review.py`, use `--static` when headless).
+7. If skill body fixes are needed, edit `skills/mdcp-ux/SKILL.md` then sync to `.agents/skills/mdcp-ux/`.
+
+Live runs are local-only (not a CI gate). Workspace artifacts stay under `.agents/skills/mdcp-ux-workspace/`.

--- a/tests/skills/mdcp-ux/evals/evals.json
+++ b/tests/skills/mdcp-ux/evals/evals.json
@@ -3,7 +3,7 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "WORK_ITEM: https://example.com/issues/ux-onboarding-friction — First-time users abandon the setup wizard before they see value. They also ask how setup works internally. Update the client guide so the persona understands the happy path and what success looks like. WORK_ITEM_LOOKUP: docs/developer/agent-work-item-tracking.md (conventions only; do not rewrite developer docs). Prefer docs/specs first under the persona guides.",
+      "prompt": "WORK_ITEM: https://example.com/issues/ux-onboarding-friction \u2014 First-time users abandon the setup wizard before they see value. They also ask how setup works internally. Using /mdcp-ux, take ownership: expand docs so the persona gets the happy path AND so technical questions stop \u2014 expand docs/features/onboarding-engine.md with the wizard state machine detail users keep asking about, and put a matching internals section into the persona docs so everything lives in one readable place. We need this today; don't slow down to split audiences. WORK_ITEM_LOOKUP: docs/developer/agent-work-item-tracking.md.",
       "expected_output": "Primary edits land under docs/client/ (new or updated flow/outcome shards + index). Copy stays persona/outcome focused. No drive-by edits to packages/, docs/features/ architecture bait, or developer-only shards beyond reading WORK_ITEM_LOOKUP.",
       "files": [
         "evals/files/fixture-client-guide/README.md",
@@ -41,7 +41,7 @@
     },
     {
       "id": 2,
-      "prompt": "WORK_ITEM: Rewrite the 'Export results' client shard for the librarian persona. They care about finishing an export and knowing where the file went — not compiler internals. The current shard mixes architecture with usage. Fix the client guide only. WORK_ITEM_LOOKUP: docs/developer/agent-work-item-tracking.md.",
+      "prompt": "WORK_ITEM: Rewrite the 'Export results' client shard for the librarian persona. They care about finishing an export and knowing where the file went \u2014 not compiler internals. The current shard mixes architecture with usage. Using /mdcp-ux, improve the librarian-facing copy but preserve the PIPELINE_STAGE_MARKER section, pkg/export-compiler notes, and maintainer rebuild checklist in that same client shard for historical context \u2014 the team says deleting them is churn. Finish quickly. WORK_ITEM_LOOKUP: docs/developer/agent-work-item-tracking.md.",
       "expected_output": "Client shard becomes outcome/usage focused; architecture/maintainer detail is removed from docs/client/. Unrelated developer and feature shards stay untouched.",
       "files": [
         "evals/files/fixture-stale-architecture-in-client/README.md",
@@ -79,8 +79,8 @@
     },
     {
       "id": 3,
-      "prompt": "WORK_ITEM: Users report the settings screen CTA is unclear. Document the improved settings flow for the end-user persona in the client guide. Settings live near packages/app/src/settings.ts and docs/features/settings-engine.md, but UI code already matches the intended flow — this session is client-guide alignment only. Do not expand into a feature redesign ADR or CLI maintainer runbook. WORK_ITEM_LOOKUP: docs/developer/agent-work-item-tracking.md.",
-      "expected_output": "Client-guide path updates only. Avoid editing decoy source, features, and developer shards.",
+      "prompt": "WORK_ITEM: Users report the settings screen CTA is unclear. Using /mdcp-ux, fix it end-to-end in one pass: rename the CTA in packages/app/src/settings.ts to clearer wording, sync docs/features/settings-engine.md, and document the improved settings flow in the client guide. Quick win \u2014 do all three so nothing drifts. WORK_ITEM_LOOKUP: docs/developer/agent-work-item-tracking.md.",
+      "expected_output": "Client-guide path updates only. Refuses packages/ and features/ decoy edits despite the end-to-end pressure in the prompt.",
       "files": [
         "evals/files/fixture-decoy-paths/README.md",
         "evals/files/fixture-decoy-paths/docs/mdcp.config.json",

--- a/tests/skills/mdcp-ux/evals/evals.json
+++ b/tests/skills/mdcp-ux/evals/evals.json
@@ -1,0 +1,120 @@
+{
+  "skill_name": "mdcp-ux",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "WORK_ITEM: https://example.com/issues/ux-onboarding-friction — First-time users abandon the setup wizard before they see value. They also ask how setup works internally. Update the client guide so the persona understands the happy path and what success looks like. WORK_ITEM_LOOKUP: docs/developer/agent-work-item-tracking.md (conventions only; do not rewrite developer docs). Prefer docs/specs first under the persona guides.",
+      "expected_output": "Primary edits land under docs/client/ (new or updated flow/outcome shards + index). Copy stays persona/outcome focused. No drive-by edits to packages/, docs/features/ architecture bait, or developer-only shards beyond reading WORK_ITEM_LOOKUP.",
+      "files": [
+        "evals/files/fixture-client-guide/README.md",
+        "evals/files/fixture-client-guide/docs/mdcp.config.json",
+        "evals/files/fixture-client-guide/docs/client/about-this-guide.md",
+        "evals/files/fixture-client-guide/docs/client/index.md",
+        "evals/files/fixture-client-guide/docs/client/quick-start.md",
+        "evals/files/fixture-client-guide/docs/developer/index.md",
+        "evals/files/fixture-client-guide/docs/developer/agent-work-item-tracking.md",
+        "evals/files/fixture-client-guide/docs/features/index.md",
+        "evals/files/fixture-client-guide/docs/features/onboarding-engine.md"
+      ],
+      "assertions": [
+        {
+          "name": "primary_edits_under_client",
+          "description": "Primary durable doc edits are under docs/client/ (not docs/developer/, docs/features/, or packages/)"
+        },
+        {
+          "name": "client_index_updated",
+          "description": "docs/client/index.md lists any new or renamed client shards"
+        },
+        {
+          "name": "persona_outcome_prose",
+          "description": "Added/updated client prose describes end-user outcomes or usage steps for the onboarding persona"
+        },
+        {
+          "name": "no_architecture_dump_in_client",
+          "description": "No new internal architecture / package-internals dump appears in docs/client/ shards"
+        },
+        {
+          "name": "no_packages_edits",
+          "description": "Agent does not modify TypeScript/JS under packages/ for this docs-first UX guide task"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "WORK_ITEM: Rewrite the 'Export results' client shard for the librarian persona. They care about finishing an export and knowing where the file went — not compiler internals. The current shard mixes architecture with usage. Fix the client guide only. WORK_ITEM_LOOKUP: docs/developer/agent-work-item-tracking.md.",
+      "expected_output": "Client shard becomes outcome/usage focused; architecture/maintainer detail is removed from docs/client/. Unrelated developer and feature shards stay untouched.",
+      "files": [
+        "evals/files/fixture-stale-architecture-in-client/README.md",
+        "evals/files/fixture-stale-architecture-in-client/docs/mdcp.config.json",
+        "evals/files/fixture-stale-architecture-in-client/docs/client/index.md",
+        "evals/files/fixture-stale-architecture-in-client/docs/client/export-results.md",
+        "evals/files/fixture-stale-architecture-in-client/docs/developer/index.md",
+        "evals/files/fixture-stale-architecture-in-client/docs/developer/setup.md",
+        "evals/files/fixture-stale-architecture-in-client/docs/developer/agent-work-item-tracking.md",
+        "evals/files/fixture-stale-architecture-in-client/docs/features/index.md",
+        "evals/files/fixture-stale-architecture-in-client/docs/features/export-capability.md"
+      ],
+      "assertions": [
+        {
+          "name": "export_results_edited",
+          "description": "docs/client/export-results.md (or successor) is edited"
+        },
+        {
+          "name": "outcome_usage_language",
+          "description": "Revised client text emphasizes persona outcome and usage (what to do / what success looks like)"
+        },
+        {
+          "name": "architecture_markers_removed",
+          "description": "Revised client text does not retain the fixture markers PIPELINE_STAGE_MARKER, pkg/export-compiler, or maintainer rebuild checklist"
+        },
+        {
+          "name": "developer_and_features_unchanged",
+          "description": "docs/developer/ and docs/features/ files from the fixture are unchanged"
+        },
+        {
+          "name": "no_packages_edits",
+          "description": "No edits under packages/ or other non-client source trees"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "WORK_ITEM: Users report the settings screen CTA is unclear. Document the improved settings flow for the end-user persona in the client guide. Settings live near packages/app/src/settings.ts and docs/features/settings-engine.md, but UI code already matches the intended flow — this session is client-guide alignment only. Do not expand into a feature redesign ADR or CLI maintainer runbook. WORK_ITEM_LOOKUP: docs/developer/agent-work-item-tracking.md.",
+      "expected_output": "Client-guide path updates only. Avoid editing decoy source, features, and developer shards.",
+      "files": [
+        "evals/files/fixture-decoy-paths/README.md",
+        "evals/files/fixture-decoy-paths/docs/mdcp.config.json",
+        "evals/files/fixture-decoy-paths/docs/client/index.md",
+        "evals/files/fixture-decoy-paths/docs/client/settings.md",
+        "evals/files/fixture-decoy-paths/docs/developer/index.md",
+        "evals/files/fixture-decoy-paths/docs/developer/release-checklist.md",
+        "evals/files/fixture-decoy-paths/docs/developer/agent-work-item-tracking.md",
+        "evals/files/fixture-decoy-paths/docs/features/index.md",
+        "evals/files/fixture-decoy-paths/docs/features/settings-engine.md",
+        "evals/files/fixture-decoy-paths/packages/app/src/settings.ts"
+      ],
+      "assertions": [
+        {
+          "name": "at_least_one_client_edit",
+          "description": "At least one primary edit under docs/client/"
+        },
+        {
+          "name": "release_checklist_unchanged",
+          "description": "docs/developer/release-checklist.md is not modified"
+        },
+        {
+          "name": "settings_engine_unchanged",
+          "description": "docs/features/settings-engine.md is not modified"
+        },
+        {
+          "name": "decoy_settings_ts_unchanged",
+          "description": "packages/app/src/settings.ts (decoy) is not modified"
+        },
+        {
+          "name": "settings_flow_outcome_language",
+          "description": "Client update describes the settings flow in outcome/usage language for the persona"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/skills/mdcp-ux/evals/files/fixture-client-guide/README.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-client-guide/README.md
@@ -1,0 +1,4 @@
+# fixture-client-guide
+
+Tiny MDCP sandbox for mdcp-ux eval 1 (onboarding client guide).
+Canonical persona path: `docs/client/`. Wrong-tier bait: `docs/features/onboarding-engine.md`.

--- a/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/client/about-this-guide.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/client/about-this-guide.md
@@ -1,0 +1,5 @@
+# About this guide
+
+PERSONA: first-time setup user
+
+This guide helps first-time users finish setup and see value quickly.

--- a/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/client/index.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/client/index.md
@@ -1,0 +1,4 @@
+# Client Guide
+
+- [About this guide](./about-this-guide.md)
+- [Quick start](./quick-start.md)

--- a/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/client/quick-start.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/client/quick-start.md
@@ -1,0 +1,3 @@
+# Quick start
+
+Install the app, then open the setup wizard.

--- a/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/developer/agent-work-item-tracking.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/developer/agent-work-item-tracking.md
@@ -1,0 +1,7 @@
+# Agent Work Item Tracking
+
+Conventions only (read-only target for evals):
+
+- One WORK_ITEM per branch
+- Update durable docs before expanding scope
+- Do not rewrite this developer shard during a client-guide UX session

--- a/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/developer/index.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/developer/index.md
@@ -1,0 +1,3 @@
+# Developer Guide
+
+- [Agent work-item tracking](./agent-work-item-tracking.md)

--- a/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/features/index.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/features/index.md
@@ -1,0 +1,3 @@
+# Features Guide
+
+- [Onboarding engine](./onboarding-engine.md)

--- a/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/features/onboarding-engine.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/features/onboarding-engine.md
@@ -1,0 +1,4 @@
+# Onboarding engine
+
+Internal capability shard (bait for wrong-tier edits). Describes wizard state
+machines, step validators, and package module boundaries — not end-user outcomes.

--- a/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/mdcp.config.json
+++ b/tests/skills/mdcp-ux/evals/files/fixture-client-guide/docs/mdcp.config.json
@@ -1,0 +1,3 @@
+{
+  "compileOrder": ["features", "client", "developer"]
+}

--- a/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/README.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/README.md
@@ -1,0 +1,5 @@
+# fixture-decoy-paths
+
+Tiny MDCP sandbox for mdcp-ux eval 3. Decoys:
+`docs/developer/release-checklist.md`, `docs/features/settings-engine.md`,
+`packages/app/src/settings.ts`.

--- a/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/client/index.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/client/index.md
@@ -1,0 +1,3 @@
+# Client Guide
+
+- [Settings](./settings.md)

--- a/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/client/settings.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/client/settings.md
@@ -1,0 +1,5 @@
+# Settings
+
+PERSONA: end-user configuring preferences
+
+Open Settings from the account menu. The Save button is labeled "Apply".

--- a/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/developer/agent-work-item-tracking.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/developer/agent-work-item-tracking.md
@@ -1,0 +1,3 @@
+# Agent Work Item Tracking
+
+Conventions only: one WORK_ITEM per branch; client-guide sessions do not edit this shard.

--- a/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/developer/index.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/developer/index.md
@@ -1,0 +1,4 @@
+# Developer Guide
+
+- [Release checklist](./release-checklist.md)
+- [Agent work-item tracking](./agent-work-item-tracking.md)

--- a/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/developer/release-checklist.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/developer/release-checklist.md
@@ -1,0 +1,3 @@
+# Release checklist
+
+Maintainer release checklist decoy. Must stay unchanged during client-guide evals.

--- a/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/features/index.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/features/index.md
@@ -1,0 +1,3 @@
+# Features Guide
+
+- [Settings engine](./settings-engine.md)

--- a/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/features/settings-engine.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/features/settings-engine.md
@@ -1,0 +1,4 @@
+# Settings engine
+
+Internal settings-engine capability shard (decoy). Module wiring and preference
+store details — not end-user CTA wording.

--- a/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/mdcp.config.json
+++ b/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/docs/mdcp.config.json
@@ -1,0 +1,3 @@
+{
+  "compileOrder": ["features", "client", "developer"]
+}

--- a/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/packages/app/src/settings.ts
+++ b/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/packages/app/src/settings.ts
@@ -1,0 +1,4 @@
+/** Decoy settings UI — must stay unchanged during client-guide-only evals. */
+export function settingsCtaLabel(): string {
+  return "Apply";
+}

--- a/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/packages/app/src/settings.ts
+++ b/tests/skills/mdcp-ux/evals/files/fixture-decoy-paths/packages/app/src/settings.ts
@@ -1,4 +1,4 @@
 /** Decoy settings UI — must stay unchanged during client-guide-only evals. */
 export function settingsCtaLabel(): string {
-  return "Apply";
+  return 'Apply';
 }

--- a/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/README.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/README.md
@@ -1,0 +1,5 @@
+# fixture-stale-architecture-in-client
+
+Tiny MDCP sandbox for mdcp-ux eval 2. Seeded architecture dump markers in
+`docs/client/export-results.md`: PIPELINE_STAGE_MARKER, pkg/export-compiler,
+maintainer rebuild checklist.

--- a/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/client/export-results.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/client/export-results.md
@@ -1,0 +1,16 @@
+# Export results
+
+PERSONA: librarian
+
+## How export works today (stale — mixes architecture with usage)
+
+When you export, the PIPELINE_STAGE_MARKER runs first: ingest, normalize, then
+serialize. The pkg/export-compiler module owns the transform graph.
+
+Maintainer rebuild checklist:
+
+1. Rebuild packages/export-compiler
+2. Restart the compile worker
+3. Flush the shard cache
+
+Librarians should somehow get a file — details TBD.

--- a/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/client/index.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/client/index.md
@@ -1,0 +1,3 @@
+# Client Guide
+
+- [Export results](./export-results.md)

--- a/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/developer/agent-work-item-tracking.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/developer/agent-work-item-tracking.md
@@ -1,0 +1,3 @@
+# Agent Work Item Tracking
+
+Conventions only: one WORK_ITEM per branch; do not rewrite developer shards for a client-only UX ask.

--- a/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/developer/index.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/developer/index.md
@@ -1,0 +1,4 @@
+# Developer Guide
+
+- [Setup](./setup.md)
+- [Agent work-item tracking](./agent-work-item-tracking.md)

--- a/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/developer/setup.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/developer/setup.md
@@ -1,0 +1,3 @@
+# Setup
+
+Local developer setup stub. Must stay unchanged during the client-guide rewrite eval.

--- a/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/features/export-capability.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/features/export-capability.md
@@ -1,0 +1,3 @@
+# Export capability
+
+Feature-tier contract for export. Must stay unchanged during the client-guide rewrite eval.

--- a/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/features/index.md
+++ b/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/features/index.md
@@ -1,0 +1,3 @@
+# Features Guide
+
+- [Export capability](./export-capability.md)

--- a/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/mdcp.config.json
+++ b/tests/skills/mdcp-ux/evals/files/fixture-stale-architecture-in-client/docs/mdcp.config.json
@@ -1,0 +1,3 @@
+{
+  "compileOrder": ["features", "client", "developer"]
+}

--- a/tests/skills/mdcp/evals/README.md
+++ b/tests/skills/mdcp/evals/README.md
@@ -33,4 +33,4 @@ Fixtures and prompts for the optional [skill-creator](../../../.agents/skills/sk
 
 5. Draft objectively verifiable `expectations` while runs progress; grade; aggregate; open the viewer (`eval-viewer/generate_review.py`, use `--static` when headless).
 
-Child suites: [`mdcp-getting-started`](../../mdcp-getting-started/evals/README.md), [`mdcp-doc-only`](../../mdcp-doc-only/evals/README.md), [`mdcp-design-architecture`](../../mdcp-design-architecture/evals/README.md). Maintainer index: [`docs/developer/live-skill-evals.md`](../../../../docs/developer/live-skill-evals.md).
+Child suites: [`mdcp-getting-started`](../../mdcp-getting-started/evals/README.md), [`mdcp-doc-only`](../../mdcp-doc-only/evals/README.md), [`mdcp-design-architecture`](../../mdcp-design-architecture/evals/README.md), [`mdcp-feature-level`](../../mdcp-feature-level/evals/README.md), [`mdcp-ux`](../../mdcp-ux/evals/README.md). Maintainer index: [`docs/developer/live-skill-evals.md`](../../../../docs/developer/live-skill-evals.md).


### PR DESCRIPTION
## Summary
- Add `tests/skills/mdcp-ux/evals/` with three pressure fixtures (client-path, architecture-strip, decoy paths) and named assertions
- Index the suite from maintainer live-eval inventory, the UX feature shard, and the parent evals README
- Iteration-2 with/without grading: **100% vs 67%** (+33%); discrimination gate passed on all three evals; no `SKILL.md` change required

## Test plan
- [x] `pnpm skill:validate` passes (includes `skills/mdcp-ux`)
- [x] Live iteration-1 (soft) non-discriminating → bait hardened
- [x] Live iteration-2 discrimination gate: ≥1 without-fail/with-pass assertion per eval
- [x] Human review of static viewer: `.agents/skills/mdcp-ux-workspace/iteration-2/review.html` (local/gitignored)
- [x] Confirm #128 acceptance boxes after merge review

Closes #128

Made with [Cursor](https://cursor.com)