### PR TITLE
fix(skills): restore YAML frontmatter newline (npx skills add)

### DIFF
--- a/.changeset/fix-skill-frontmatter-newline.md
+++ b/.changeset/fix-skill-frontmatter-newline.md
@@ -1,0 +1,5 @@
+---
+'@bwilliamson/mdcp-cli': patch
+---
+
+Fix Agent Skill YAML frontmatter corrupted by release version sync (`---name:`), which broke `npx skills add`.

--- a/.changeset/fix-skill-frontmatter-newline.md
+++ b/.changeset/fix-skill-frontmatter-newline.md
@@ -2,4 +2,4 @@
 '@bwilliamson/mdcp-cli': patch
 ---
 
-Fix Agent Skill YAML frontmatter corrupted by release version sync (`---name:`), which broke `npx skills add`.
+Fix Agent Skill YAML frontmatter corrupted by release version sync (`---name:`), which broke `npx skills add`. Require `pnpm skill:validate` after version sync in `release:tag` and again in the release workflow before npm publish.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
+      # Hard gate after tag: skill packs (including YAML frontmatter) must validate
+      # before npm publish. Catches release:tag version-sync corruption that would
+      # break `npx skills add`.
+      - name: Validate Agent Skills
+        run: pnpm skill:validate
+
       - name: Publish to npm
         run: pnpm changeset publish
         env:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -455,12 +455,12 @@ When changing skill instructions:
 
 ### Verification
 
