### PR TITLE
docs(skills): align minimum Node requirement with Node 18

### DIFF
--- a/.agents/skills/mdcp-design-architecture/SKILL.md
+++ b/.agents/skills/mdcp-design-architecture/SKILL.md
@@ -3,7 +3,7 @@ name: mdcp-design-architecture
 description: 'MDCP Helper: Act as an expert Systems Architect to draft and design system architecture using MDCP shards.'
 license: MIT
 compatibility: >-
-  Requires Node.js 24+ and the mdcp-cli installed globally or locally.
+  Requires Node.js 18+ and the mdcp-cli installed globally or locally.
 metadata:
   author: betsalel-williamson
   version: '0.5.0'

--- a/.agents/skills/mdcp-doc-only/SKILL.md
+++ b/.agents/skills/mdcp-doc-only/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   pass without product-code changes.
 license: MIT
 compatibility: >-
-  Requires Node.js 24+ and the mdcp-cli installed globally or locally.
+  Requires Node.js 18+ and the mdcp-cli installed globally or locally.
 metadata:
   author: betsalel-williamson
   version: '0.5.0'

--- a/.agents/skills/mdcp-feature-level/SKILL.md
+++ b/.agents/skills/mdcp-feature-level/SKILL.md
@@ -3,7 +3,7 @@ name: mdcp-feature-level
 description: 'MDCP Helper: Act as an expert Software Engineer to implement and document new features using MDCP shards.'
 license: MIT
 compatibility: >-
-  Requires Node.js 24+ and the mdcp-cli installed globally or locally.
+  Requires Node.js 18+ and the mdcp-cli installed globally or locally.
 metadata:
   author: betsalel-williamson
   version: '0.5.1'

--- a/.agents/skills/mdcp-getting-started/SKILL.md
+++ b/.agents/skills/mdcp-getting-started/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   user asks to get started with an MDCP documentation pipeline.
 license: MIT
 compatibility: >-
-  Requires Node.js 24+ and the mdcp-cli installed globally or locally.
+  Requires Node.js 18+ and the mdcp-cli installed globally or locally.
 metadata:
   author: betsalel-williamson
   version: '0.5.0'

--- a/.agents/skills/mdcp-ux/SKILL.md
+++ b/.agents/skills/mdcp-ux/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   those flows).
 license: MIT
 compatibility: >-
