### PR TITLE
docs(developer): record issue value-add priority conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -9,6 +9,22 @@ body:
       value: |
         Thanks for the report. Include steps to reproduce and the `mdcp-cli` version if you can.
 
+        Maintainers apply a matching `priority:*` label from your selection below — see [Agent work-item tracking](https://github.com/betsalel-williamson/mdcp/blob/main/docs/developer/agent-work-item-tracking.md#issue-priority-value-add).
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Value-add priority
+      description: How urgent is this for adopters and the core path? (One label will be applied on triage.)
+      options:
+        - P0 — user-facing blocker or broken core path (compile / check / refs)
+        - P1 — high near-term value
+        - P2 — important backlog
+        - P3 — nice-to-have / low urgency
+        - Defer — parked on an explicit gate
+    validations:
+      required: true
+
   - type: input
     id: mdcp-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/02-feedback.yml
@@ -9,6 +9,22 @@ body:
       value: |
         Questions and suggestions are welcome. For real-world outcomes, prefer the **Adoption story** template instead.
 
+        Maintainers apply a matching `priority:*` label from your selection below — see [Agent work-item tracking](https://github.com/betsalel-williamson/mdcp/blob/main/docs/developer/agent-work-item-tracking.md#issue-priority-value-add).
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Value-add priority
+      description: How much adopter or product value does this represent if we act on it?
+      options:
+        - P0 — user-facing blocker or broken core path (compile / check / refs)
+        - P1 — high near-term value
+        - P2 — important backlog
+        - P3 — nice-to-have / low urgency
+        - Defer — parked on an explicit gate
+    validations:
+      required: true
+
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/adoption-story.yml
+++ b/.github/ISSUE_TEMPLATE/adoption-story.yml
@@ -47,7 +47,7 @@ body:
     id: what-you-tried
     attributes:
       label: What you tried
-      description: Setup path (paste prompt, `mdcp init`, manual config), commands, CI wiring, agent workflow.
+      description: Setup path (skill install / paste prompt, config, commands, CI wiring, agent workflow).
     validations:
       required: true
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -135,7 +135,27 @@ Issue base URL=https://github.com/betsalel-williamson/mdcp/issues/
 WORK_ITEM=enough to resolve the issue — number, URL, or short name/description
 ```
 
-All repo issues live on the public [MarkDown Context Protocol project board](https://github.com/users/betsalel-williamson/projects/4). **Status** tracks delivery (Todo / In Progress / Done); **Track** groups work by roadmap area (0.5 Spec & adoption, 1.0 Formalization, Maintenance, Performance, Future V2+). Move items to **In Progress** when you start a branch; set **Done** when the issue closes.
+All repo issues live on the public [MarkDown Context Protocol project board](https://github.com/users/betsalel-williamson/projects/4). **Status** tracks delivery (Todo / In Progress / Done); **Track** groups work by roadmap area (0.5 Spec & adoption, 1.0 Formalization, Maintenance, Performance, Future V2+). Move items to **In Progress** when you start a branch; set **Done** when the issue closes. Every open issue should appear on that board.
+
+### Issue priority (value-add)
+
+Use **one** mutually exclusive GitHub label so the board and `gh issue list` stay sortable. These labels are **issue triage priority**, not the product capability tiers in [Personas and priority tiers](docs/features/personas-and-priority-tiers.md).
+
+| Label            | Meaning                                                               |
+| ---------------- | --------------------------------------------------------------------- |
+| `priority:P0`    | User-facing blocker or broken core path (compile / check / refs)      |
+| `priority:P1`    | High near-term value — do next after P0                               |
+| `priority:P2`    | Important backlog — clear value, not next                             |
+| `priority:P3`    | Nice-to-have / polish / low urgency                                   |
+| `priority:defer` | Parked on an explicit gate (benchmark, V2 dependency, adopter demand) |
+
+#### How priority is set
+
+1. **Issue forms** — Bug report and Feedback templates require a **Value-add priority** dropdown. That choice is recorded in the issue body.
+2. **Labels** — Maintainers or coding agents apply the matching `priority:*` label when triaging (GitHub forms cannot map a dropdown to a label automatically). Replace any previous `priority:*` label so only one remains.
+3. **What to work on next** — Prefer open issues labeled `priority:P0`, then `P1`. Skip `priority:defer` until the gate in the issue body is met.
+
+Issue templates live under `.github/ISSUE_TEMPLATE/`. Adoption stories do not require a priority dropdown (qualitative evidence, not a delivery backlog item).
 
 ### Load scope (pick what your agent has)
 
@@ -174,6 +194,7 @@ Parent skill QA and day-to-day helpers encode the same rule so plan-only agents 
 4. **Plan Atomic commit groups** — before waiting for human review / implementation, include numbered commit groups for multi-concern work (see [Git and delivery](#git-and-delivery)). After approval, land one group per commit.
 5. **Docs describe now** — update shards to match as-built behavior. Do not document superseded workflows in `docs/features/` or `docs/client/`; record consumer notice in the changeset (lands in package CHANGELOGs). Never link durable shards or ADRs to pending `.changeset/*.md` files.
 6. **Add a changeset** — run `pnpm changeset` (or manually create a `.changeset/*.md` file) if you changed published package behavior. This is required for release notes and versioning.
+7. **Triage priority** — when opening or reviewing issues, ensure exactly one `priority:*` label matches the template dropdown (see [Issue priority](#issue-priority-value-add)).
 
 ### Example intake answers
 

--- a/docs/developer/agent-work-item-tracking.md
+++ b/docs/developer/agent-work-item-tracking.md
@@ -16,7 +16,27 @@ Issue base URL=https://github.com/betsalel-williamson/mdcp/issues/
 WORK_ITEM=enough to resolve the issue — number, URL, or short name/description
 ```
 
-All repo issues live on the public [MarkDown Context Protocol project board](https://github.com/users/betsalel-williamson/projects/4). **Status** tracks delivery (Todo / In Progress / Done); **Track** groups work by roadmap area (0.5 Spec & adoption, 1.0 Formalization, Maintenance, Performance, Future V2+). Move items to **In Progress** when you start a branch; set **Done** when the issue closes.
+All repo issues live on the public [MarkDown Context Protocol project board](https://github.com/users/betsalel-williamson/projects/4). **Status** tracks delivery (Todo / In Progress / Done); **Track** groups work by roadmap area (0.5 Spec & adoption, 1.0 Formalization, Maintenance, Performance, Future V2+). Move items to **In Progress** when you start a branch; set **Done** when the issue closes. Every open issue should appear on that board.
+
+## Issue priority (value-add)
+
+Use **one** mutually exclusive GitHub label so the board and `gh issue list` stay sortable. These labels are **issue triage priority**, not the product capability tiers in [Personas and priority tiers](../features/personas-and-priority-tiers.md).
+
+| Label            | Meaning                                                               |
+| ---------------- | --------------------------------------------------------------------- |
+| `priority:P0`    | User-facing blocker or broken core path (compile / check / refs)      |
+| `priority:P1`    | High near-term value — do next after P0                               |
+| `priority:P2`    | Important backlog — clear value, not next                             |
+| `priority:P3`    | Nice-to-have / polish / low urgency                                   |
+| `priority:defer` | Parked on an explicit gate (benchmark, V2 dependency, adopter demand) |
+
+### How priority is set
+
+1. **Issue forms** — Bug report and Feedback templates require a **Value-add priority** dropdown. That choice is recorded in the issue body.
+2. **Labels** — Maintainers or coding agents apply the matching `priority:*` label when triaging (GitHub forms cannot map a dropdown to a label automatically). Replace any previous `priority:*` label so only one remains.
+3. **What to work on next** — Prefer open issues labeled `priority:P0`, then `P1`. Skip `priority:defer` until the gate in the issue body is met.
+
+Issue templates live under `.github/ISSUE_TEMPLATE/`. Adoption stories do not require a priority dropdown (qualitative evidence, not a delivery backlog item).
 
 ## Load scope (pick what your agent has)
 
@@ -55,6 +75,7 @@ Parent skill QA and day-to-day helpers encode the same rule so plan-only agents 
 4. **Plan Atomic commit groups** — before waiting for human review / implementation, include numbered commit groups for multi-concern work (see [Git and delivery](#git-and-delivery)). After approval, land one group per commit.
 5. **Docs describe now** — update shards to match as-built behavior. Do not document superseded workflows in `docs/features/` or `docs/client/`; record consumer notice in the changeset (lands in package CHANGELOGs). Never link durable shards or ADRs to pending `.changeset/*.md` files.
 6. **Add a changeset** — run `pnpm changeset` (or manually create a `.changeset/*.md` file) if you changed published package behavior. This is required for release notes and versioning.
+7. **Triage priority** — when opening or reviewing issues, ensure exactly one `priority:*` label matches the template dropdown (see [Issue priority](#issue-priority-value-add)).
 
 ## Example intake answers
 


### PR DESCRIPTION
## Summary
- Document mutually exclusive `priority:P0`–`P3` / `priority:defer` triage labels in agent work-item tracking (compiled to `DEVELOPERS.md`)
- Require a Value-add priority dropdown on Bug and Feedback issue templates; scrub stale `mdcp init` wording from the adoption-story template
- (Already applied on GitHub) matching labels exist and open issues were labeled during triage

## Test plan
- [ ] Confirm new issue forms show the required priority dropdown
- [ ] Confirm `docs/developer/agent-work-item-tracking.md` § Issue priority reads clearly vs product P0–P3 tiers
- [ ] `pnpm docs:check` (passes in pre-commit)


Made with [Cursor](https://cursor.com)