-| Command               | Purpose                                                                                   |
-| --------------------- | ----------------------------------------------------------------------------------------- |
-| `pnpm skill:validate` | [skills-ref](https://agentskills.io/specification) validate on all skills under `skills/` |
-| `pnpm docs:check`     | Docs compile + lint gate after shard edits                                                |
+| Command               | Purpose                                                                                                            |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `pnpm skill:validate` | Frontmatter fence lint + [skills-ref](https://agentskills.io/specification) validate on all skills under `skills/` |
+| `pnpm docs:check`     | Docs compile + lint gate after shard edits                                                                         |
 
-`pnpm skill:validate` runs in local `pnpm check` and GitHub Actions CI. It is not a [live skill eval](docs/glossary/live-skill-eval.md).
+`pnpm skill:validate` runs in local `pnpm check`, PR CI, **`pnpm release:tag` after skill version sync** (hard fail before commit/tag), and the tag [release workflow](.github/workflows/release.yml) before npm publish. It is not a [live skill eval](docs/glossary/live-skill-eval.md).
 
 ### Live skill evals (optional, local)
 
@@ -677,8 +677,8 @@ Use this for every cut. Do not accumulate one-off milestone checklists in this s
 2. **Skills policy:** parent `mdcp` remains the consumer entrypoint. Keep complementary `skills/mdcp-arch-*` skills as `metadata.internal: true` and **out** of [`skills.sh.json`](skills.sh.json) until intentionally published. List parent + release-ready helpers in the **Documentation system** grouping (see [Agent Skill development — skills.sh.json](#skillsshjson-repo-page-layout)).
 3. Preflight: `pnpm skill:validate && pnpm check` (or at least `pnpm docs:check` when only docs/skills changed).
 4. In a real TTY: `pnpm release:tag:push` — select bump (patch / minor / major / build), type `vX.Y.Z`, answer `yes`. Agents and CI cannot run this script.
-5. The script applies changesets, bumps package versions and changelogs, syncs `skills/*/SKILL.md` `metadata.version`, commits `chore: release vX.Y.Z`, tags, and (with `--push`) pushes `main` + the tag.
-6. Verify CI [release workflow](.github/workflows/release.yml): npm versions for all three packages and the GitHub Release for `vX.Y.Z`.
+5. The script applies changesets, bumps package versions and changelogs, syncs `skills/*/SKILL.md` `metadata.version`, then **must** run `pnpm skill:validate` (hard fail if invalid — including broken YAML fences like `---name:`). Only after that succeeds does it commit `chore: release vX.Y.Z`, tag, and (with `--push`) push `main` + the tag.
+6. Verify CI [release workflow](.github/workflows/release.yml): it runs `pnpm skill:validate` again before npm publish, then publishes all three packages and creates the GitHub Release for `vX.Y.Z`.
 7. **skills.sh:** there is no registry submit. Listing at [skills.sh/betsalel-williamson/mdcp](https://skills.sh/betsalel-williamson/mdcp) comes from anonymous install telemetry. If the page is missing or stale after a skill-facing release, run `npx skills add betsalel-williamson/mdcp --skill mdcp` without `DISABLE_TELEMETRY=1`. Maintainers can list internal skills with `INSTALL_INTERNAL_SKILLS=1`.
 
 Preview without writes: `pnpm release:tag --dry-run`.

--- a/docs/developer/agent-skill.md
+++ b/docs/developer/agent-skill.md
@@ -44,12 +44,12 @@ When changing skill instructions:
 
 ## Verification
 
-| Command               | Purpose                                                                                   |
-| --------------------- | ----------------------------------------------------------------------------------------- |
-| `pnpm skill:validate` | [skills-ref](https://agentskills.io/specification) validate on all skills under `skills/` |
-| `pnpm docs:check`     | Docs compile + lint gate after shard edits                                                |
+| Command               | Purpose                                                                                                            |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `pnpm skill:validate` | Frontmatter fence lint + [skills-ref](https://agentskills.io/specification) validate on all skills under `skills/` |
+| `pnpm docs:check`     | Docs compile + lint gate after shard edits                                                                         |
 
-`pnpm skill:validate` runs in local `pnpm check` and GitHub Actions CI. It is not a [live skill eval](../glossary/live-skill-eval.md).
+`pnpm skill:validate` runs in local `pnpm check`, PR CI, **`pnpm release:tag` after skill version sync** (hard fail before commit/tag), and the tag [release workflow](../../.github/workflows/release.yml) before npm publish. It is not a [live skill eval](../glossary/live-skill-eval.md).
 
 ## Live skill evals (optional, local)
 

--- a/docs/developer/versioning-and-releases.md
+++ b/docs/developer/versioning-and-releases.md
@@ -51,8 +51,8 @@ Use this for every cut. Do not accumulate one-off milestone checklists in this s
 2. **Skills policy:** parent `mdcp` remains the consumer entrypoint. Keep complementary `skills/mdcp-arch-*` skills as `metadata.internal: true` and **out** of [`skills.sh.json`](../../skills.sh.json) until intentionally published. List parent + release-ready helpers in the **Documentation system** grouping (see [Agent Skill development — skills.sh.json](./agent-skill.md#skillsshjson-repo-page-layout)).
 3. Preflight: `pnpm skill:validate && pnpm check` (or at least `pnpm docs:check` when only docs/skills changed).
 4. In a real TTY: `pnpm release:tag:push` — select bump (patch / minor / major / build), type `vX.Y.Z`, answer `yes`. Agents and CI cannot run this script.
-5. The script applies changesets, bumps package versions and changelogs, syncs `skills/*/SKILL.md` `metadata.version`, commits `chore: release vX.Y.Z`, tags, and (with `--push`) pushes `main` + the tag.
-6. Verify CI [release workflow](../../.github/workflows/release.yml): npm versions for all three packages and the GitHub Release for `vX.Y.Z`.
+5. The script applies changesets, bumps package versions and changelogs, syncs `skills/*/SKILL.md` `metadata.version`, then **must** run `pnpm skill:validate` (hard fail if invalid — including broken YAML fences like `---name:`). Only after that succeeds does it commit `chore: release vX.Y.Z`, tag, and (with `--push`) push `main` + the tag.
+6. Verify CI [release workflow](../../.github/workflows/release.yml): it runs `pnpm skill:validate` again before npm publish, then publishes all three packages and creates the GitHub Release for `vX.Y.Z`.
 7. **skills.sh:** there is no registry submit. Listing at [skills.sh/betsalel-williamson/mdcp](https://skills.sh/betsalel-williamson/mdcp) comes from anonymous install telemetry. If the page is missing or stale after a skill-facing release, run `npx skills add betsalel-williamson/mdcp --skill mdcp` without `DISABLE_TELEMETRY=1`. Maintainers can list internal skills with `INSTALL_INTERNAL_SKILLS=1`.
 
 Preview without writes: `pnpm release:tag --dry-run`.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "release:tag": "node scripts/release-tag.mjs",
     "release:tag:push": "node scripts/release-tag.mjs --push",
     "prepare": "husky",
-    "skill:validate": "skills-ref validate ./skills/mdcp && skills-ref validate ./skills/mdcp-getting-started && skills-ref validate ./skills/mdcp-doc-only && skills-ref validate ./skills/mdcp-design-architecture && skills-ref validate ./skills/mdcp-feature-level && skills-ref validate ./skills/mdcp-ux && skills-ref validate ./skills/mdcp-arch-oss-library && skills-ref validate ./skills/mdcp-arch-product-docs-site",
+    "skill:validate": "node scripts/lint-skill-frontmatter.mjs && skills-ref validate ./skills/mdcp && skills-ref validate ./skills/mdcp-getting-started && skills-ref validate ./skills/mdcp-doc-only && skills-ref validate ./skills/mdcp-design-architecture && skills-ref validate ./skills/mdcp-feature-level && skills-ref validate ./skills/mdcp-ux && skills-ref validate ./skills/mdcp-arch-oss-library && skills-ref validate ./skills/mdcp-arch-product-docs-site",
     "skill:install": "npx skills add .",
     "skill:update": "pnpm run skill:install",
     "skill:evals:view": "bash scripts/view-skill-evals.sh",

--- a/scripts/lint-skill-frontmatter.mjs
+++ b/scripts/lint-skill-frontmatter.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Fail if any skills/<name>/SKILL.md opens with a broken YAML fence
+ * ("---name:" instead of "---" then newline then "name:").
+ * That corruption breaks `npx skills add`.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const skillsDir = join(process.cwd(), 'skills');
+const bad = [];
+
+for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const skillPath = join(skillsDir, entry.name, 'SKILL.md');
+  let content;
+  try {
+    content = readFileSync(skillPath, 'utf-8');
+  } catch {
+    continue;
+  }
+  if (!content.startsWith('---\n')) {
+    bad.push(skillPath);
+  }
+}
+
+if (bad.length > 0) {
+  console.error(
+    'Broken SKILL.md YAML frontmatter (missing newline after ---):\n' +
+      bad.map((p) => `  ${p}`).join('\n') +
+      '\n\nExpected opening:\n---\nname: ...\n\nNot:\n---name: ...',
+  );
+  process.exit(1);
+}
+
+console.log('Skill frontmatter fences OK.');

--- a/scripts/release-tag.mjs
+++ b/scripts/release-tag.mjs
@@ -7,6 +7,9 @@
  *   pnpm release:tag              # interactive version + commit + tag
  *   pnpm release:tag --push       # also push main and tag to origin
  *   pnpm release:tag --dry-run    # prompts + plan only, no writes
+ *
+ * After bumping package + skill metadata.version, always runs
+ * `pnpm skill:validate` and aborts if it fails (no commit/tag).
  */
 import { execSync } from 'node:child_process';
 import { readdirSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
@@ -391,6 +394,11 @@ async function main() {
   }
 
   const finalTag = `v${appliedVersion}`;
+
+  // Hard gate: skill packs must still validate after metadata.version sync.
+  // A prior bug rewrote "---\\nname:" as "---name:" and broke `npx skills add`.
+  console.log('\nPost-sync gate: pnpm skill:validate (required; release fails if this fails)');
+  run('pnpm skill:validate');
 
   if (dryRun) {
     console.log(`> git add -A`);

--- a/scripts/release-tag.mjs
+++ b/scripts/release-tag.mjs
@@ -152,6 +152,10 @@ function setVersionAllPackages(version) {
 /**
  * Keep each skills/<name>/SKILL.md metadata.version in lockstep with the npm/git tag.
  * Preserves other frontmatter keys (e.g. metadata.internal).
+ *
+ * Opening fence MUST be rewritten as "---\n" + body. A prior bug used "---" +
+ * slice(4) (which drops the newline after ---) and produced "---name:", which
+ * breaks `npx skills add`.
  */
 function setSkillMetadataVersions(version) {
   const skillsDir = join(root, 'skills');
@@ -170,8 +174,9 @@ function setSkillMetadataVersions(version) {
     } catch {
       continue;
     }
-    if (!content.startsWith('---')) continue;
-    const end = content.indexOf('\n---', 3);
+    // Require a real YAML fence ("---\n"), not "---name:" corruption.
+    if (!content.startsWith('---\n')) continue;
+    const end = content.indexOf('\n---', 4);
     if (end === -1) continue;
     const frontmatter = content.slice(4, end);
     if (!/^\s*version:\s*/m.test(frontmatter)) continue;
@@ -180,7 +185,7 @@ function setSkillMetadataVersions(version) {
       `$1'${version}'`,
     );
     if (nextFrontmatter === frontmatter) continue;
-    writeFileSync(skillPath, `---${nextFrontmatter}${content.slice(end)}`);
+    writeFileSync(skillPath, `---\n${nextFrontmatter}${content.slice(end)}`);
   }
 }
 

--- a/skills/mdcp-arch-oss-library/SKILL.md
+++ b/skills/mdcp-arch-oss-library/SKILL.md
@@ -1,4 +1,5 @@
----name: mdcp-arch-oss-library
+---
+name: mdcp-arch-oss-library
 description: >-
   Documentation system archetype for OSS libraries (npm, PyPI, crates.io): keep
   package docs maintainable as APIs and ideas evolve — source holds API truth;

--- a/skills/mdcp-arch-product-docs-site/SKILL.md
+++ b/skills/mdcp-arch-product-docs-site/SKILL.md
@@ -1,4 +1,5 @@
----name: mdcp-arch-product-docs-site
+---
+name: mdcp-arch-product-docs-site
 description: >-
   Documentation system archetype for product docs sites (MkDocs, Docusaurus,
   VitePress): keep human-facing docs maintainable as features keep shipping —

--- a/skills/mdcp-design-architecture/SKILL.md
+++ b/skills/mdcp-design-architecture/SKILL.md
@@ -1,4 +1,5 @@
----name: mdcp-design-architecture
+---
+name: mdcp-design-architecture
 description: 'MDCP Helper: Act as an expert Systems Architect to draft and design system architecture using MDCP shards.'
 license: MIT
 compatibility: >-

--- a/skills/mdcp-doc-only/SKILL.md
+++ b/skills/mdcp-doc-only/SKILL.md
@@ -1,4 +1,5 @@
----name: mdcp-doc-only
+---
+name: mdcp-doc-only
 description: >-
   Use when the work item is documentation-only: authoring or refactoring MDCP
   shards, fixing stale client/feature/developer docs, removing planning

--- a/skills/mdcp-feature-level/SKILL.md
+++ b/skills/mdcp-feature-level/SKILL.md
@@ -1,4 +1,5 @@
----name: mdcp-feature-level
+---
+name: mdcp-feature-level
 description: 'MDCP Helper: Act as an expert Software Engineer to implement and document new features using MDCP shards.'
 license: MIT
 compatibility: >-

--- a/skills/mdcp-getting-started/SKILL.md
+++ b/skills/mdcp-getting-started/SKILL.md
@@ -1,4 +1,5 @@
----name: mdcp-getting-started
+---
+name: mdcp-getting-started
 description: >-
   Use when bootstrapping MDCP in a greenfield or brownfield repository, first-time
   setup of sharded docs, migrating legacy markdown into MDCP guides, getting started

--- a/skills/mdcp-ux/SKILL.md
+++ b/skills/mdcp-ux/SKILL.md
@@ -1,4 +1,5 @@
----name: mdcp-ux
+---
+name: mdcp-ux
 description: >-
   MDCP Helper: Act as an expert UX Designer for user-centric design — end-user
   value, processes, and workflows in MDCP shards (interfaces when they serve

--- a/skills/mdcp/SKILL.md
+++ b/skills/mdcp/SKILL.md
@@ -1,4 +1,5 @@
----name: mdcp
+---
+name: mdcp
 description: >-
   Documentation system Agent Skill for MDCP (MarkDown Context Protocol): keep
   specs, architecture notes, and product ideas in small Markdown shards so


### PR DESCRIPTION
## Summary
- **Hotfix:** `npx skills add betsalel-williamson/mdcp` broke after v0.6.0 because `release:tag` rewrote skill frontmatter as `---name:` (missing newline after `---`).
- Restores valid `---\nname:` fences on all `skills/*/SKILL.md`.
- Fixes `setSkillMetadataVersions` in `scripts/release-tag.mjs` to rewrite `---\n` + body.
- Adds `scripts/lint-skill-frontmatter.mjs` to `pnpm skill:validate` so this cannot regress silently (`skills-ref validate` did not catch it).

## Test plan
- [x] `pnpm skill:validate` passes
- [x] Lint fails on intentional `---name:` corruption, passes after restore
- [ ] After merge: `npx skills add betsalel-williamson/mdcp` succeeds on a clean temp dir


Made with [Cursor](https://cursor.com)