-  Requires Node.js 24+ and the mdcp-cli installed globally or locally.
+  Requires Node.js 18+ and the mdcp-cli installed globally or locally.
 metadata:
   author: betsalel-williamson
   version: '0.5.0'

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,32 +4,32 @@
     "mdcp": {
       "source": "./mdcp",
       "sourceType": "local",
-      "computedHash": "a05503c6d7e4bca47ff46466405d69e4ac3dec4dc143cc4304ebbd01966de854"
+      "computedHash": "6ca52724af0e9f8fb3a40ffce9302027c8bc6eb34a58922d2aced4c7d3b33f12"
     },
     "mdcp-design-architecture": {
       "source": "./mdcp",
       "sourceType": "local",
-      "computedHash": "c4529bc021d18b5d331d714d6a9bcc8e4b96115a60d370fac0d2b9202626dd28"
+      "computedHash": "eadd8054c07dd67d877503eb17f4412f3e793edb1480cbe3cf7804c54d84b472"
     },
     "mdcp-doc-only": {
       "source": "./mdcp",
       "sourceType": "local",
-      "computedHash": "ed6e05fb9857a72ebe4a4825f4f9df1e5e4ef7a082a4ab827a57d27e417f6a6e"
+      "computedHash": "b7690f86a91c8fb9485396c01cdb61c6bf9c70961ef1713bb41ff3139772c604"
     },
     "mdcp-feature-level": {
       "source": "./mdcp",
       "sourceType": "local",
-      "computedHash": "8e36e3abc2b3e2827bd1d2433aeb134c4f560f48dac9f26cffcf1aa22d4a4d7b"
+      "computedHash": "87153a5b4f343deb44189e1069acb6e718ab0dddf2ca00a333e88ecadf3153b0"
     },
     "mdcp-getting-started": {
       "source": "./mdcp",
       "sourceType": "local",
-      "computedHash": "536191e9d2d3b006435c562038b0395a50939aa644fb269d0ab816aa5c1aea5b"
+      "computedHash": "993ec8ed7766af9b404794e859320cc2b9cd3403ceea16be89dd71499242bd70"
     },
     "mdcp-ux": {
       "source": "./mdcp",
       "sourceType": "local",
-      "computedHash": "1d1a214cdd4108f930bf245d2e1500190bac82da4f7feee03ba52e4029e1144d"
+      "computedHash": "66a1f8e4b436e0b7386b9be20048df161ca89199f7a974ddd95b8f32bc9912fd"
     },
     "skill-creator": {
       "source": "anthropics/skills",

--- a/skills/mdcp-design-architecture/SKILL.md
+++ b/skills/mdcp-design-architecture/SKILL.md
@@ -3,7 +3,7 @@ name: mdcp-design-architecture
 description: 'MDCP Helper: Act as an expert Systems Architect to draft and design system architecture using MDCP shards.'
 license: MIT
 compatibility: >-
-  Requires Node.js 24+ and the mdcp-cli installed globally or locally.
+  Requires Node.js 18+ and the mdcp-cli installed globally or locally.
 metadata:
   author: betsalel-williamson
   version: '0.5.0'

--- a/skills/mdcp-doc-only/SKILL.md
+++ b/skills/mdcp-doc-only/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   pass without product-code changes.
 license: MIT
 compatibility: >-
-  Requires Node.js 24+ and the mdcp-cli installed globally or locally.
+  Requires Node.js 18+ and the mdcp-cli installed globally or locally.
 metadata:
   author: betsalel-williamson
   version: '0.5.0'

--- a/skills/mdcp-feature-level/SKILL.md
+++ b/skills/mdcp-feature-level/SKILL.md
@@ -3,7 +3,7 @@ name: mdcp-feature-level
 description: 'MDCP Helper: Act as an expert Software Engineer to implement and document new features using MDCP shards.'
 license: MIT
 compatibility: >-
-  Requires Node.js 24+ and the mdcp-cli installed globally or locally.
+  Requires Node.js 18+ and the mdcp-cli installed globally or locally.
 metadata:
   author: betsalel-williamson
   version: '0.5.1'

--- a/skills/mdcp-getting-started/SKILL.md
+++ b/skills/mdcp-getting-started/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   user asks to get started with an MDCP documentation pipeline.
 license: MIT
 compatibility: >-
-  Requires Node.js 24+ and the mdcp-cli installed globally or locally.
+  Requires Node.js 18+ and the mdcp-cli installed globally or locally.
 metadata:
   author: betsalel-williamson
   version: '0.5.0'

--- a/skills/mdcp-ux/SKILL.md
+++ b/skills/mdcp-ux/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   those flows).
 license: MIT
 compatibility: >-
-  Requires Node.js 24+ and the mdcp-cli installed globally or locally.
+  Requires Node.js 18+ and the mdcp-cli installed globally or locally.
 metadata:
   author: betsalel-williamson
   version: '0.5.0'

--- a/skills/mdcp/references/cli-and-scripts.md
+++ b/skills/mdcp/references/cli-and-scripts.md
@@ -22,7 +22,7 @@ The core packages are:
 
 ## Dependencies
 
-- Node.js **24+**
+- Node.js **18+**
 - `npm install -g @bwilliamson/mdcp-cli` or `npm install -D @bwilliamson/mdcp-cli`
 - Optional: Vale on `PATH` for prose (`mdcp prose` / `mdcp check --require-vale`)
 

--- a/skills/mdcp/references/install.md
+++ b/skills/mdcp/references/install.md
@@ -33,7 +33,7 @@ the consumer install path yet.
 
 ## CLI still required (build, validate, cross-link registry)
 
-The skills rely on the `mdcp` CLI. You need Node.js 24+ and must install
+The skills rely on the `mdcp` CLI. You need Node.js 18+ and must install
 `@bwilliamson/mdcp-cli` globally or locally in your project:
 
 ```bash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Merges latest `main` and updates remaining skill docs that still claimed a **Node.js 24+** minimum so they match the CAC / Node 18 engines switch.

## Changes

- Helper skill `compatibility` frontmatter: `Node.js 24+` → `Node.js 18+` under `skills/mdcp-*` and vendored `.agents/skills/mdcp-*`
- Parent skill references: `skills/mdcp/references/install.md` and `cli-and-scripts.md`
- Refreshed `skills-lock.json` hashes after `pnpm skill:update`

## Validation

- `pnpm skill:lint` — pass
- `pnpm skill:validate` — pass
- Confirmed no remaining `Node.js 24` / `24+` min-requirement wording under `skills/` or `.agents/skills/`

## Intentionally unchanged

- CI workflow `node-version: 24` (runner pin, not project minimum)
- `.changeset/node-18-cac.md` (historical note about dropping from 24 to 18)
- Third-party `engines` entries in `pnpm-lock.yaml`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7787912a-d2f7-4a3c-b8e5-b0bf6bd94366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7787912a-d2f7-4a3c-b8e5-b0bf6bd94366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

