### PR TITLE
test(skills): extend mdcp-feature-level evals for scope, docs-first, stale wrap-up

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -121,14 +121,17 @@ CI runs the full gate: `pnpm run check`.
 
 How coding agents load tracker issues and delivery conventions **for this repository**. Helper skills in [Helper Skills](docs/skills.md) (installed alongside the MDCP CLI) point here via `WORK_ITEM_LOOKUP`.
 
-Configure an equivalent shard in consumer repos during [local setup](#local-setup).
+**This repo’s work-item lookup system uses GitHub** for both **issues** (acceptance, discussion, `Closes #N`) and **project planning** (the Project board below — status, track, roadmap grouping). Do not invent a second tracker or stuff tickets / sprint backlogs into durable `docs/` shards; load scope from GitHub via this shard.
+
+Configure an equivalent shard in consumer repos during [local setup](#local-setup) (point `WORK_ITEM_LOOKUP` at whatever issue tracker and project-planning host that repo uses).
 
 ### Tracker
 
 ```text
 Host=GitHub (betsalel-williamson/mdcp)
+Issues=https://github.com/betsalel-williamson/mdcp/issues/  (record WORK_ITEMs here)
+Project board=https://github.com/users/betsalel-williamson/projects/4  (project plan / delivery board)
 Issue base URL=https://github.com/betsalel-williamson/mdcp/issues/
-Project board=https://github.com/users/betsalel-williamson/projects/4
 WORK_ITEM=enough to resolve the issue — number, URL, or short name/description
 ```
 

--- a/docs/developer/agent-work-item-tracking.md
+++ b/docs/developer/agent-work-item-tracking.md
@@ -2,14 +2,17 @@
 
 How coding agents load tracker issues and delivery conventions **for this repository**. Helper skills in [Helper Skills](../../docs/skills.md) (installed alongside the MDCP CLI) point here via `WORK_ITEM_LOOKUP`.
 
-Configure an equivalent shard in consumer repos during [local setup](./local-setup.md).
+**This repo’s work-item lookup system uses GitHub** for both **issues** (acceptance, discussion, `Closes #N`) and **project planning** (the Project board below — status, track, roadmap grouping). Do not invent a second tracker or stuff tickets / sprint backlogs into durable `docs/` shards; load scope from GitHub via this shard.
+
+Configure an equivalent shard in consumer repos during [local setup](./local-setup.md) (point `WORK_ITEM_LOOKUP` at whatever issue tracker and project-planning host that repo uses).
 
 ## Tracker
 
 ```text
 Host=GitHub (betsalel-williamson/mdcp)
+Issues=https://github.com/betsalel-williamson/mdcp/issues/  (record WORK_ITEMs here)
+Project board=https://github.com/users/betsalel-williamson/projects/4  (project plan / delivery board)
 Issue base URL=https://github.com/betsalel-williamson/mdcp/issues/
-Project board=https://github.com/users/betsalel-williamson/projects/4
 WORK_ITEM=enough to resolve the issue — number, URL, or short name/description
 ```
 

--- a/tests/skills/mdcp-feature-level/evals/README.md
+++ b/tests/skills/mdcp-feature-level/evals/README.md
@@ -55,7 +55,15 @@ shards.
 | 4 Docs-first + TDD          | `shards_before_product_code`                         | Codes under `packages/` before shards              | Features+client shards first, then tests, then impl |
 | 5 Stale wrap-up             | `removes_legacy_and_backlog`                         | Keeps legacySync / migration backlog “for history” | Current `syncMode` only; archaeology removed        |
 
-Update this table with **observed** pass/fail after iteration-1 (commit 2b). Gate: ≥1 assertion where without=`fail` and with=`pass` per new eval.
+## Observed discrimination (iteration-1 / 1b)
+
+| Eval                        | With skill     | Without skill     | Notes                                                                                              |
+| --------------------------- | -------------- | ----------------- | -------------------------------------------------------------------------------------------------- |
+| 3 Scope creep / small-batch | **Pass** (1.0) | **Fail** (0.25)   | After bait harden (1b): without edited settings/SSO/billing + new packages; with deferred siblings |
+| 4 Docs-first + TDD          | **Pass** (1.0) | **Fail** (0.25)   | Without coded first; skipped failing-first TDD and `mdcp check`                                    |
+| 5 Stale wrap-up             | **Pass** (1.0) | **Partial** (0.5) | Without kept old-way + migration backlog; with removed archaeology + changeset                     |
+
+Aggregate (evals 3–5): with-skill mean **1.0** vs without-skill mean **~0.33** (delta **~+0.67**). No `SKILL.md` behavior change required for this iteration. Gate met: ≥1 without-fail / with-pass assertion per new eval.
 
 Workspace grading (gitignored): `.agents/skills/mdcp-feature-level-workspace/`.
 

--- a/tests/skills/mdcp-feature-level/evals/README.md
+++ b/tests/skills/mdcp-feature-level/evals/README.md
@@ -6,10 +6,13 @@ Parent suite: [`tests/skills/mdcp/evals/`](../../mdcp/evals/README.md). Maintain
 
 ## Layout
 
-| Path                     | Purpose                                                                     |
-| ------------------------ | --------------------------------------------------------------------------- |
-| `evals.json`             | Prompts, `expected_output`, and named `assertions` for docs-first delivery  |
-| `files/feature-fixture/` | Tiny MDCP sandbox with `features/` + `client/` tiers and a real `packages/` |
+| Path                            | Purpose                                                                      |
+| ------------------------------- | ---------------------------------------------------------------------------- |
+| `evals.json`                    | Prompts, `expected_output`, and named `assertions` for docs-first delivery   |
+| `files/feature-fixture/`        | Placement + backfill sandbox (`features/` + `client/` + `packages/`)         |
+| `files/fixture-scope-bait/`     | Multi-feature bait (settings / SSO / billing) for small-batch scoping        |
+| `files/fixture-docs-first-tdd/` | Sync status panel + existing test file for docs-before-code and TDD ordering |
+| `files/fixture-stale-wrapup/`   | `legacySync` + migration backlog seed for current-docs-only wrap-up          |
 
 ## What the suite covers
 
@@ -20,6 +23,13 @@ Parent suite: [`tests/skills/mdcp/evals/`](../../mdcp/evals/README.md). Maintain
 2. **User-facing backfill** — a `--format=csv` option must backfill BOTH
    `docs/features/` and `docs/client/` (with index updates), not be buried in
    `docs/developer/`.
+3. **Small-batch / multi-feature bait** — export-to-CSV WORK_ITEM with sibling
+   asks (settings redesign, SSO, billing); agent must defer adjacent scope.
+4. **Docs-first + TDD gate** — `lastSyncedAt` on sync status: shards (and
+   `mdcp check`) before product code; failing tests before implementation when
+   the repo already uses tests.
+5. **Stale wrap-up** — replace `legacySync` with `syncMode`; remove durable
+   archaeology / migration backlog from features/client.
 
 ## Red → green (eval 1)
 
@@ -37,6 +47,16 @@ audience**, with an explicit maintainer-only → `developer/` row and a placemen
 test that forbids co-locating live skill-eval runbooks beside product `skills`
 shards.
 
+## Predicted discrimination (evals 3–5)
+
+| Eval                        | Primary discriminator                                | Without expected fail                              | With expected pass                                  |
+| --------------------------- | ---------------------------------------------------- | -------------------------------------------------- | --------------------------------------------------- |
+| 3 Scope creep / small-batch | `scopes_to_csv_export_only` / `defers_adjacent_asks` | Starts settings/SSO/billing                        | CSV export only; defers siblings                    |
+| 4 Docs-first + TDD          | `shards_before_product_code`                         | Codes under `packages/` before shards              | Features+client shards first, then tests, then impl |
+| 5 Stale wrap-up             | `removes_legacy_and_backlog`                         | Keeps legacySync / migration backlog “for history” | Current `syncMode` only; archaeology removed        |
+
+Update this table with **observed** pass/fail after iteration-1 (commit 2b). Gate: ≥1 assertion where without=`fail` and with=`pass` per new eval.
+
 Workspace grading (gitignored): `.agents/skills/mdcp-feature-level-workspace/`.
 
 ## Run path (skill-creator)
@@ -46,5 +66,22 @@ Workspace grading (gitignored): `.agents/skills/mdcp-feature-level-workspace/`.
 3. Copy the listed `files` into an isolated working tree per run (do not edit this monorepo’s real `docs/`).
 4. Follow skill-creator: spawn **with_skill** and **without_skill** baselines together.
 5. Write results under `.agents/skills/mdcp-feature-level-workspace/iteration-N/` (gitignored via `*-workspace/`).
+
+```text
+.agents/skills/mdcp-feature-level-workspace/
+  iteration-N/
+    eval-1-wrong-tier-placement/
+    eval-2-user-facing-backfill/
+    eval-3-scope-creep-small-batch/
+      eval_metadata.json
+      with_skill/{outputs,grading.json,timing.json}
+      without_skill/{outputs,grading.json,timing.json}
+    eval-4-docs-first-tdd-gate/
+    eval-5-stale-wrap-up/
+    benchmark.json
+```
+
+6. Grade both arms against the same assertion list; aggregate; open the viewer.
+7. If skill body fixes are needed, edit `skills/mdcp-feature-level/SKILL.md` then sync via `pnpm skill:install`.
 
 Live runs are local-only (not a CI gate). Workspace artifacts stay under `.agents/skills/mdcp-feature-level-workspace/` (gitignored).

--- a/tests/skills/mdcp-feature-level/evals/evals.json
+++ b/tests/skills/mdcp-feature-level/evals/evals.json
@@ -73,8 +73,8 @@
     },
     {
       "id": 3,
-      "prompt": "Use /mdcp-feature-level. WORK_ITEM=Add an export-to-CSV button on the reports page (acceptance: button visible when a report is selected; clicking downloads CSV). Also while you're in there, please redesign the settings page, add SSO login, and refactor the billing module. WORK_ITEM_LOOKUP=docs/developer/agent-work-item-tracking.md. Plan and start the work for this session only — do not invent extra scope.",
-      "expected_output": "Agent treats acceptance criteria as the sole scope boundary: only the export-to-CSV feature. Explicitly declines or defers settings redesign, SSO, and billing. Creates/updates docs/features/ (+ docs/client/ value) for CSV export before functional product code; one WORK_ITEM for this session.",
+      "prompt": "Use /mdcp-feature-level. WORK_ITEM_LOOKUP=docs/developer/agent-work-item-tracking.md. The team dumped several asks into one chat — please knock them out in this session so we can close the week: (1) Add an export-to-CSV button on the reports page (acceptance: button visible when a report is selected; clicking downloads CSV). (2) Redesign the settings page while you're in docs/features/settings.md. (3) Add SSO login (see docs/features/sso.md). (4) Refactor the billing module (docs/features/billing.md). Ship whatever you can of all four; leadership wants progress on each.",
+      "expected_output": "Agent treats export-to-CSV as the sole in-scope feature for /mdcp-feature-level (small batch / one WORK_ITEM). Explicitly declines or defers settings redesign, SSO, and billing despite leadership pressure. Creates/updates docs/features/ (+ docs/client/ value) for CSV export before functional product code.",
       "files": [
         "evals/files/fixture-scope-bait/README.md",
         "evals/files/fixture-scope-bait/docs/mdcp.config.json",

--- a/tests/skills/mdcp-feature-level/evals/evals.json
+++ b/tests/skills/mdcp-feature-level/evals/evals.json
@@ -70,6 +70,114 @@
           "description": "Implements the --format=csv option in packages/example-cli"
         }
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "Use /mdcp-feature-level. WORK_ITEM=Add an export-to-CSV button on the reports page (acceptance: button visible when a report is selected; clicking downloads CSV). Also while you're in there, please redesign the settings page, add SSO login, and refactor the billing module. WORK_ITEM_LOOKUP=docs/developer/agent-work-item-tracking.md. Plan and start the work for this session only — do not invent extra scope.",
+      "expected_output": "Agent treats acceptance criteria as the sole scope boundary: only the export-to-CSV feature. Explicitly declines or defers settings redesign, SSO, and billing. Creates/updates docs/features/ (+ docs/client/ value) for CSV export before functional product code; one WORK_ITEM for this session.",
+      "files": [
+        "evals/files/fixture-scope-bait/README.md",
+        "evals/files/fixture-scope-bait/docs/mdcp.config.json",
+        "evals/files/fixture-scope-bait/docs/developer/agent-work-item-tracking.md",
+        "evals/files/fixture-scope-bait/docs/developer/index.md",
+        "evals/files/fixture-scope-bait/docs/features/index.md",
+        "evals/files/fixture-scope-bait/docs/features/reports-page.md",
+        "evals/files/fixture-scope-bait/docs/features/settings.md",
+        "evals/files/fixture-scope-bait/docs/features/sso.md",
+        "evals/files/fixture-scope-bait/docs/features/billing.md",
+        "evals/files/fixture-scope-bait/docs/client/index.md",
+        "evals/files/fixture-scope-bait/docs/client/reports.md",
+        "evals/files/fixture-scope-bait/packages/reports-ui/src/reports.ts"
+      ],
+      "assertions": [
+        {
+          "name": "scopes_to_csv_export_only",
+          "description": "Scopes work to the single WORK_ITEM feature (CSV export) and does not implement settings redesign, SSO, or billing in this session"
+        },
+        {
+          "name": "defers_adjacent_asks",
+          "description": "Explicitly declines or defers the sibling asks (settings redesign, SSO, billing) rather than starting them"
+        },
+        {
+          "name": "docs_first_for_in_scope_feature",
+          "description": "Updates or plans docs/features/ (and docs/client/ value) for the CSV export feature before writing functional product code"
+        },
+        {
+          "name": "decoy_settings_sso_billing_unchanged",
+          "description": "Does not deliver product or feature-shard work for settings.md / sso.md / billing.md beyond reading them"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Use /mdcp-feature-level. WORK_ITEM=Add a 'last synced at' timestamp to the sync status panel (acceptance: show ISO timestamp when sync completes; hide when never synced). WORK_ITEM_LOOKUP=docs/developer/agent-work-item-tracking.md. Proceed through docs-first then TDD for this one feature. The repo already uses tests.",
+      "expected_output": "Agent follows docs-first: feature (+ client) shards and index updates, mdcp check, then failing tests, then implementation. No functional product code lands before the documented contract exists. Does not expand into unrelated sync features (e.g. sync scheduler).",
+      "files": [
+        "evals/files/fixture-docs-first-tdd/README.md",
+        "evals/files/fixture-docs-first-tdd/docs/mdcp.config.json",
+        "evals/files/fixture-docs-first-tdd/docs/developer/agent-work-item-tracking.md",
+        "evals/files/fixture-docs-first-tdd/docs/developer/index.md",
+        "evals/files/fixture-docs-first-tdd/docs/features/index.md",
+        "evals/files/fixture-docs-first-tdd/docs/features/sync-status-panel.md",
+        "evals/files/fixture-docs-first-tdd/docs/features/sync-scheduler.md",
+        "evals/files/fixture-docs-first-tdd/docs/client/index.md",
+        "evals/files/fixture-docs-first-tdd/docs/client/sync-status.md",
+        "evals/files/fixture-docs-first-tdd/packages/example-cli/src/sync-status.ts",
+        "evals/files/fixture-docs-first-tdd/packages/example-cli/src/sync-status.test.ts"
+      ],
+      "assertions": [
+        {
+          "name": "shards_before_product_code",
+          "description": "Adds or updates shards under docs/features/ (and docs/client/ for end-user value) for the timestamp feature before or as a hard gate before functional product code under packages/"
+        },
+        {
+          "name": "runs_mdcp_check",
+          "description": "Mentions or runs mdcp check (or docs:check) after shard edits"
+        },
+        {
+          "name": "failing_tests_before_impl",
+          "description": "Writes or plans failing tests before implementation code (TDD), because the prompt states the repo uses tests"
+        },
+        {
+          "name": "no_scope_expansion",
+          "description": "Does not expand scope beyond the last-synced timestamp acceptance criteria (e.g. does not redesign sync-scheduler)"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Use /mdcp-feature-level. WORK_ITEM=Replace the deprecated 'legacy sync' flag with the new 'syncMode' setting (acceptance: remove legacySync from public API; document syncMode). An existing feature shard still describes the old legacySync workflow and a migration backlog. Finish wrap-up for this feature only: update as-built docs and remove stale guidance.",
+      "expected_output": "Agent updates feature/client shards to describe syncMode as current behavior, removes legacySync / migration-backlog text from durable docs (changeset/history for removed behavior), and does not start unrelated features (e.g. alerts) while wrapping up.",
+      "files": [
+        "evals/files/fixture-stale-wrapup/README.md",
+        "evals/files/fixture-stale-wrapup/docs/mdcp.config.json",
+        "evals/files/fixture-stale-wrapup/docs/developer/agent-work-item-tracking.md",
+        "evals/files/fixture-stale-wrapup/docs/developer/index.md",
+        "evals/files/fixture-stale-wrapup/docs/features/index.md",
+        "evals/files/fixture-stale-wrapup/docs/features/sync-mode.md",
+        "evals/files/fixture-stale-wrapup/docs/features/alerts.md",
+        "evals/files/fixture-stale-wrapup/docs/client/index.md",
+        "evals/files/fixture-stale-wrapup/docs/client/configure-sync.md",
+        "evals/files/fixture-stale-wrapup/packages/sync-lib/src/sync.ts"
+      ],
+      "assertions": [
+        {
+          "name": "removes_legacy_and_backlog",
+          "description": "Removes or rewrites stale legacySync / migration-backlog content from durable docs so shards describe current syncMode behavior only"
+        },
+        {
+          "name": "describes_syncMode_now",
+          "description": "Feature and/or client shards describe syncMode as current behavior (not legacySync as the primary API)"
+        },
+        {
+          "name": "no_old_way_archaeology",
+          "description": "Does not leave 'old way' archaeology in docs/features/ or docs/client/; points breaking/removed behavior to changeset/CHANGELOG conventions when relevant"
+        },
+        {
+          "name": "stays_on_wrapup_work_item",
+          "description": "Stays on this single wrap-up WORK_ITEM and does not open adjacent feature work (e.g. alerts)"
+        }
+      ]
     }
   ]
 }

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/README.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/README.md
@@ -1,0 +1,4 @@
+# Fake consumer repo — docs-first + TDD fixture
+
+Isolated fixture for skill-creator eval 4 (docs before code, then failing tests).
+Treat this directory as the working-tree root. Do not edit the real monorepo.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/client/index.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/client/index.md
@@ -1,0 +1,3 @@
+# Client Guide
+
+- [Sync status](./sync-status.md)

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/client/sync-status.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/client/sync-status.md
@@ -1,0 +1,6 @@
+# Sync status
+
+Open the sync status panel to see whether background sync is idle, running, or
+failed.
+
+A precise last-synced timestamp is not shown yet.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/developer/agent-work-item-tracking.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/developer/agent-work-item-tracking.md
@@ -1,0 +1,16 @@
+# Agent work-item tracking
+
+Stub WORK_ITEM_LOOKUP for the docs-first TDD fixture.
+
+```text
+Integration branch=main (pull before branching)
+Feature branches=descriptive (e.g. feature/issue-N-short-slug)
+One branch per WORK_ITEM=do not mix unrelated features
+Docs first=update docs/features/ AND docs/client/ before code; update each index.md
+Validate=run mdcp check after shard edits
+Tests=this repo already uses tests under packages/**/*.test.ts — write failing tests before implementation
+Docs=describe current behavior only; planning/backlogs stay in the tracker
+```
+
+Load this shard for delivery conventions. Do not invent tracker scope beyond the
+provided WORK_ITEM.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/developer/index.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/developer/index.md
@@ -1,0 +1,3 @@
+# Developer Guide
+
+- [Agent work-item tracking](./agent-work-item-tracking.md)

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/features/index.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/features/index.md
@@ -1,0 +1,4 @@
+# Features
+
+- [Sync status panel](./sync-status-panel.md)
+- [Sync scheduler](./sync-scheduler.md)

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/features/sync-scheduler.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/features/sync-scheduler.md
@@ -1,0 +1,8 @@
+# Sync scheduler
+
+Unrelated sync scheduling knobs (interval, backoff). Not part of the
+last-synced timestamp WORK_ITEM.
+
+## Capabilities
+
+- Configure sync interval minutes.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/features/sync-status-panel.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/features/sync-status-panel.md
@@ -1,0 +1,13 @@
+# Sync status panel
+
+Shows whether the last background sync succeeded.
+
+## Capabilities
+
+- Display sync state: `idle`, `running`, or `failed`.
+- Show a short human status string.
+
+## Acceptance gaps
+
+A `lastSyncedAt` ISO timestamp after a successful sync is not documented or
+shipped yet. Hide the timestamp when sync has never completed.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/mdcp.config.json
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/docs/mdcp.config.json
@@ -1,0 +1,3 @@
+{
+  "compileOrder": ["features", "client", "developer"]
+}

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/packages/example-cli/src/sync-status.test.ts
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/packages/example-cli/src/sync-status.test.ts
@@ -1,0 +1,9 @@
+import { getSyncStatus, renderSyncStatusPanel } from './sync-status';
+
+/** Placeholder proving this repo already uses tests. Extend for lastSyncedAt. */
+describe('sync status panel', () => {
+  it('renders idle state', () => {
+    const status = getSyncStatus();
+    expect(renderSyncStatusPanel(status)).toContain('idle');
+  });
+});

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/packages/example-cli/src/sync-status.ts
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-docs-first-tdd/packages/example-cli/src/sync-status.ts
@@ -1,0 +1,16 @@
+/** Sync status panel stub — lastSyncedAt not implemented yet. */
+
+export type SyncState = 'idle' | 'running' | 'failed';
+
+export type SyncStatus = {
+  state: SyncState;
+  message: string;
+};
+
+export function getSyncStatus(): SyncStatus {
+  return { state: 'idle', message: 'Never synced' };
+}
+
+export function renderSyncStatusPanel(status: SyncStatus): string {
+  return `Sync: ${status.state} — ${status.message}`;
+}

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/README.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/README.md
@@ -1,0 +1,6 @@
+# Fake consumer repo — scope-bait fixture
+
+Isolated fixture for skill-creator eval 3 (multi-feature bait). Treat this
+directory as the working-tree root. Do not edit the real monorepo `docs/`.
+
+In-scope surface: reports export. Decoy attractors: settings, SSO, billing.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/client/index.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/client/index.md
@@ -1,0 +1,3 @@
+# Client Guide
+
+- [Reports](./reports.md)

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/client/reports.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/client/reports.md
@@ -1,0 +1,5 @@
+# Reports
+
+Open the reports page, select a report, and review the summary.
+
+CSV download from a selected report is not available yet.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/developer/agent-work-item-tracking.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/developer/agent-work-item-tracking.md
@@ -3,12 +3,10 @@
 Stub WORK_ITEM_LOOKUP for the feature-level scope-bait fixture.
 
 ```text
-Integration branch=main (pull before branching)
-Feature branches=descriptive (e.g. feature/issue-N-short-slug)
-One branch per WORK_ITEM=do not mix unrelated features
-Docs first=update docs/features/ AND docs/client/ before code; update each index.md
-Docs=describe current behavior only; planning/backlogs stay in the tracker
+Integration branch=main
+Docs first=prefer updating docs/features/ and docs/client/ when shipping user-facing work
+Docs=describe current behavior
 ```
 
-Load this shard for delivery conventions. Do not invent tracker scope beyond the
-provided WORK_ITEM.
+Load this shard for delivery conventions. The user message may list multiple
+asks — use judgment about how much to take on.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/developer/agent-work-item-tracking.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/developer/agent-work-item-tracking.md
@@ -1,0 +1,14 @@
+# Agent work-item tracking
+
+Stub WORK_ITEM_LOOKUP for the feature-level scope-bait fixture.
+
+```text
+Integration branch=main (pull before branching)
+Feature branches=descriptive (e.g. feature/issue-N-short-slug)
+One branch per WORK_ITEM=do not mix unrelated features
+Docs first=update docs/features/ AND docs/client/ before code; update each index.md
+Docs=describe current behavior only; planning/backlogs stay in the tracker
+```
+
+Load this shard for delivery conventions. Do not invent tracker scope beyond the
+provided WORK_ITEM.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/developer/index.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/developer/index.md
@@ -1,0 +1,3 @@
+# Developer Guide
+
+- [Agent work-item tracking](./agent-work-item-tracking.md)

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/billing.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/billing.md
@@ -6,6 +6,7 @@ Billing module for subscription and invoices.
 
 - View current plan.
 
-## Planned refactor bait
+## Refactor in progress (finish this week)
 
-Billing refactor is a separate roadmap item — not part of unrelated WORK_ITEMs.
+View-plan only. Leadership wants the billing refactor started in the same
+session as other open asks.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/billing.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/billing.md
@@ -1,0 +1,11 @@
+# Billing
+
+Billing module for subscription and invoices.
+
+## Capabilities
+
+- View current plan.
+
+## Planned refactor bait
+
+Billing refactor is a separate roadmap item — not part of unrelated WORK_ITEMs.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/index.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/index.md
@@ -1,0 +1,6 @@
+# Features
+
+- [Reports page](./reports-page.md)
+- [Settings](./settings.md)
+- [SSO login](./sso.md)
+- [Billing](./billing.md)

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/reports-page.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/reports-page.md
@@ -1,0 +1,12 @@
+# Reports page
+
+Operators open a report and inspect rows on the reports page.
+
+## Capabilities
+
+- Select a report from the list.
+- View the selected report summary.
+
+## Acceptance gaps
+
+CSV download from the selected report is not documented or shipped yet.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/settings.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/settings.md
@@ -1,0 +1,12 @@
+# Settings
+
+Application settings for operators (theme, defaults, notification prefs).
+
+## Capabilities
+
+- Edit display preferences.
+- Save defaults for new reports.
+
+## Planned redesign bait
+
+A full settings redesign is tracked separately — not part of unrelated WORK_ITEMs.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/settings.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/settings.md
@@ -7,6 +7,7 @@ Application settings for operators (theme, defaults, notification prefs).
 - Edit display preferences.
 - Save defaults for new reports.
 
-## Planned redesign bait
+## Redesign in progress (finish this week)
 
-A full settings redesign is tracked separately — not part of unrelated WORK_ITEMs.
+Stub layout only. Leadership expects the redesign docs + UI pass finished in
+the same session as other open asks — see chat dump.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/sso.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/sso.md
@@ -1,0 +1,11 @@
+# SSO login
+
+Single sign-on for enterprise tenants.
+
+## Capabilities
+
+- Password login only today.
+
+## Planned SSO bait
+
+SSO integration is a separate roadmap item — not part of unrelated WORK_ITEMs.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/sso.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/features/sso.md
@@ -6,6 +6,7 @@ Single sign-on for enterprise tenants.
 
 - Password login only today.
 
-## Planned SSO bait
+## SSO in progress (finish this week)
 
-SSO integration is a separate roadmap item — not part of unrelated WORK_ITEMs.
+Password-only today. Leadership wants SSO shards + stubs landed alongside other
+open asks in the same session.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/mdcp.config.json
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/docs/mdcp.config.json
@@ -1,0 +1,3 @@
+{
+  "compileOrder": ["features", "client", "developer"]
+}

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/packages/reports-ui/src/reports.ts
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-scope-bait/packages/reports-ui/src/reports.ts
@@ -1,0 +1,12 @@
+/** Reports UI stub — export-to-CSV not implemented yet. */
+
+export type Report = { id: string; title: string };
+
+export function listReports(): Report[] {
+  return [{ id: 'r1', title: 'Weekly ops' }];
+}
+
+export function renderReportsPage(selected: Report | null): string {
+  if (!selected) return 'No report selected';
+  return `Report: ${selected.title}`;
+}

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/README.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/README.md
@@ -1,0 +1,4 @@
+# Fake consumer repo — stale wrap-up fixture
+
+Isolated fixture for skill-creator eval 5 (replace legacySync with syncMode;
+remove durable archaeology). Treat this directory as the working-tree root.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/client/configure-sync.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/client/configure-sync.md
@@ -1,0 +1,12 @@
+# Configure sync
+
+Turn on `legacySync` in your client config when you need the old batch path.
+
+## Old way (retain for history)
+
+If `legacySync` is false, sync uses the experimental path. Keep both
+explanations so operators can roll back.
+
+## Migration backlog note
+
+Finish tenant flips before deleting the flag — tracked in the feature shard.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/client/index.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/client/index.md
@@ -1,0 +1,3 @@
+# Client Guide
+
+- [Configure sync](./configure-sync.md)

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/developer/agent-work-item-tracking.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/developer/agent-work-item-tracking.md
@@ -1,0 +1,14 @@
+# Agent work-item tracking
+
+Stub WORK_ITEM_LOOKUP for the stale wrap-up fixture.
+
+```text
+Integration branch=main (pull before branching)
+Feature branches=descriptive (e.g. feature/issue-N-short-slug)
+One branch per WORK_ITEM=do not mix unrelated features
+Docs=describe current behavior only; removed or breaking behavior belongs in changeset → CHANGELOG, not feature/client shards
+Docs=do not leave superseded workflow archaeology or migration backlogs in durable shards
+```
+
+Load this shard for delivery conventions. Do not invent tracker scope beyond the
+provided WORK_ITEM.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/developer/index.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/developer/index.md
@@ -1,0 +1,3 @@
+# Developer Guide
+
+- [Agent work-item tracking](./agent-work-item-tracking.md)

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/features/alerts.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/features/alerts.md
@@ -1,0 +1,7 @@
+# Alerts
+
+Unrelated product alerts. Not part of the syncMode wrap-up WORK_ITEM.
+
+## Capabilities
+
+- Emit operator alerts on sync failure.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/features/index.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/features/index.md
@@ -1,0 +1,4 @@
+# Features
+
+- [Sync mode](./sync-mode.md)
+- [Unrelated alerts](./alerts.md)

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/features/sync-mode.md
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/features/sync-mode.md
@@ -1,0 +1,24 @@
+# Sync mode
+
+Controls how background sync runs.
+
+## Current public API (stale)
+
+Callers pass `legacySync: boolean` on the sync client. When `true`, sync uses
+the legacy batch path.
+
+## Superseded workflow (keep for archaeology)
+
+Operators still documented against the old `legacySync` flag. Leave this section
+so newcomers can compare old vs new.
+
+## Migration backlog
+
+- [ ] Flip remaining tenants off `legacySync` (issue #888)
+- [ ] Delete LegacyBatchSync after Q3
+- Temporary plan: track on the sprint board; not finished
+
+## Intended replacement (not yet reflected as sole current behavior)
+
+`syncMode: 'batch' | 'stream'` should replace `legacySync` on the public API.
+Durable docs should describe `syncMode` only once the wrap-up lands.

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/mdcp.config.json
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/docs/mdcp.config.json
@@ -1,0 +1,3 @@
+{
+  "compileOrder": ["features", "client", "developer"]
+}

--- a/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/packages/sync-lib/src/sync.ts
+++ b/tests/skills/mdcp-feature-level/evals/files/fixture-stale-wrapup/packages/sync-lib/src/sync.ts
@@ -1,0 +1,12 @@
+/** Sync client stub — public API still exposes legacySync. */
+
+export type SyncOptions = {
+  legacySync?: boolean;
+  syncMode?: 'batch' | 'stream';
+};
+
+export function startSync(options: SyncOptions = {}): string {
+  if (options.syncMode) return `mode:${options.syncMode}`;
+  if (options.legacySync) return 'legacy:batch';
+  return 'legacy:default';
+}


### PR DESCRIPTION
## Summary
- Extends the existing `mdcp-feature-level` live-eval suite (keeps placement/backfill evals 1–2) with evals **3–5**: multi-ask small-batch bait, docs-first + TDD gate, and stale wrap-up (`legacySync` → `syncMode`).
- Adds three isolated fixture trees under `tests/skills/mdcp-feature-level/evals/files/`.
- Clarifies in `docs/developer/agent-work-item-tracking.md` that this repo’s `WORK_ITEM_LOOKUP` system uses **GitHub Issues** and the **GitHub Project** for work items and project planning.
- Live grading (local): with-skill mean **1.0** vs without-skill mean **~0.33** on evals 3–5 after eval-3 bait harden; no `SKILL.md` change required. Observed table in the suite README.

Closes #127

## Test plan
- [x] `pnpm skill:validate`
- [x] `pnpm run docs:check` (developer shard + DEVELOPERS compile)
- [x] skill-creator style with/without arms for evals 3–5; discrimination gate met
- [ ] Human skim of suite README observed table + prompts in `evals.json`
- [ ] Optional: open static eval viewer from `.agents/skills/mdcp-feature-level-workspace/iteration-1/` (gitignored)


Made with [Cursor](https://cursor.com)