### PR TITLE
docs: GitHub project intake and weekly triage runbook

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -9,7 +9,7 @@ body:
       value: |
         Thanks for the report. Include steps to reproduce and the `mdcp-cli` version if you can.
 
-        Maintainers apply a matching `priority:*` label from your selection below — see [Agent work-item tracking](https://github.com/betsalel-williamson/mdcp/blob/main/docs/developer/agent-work-item-tracking.md#issue-priority-value-add).
+        Maintainers apply a matching `priority:*` label from your selection below, then finish [new issue intake](https://github.com/betsalel-williamson/mdcp/blob/main/docs/developer/agent-work-item-tracking.md#new-issue-intake-required) (board, Track, Status) — see [Agent work-item tracking](https://github.com/betsalel-williamson/mdcp/blob/main/docs/developer/agent-work-item-tracking.md#issue-priority-value-add).
 
   - type: dropdown
     id: priority

--- a/.github/ISSUE_TEMPLATE/02-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/02-feedback.yml
@@ -9,7 +9,7 @@ body:
       value: |
         Questions and suggestions are welcome. For real-world outcomes, prefer the **Adoption story** template instead.
 
-        Maintainers apply a matching `priority:*` label from your selection below — see [Agent work-item tracking](https://github.com/betsalel-williamson/mdcp/blob/main/docs/developer/agent-work-item-tracking.md#issue-priority-value-add).
+        Maintainers apply a matching `priority:*` label from your selection below, then finish [new issue intake](https://github.com/betsalel-williamson/mdcp/blob/main/docs/developer/agent-work-item-tracking.md#new-issue-intake-required) (board, Track, Status) — see [Agent work-item tracking](https://github.com/betsalel-williamson/mdcp/blob/main/docs/developer/agent-work-item-tracking.md#issue-priority-value-add).
 
   - type: dropdown
     id: priority

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,8 @@ dist/
 pnpm-lock.yaml
 .specstory/
 .cursor/
+.superpowers/
+docs/superpowers/
 legacy/
 examples/sample-guides/guides.md
 examples/sample-guides/refs.json

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -135,7 +135,39 @@ Issue base URL=https://github.com/betsalel-williamson/mdcp/issues/
 WORK_ITEM=enough to resolve the issue — number, URL, or short name/description
 ```
 
-All repo issues live on the public [MarkDown Context Protocol project board](https://github.com/users/betsalel-williamson/projects/4). **Status** tracks delivery (Todo / In Progress / Done); **Track** groups work by roadmap area (0.5 Spec & adoption, 1.0 Formalization, Maintenance, Performance, Future V2+). Move items to **In Progress** when you start a branch; set **Done** when the issue closes. Every open issue should appear on that board.
+All repo issues live on the public [MarkDown Context Protocol project board](https://github.com/users/betsalel-williamson/projects/4). **Status** tracks delivery (Todo / In Progress / Done); **Track** groups work by roadmap area. Move items to **In Progress** when you start a branch; set **Done** when the issue closes. Every open issue should appear on that board.
+
+#### Project fields
+
+| Field     | Values                                                                             | When to set                                     |
+| --------- | ---------------------------------------------------------------------------------- | ----------------------------------------------- |
+| Status    | Todo · In Progress · Done                                                          | Todo on intake; In Progress on branch start     |
+| Track     | 0.5 Spec & adoption · 1.0 Formalization · Maintenance · Performance · Future (V2+) | On intake ([Track selection](#track-selection)) |
+| Milestone | Current release milestone when the issue is in-scope for that cut (e.g. `v0.7`)    | When it clearly belongs on the next ship slice  |
+
+#### Track selection
+
+| Track               | Use for                                                                              |
+| ------------------- | ------------------------------------------------------------------------------------ |
+| 0.5 Spec & adoption | Residual items still tied to the historical 0.5 epic (prefer closing or retargeting) |
+| 1.0 Formalization   | Protocol ADR, normative spec, schemas, conformance (#44 program)                     |
+| Maintenance         | Bugs, compile/check correctness, agent-process hygiene, adoption polish              |
+| Performance         | SLOs, benchmarks, engine spikes (often `priority:defer`)                             |
+| Future (V2+)        | MCP server, hosted API, and other post-V1 delivery surfaces                          |
+
+### Auth for board writes
+
+Issue CRUD needs the usual `repo` scope. **Adding or updating Project items needs `project` scope** on the token used by `gh` or GitHub MCP.
+
+```bash
+gh auth status
+# If Project GraphQL fails with INSUFFICIENT_SCOPES / missing read:project|project:
+gh auth refresh -s project
+# Multi-account: use the owner account that has project scope
+gh auth switch --user betsalel-williamson
+```
+
+Without `project` scope you can still triage labels and milestones; note board gaps in the issue comment and stop — do not invent a second tracker.
 
 ### Issue priority (value-add)
 
@@ -156,6 +188,115 @@ Use **one** mutually exclusive GitHub label so the board and `gh issue list` sta
 3. **What to work on next** — Prefer open issues labeled `priority:P0`, then `P1`. Skip `priority:defer` until the gate in the issue body is met.
 
 Issue templates live under `.github/ISSUE_TEMPLATE/`. Adoption stories do not require a priority dropdown (qualitative evidence, not a delivery backlog item).
+
+#### Other labels (apply on intake)
+
+| Kind      | Labels                                                           | Rule                                       |
+| --------- | ---------------------------------------------------------------- | ------------------------------------------ |
+| Type      | `bug`, `enhancement`, `documentation`, `feedback`, `epic`        | At least one type that matches the issue   |
+| Component | `cli`, `compile`, `refs`, `sections`, `hooks`, `presets`, `lint` | When the work is localized to that surface |
+| Domain    | `protocol`                                                       | Spec / positioning / formalization work    |
+
+Do **not** rely on the historical `0.5` label for new work — prefer Track + milestone instead.
+
+### New issue intake (required)
+
+Whenever you **open** an issue or find a brand-new open issue missing hygiene, finish this checklist before starting implementation. Same rules for humans and coding agents.
+
+1. **Priority** — exactly one `priority:*` (from the form dropdown or triage judgment).
+2. **Type (+ component/domain)** — see [Other labels](#other-labels-apply-on-intake).
+3. **Project board** — add the issue to [project #4](https://github.com/users/betsalel-williamson/projects/4) if absent; set **Status = Todo**.
+4. **Track** — set per [Track selection](#track-selection).
+5. **Milestone** — attach the current delivery milestone when the issue is in that cut’s scope; leave empty for long-range / deferred work.
+6. **Sanity** — title is actionable; body has acceptance criteria or a clear problem statement.
+
+#### Add an issue to the board (`gh`)
+
+Resolve the project and issue node IDs, then add the item (requires `project` scope):
+
+```bash
+# Project #4 under the user account
+PROJECT_ID=$(gh api graphql -f query='
+  query { user(login:"betsalel-williamson") {
+    projectV2(number:4) { id }
+  }}' --jq '.data.user.projectV2.id')
+
+ISSUE_NODE=$(gh api graphql -f query='
+  query($n:Int!) {
+    repository(owner:"betsalel-williamson", name:"mdcp") {
+      issue(number:$n) { id }
+    }
+  }' -F n=<N> --jq '.data.repository.issue.id')
+
+gh api graphql -f query='
+  mutation($project:ID!, $content:ID!) {
+    addProjectV2ItemById(input:{projectId:$project, contentId:$content}) {
+      item { id }
+    }
+  }' -f project="$PROJECT_ID" -f content="$ISSUE_NODE"
+```
+
+Set **Status** / **Track** in the GitHub Project UI, or via `updateProjectV2ItemFieldValue` after reading field and option IDs from `projectV2 { fields(...) }` (option IDs change if the field is rebuilt — always re-query; do not hard-code them in scripts committed to the repo).
+
+**GitHub MCP:** create/update the issue with labels, then add it to the user project (same project number **4**). If the MCP token lacks project scope, fall back to `gh` with a token that has `project`, or leave a comment listing the board gap for a maintainer.
+
+#### Labels via CLI
+
+```bash
+gh issue edit <N> --add-label "priority:P1" --add-label "bug" --add-label "compile"
+# Replace priority: remove the old one when changing level
+gh issue edit <N> --remove-label "priority:P2" --add-label "priority:P1"
+```
+
+### Weekly triage run
+
+Run **about once a week** (maintainer or coding agent with project scope). Goal: board and labels match reality; stale or duplicate tickets get a **human verification prompt** — never silent close-without-action.
+
+#### Checklist
+
+1. **Auth** — `gh auth status` shows `project` (or `read:project` at minimum for reads; writes need `project`). Switch to the owner account if needed.
+2. **Open vs board** — list open issues; add any missing ones (intake steps 3–5). Every open issue must appear on the board.
+3. **Label audit** — every open delivery issue has exactly one `priority:*` and a sensible type label; add component/domain when obvious.
+4. **Milestone hygiene** — close empty leftover milestones; keep the current cut (e.g. `v0.7`) populated only with in-scope issues.
+5. **Stale review** — candidates include: epic/goals already shipped in a release, ACs satisfied by existing docs/code, or no meaningful progress with superseded approach. On each candidate, **comment** asking the human to verify close-without-action ([Human verification comment](#human-verification-comment-stale--close-without-action)). Do **not** close until they reply.
+6. **Duplicate review** — if two issues share the same root cause, comment with the canonical issue and ask which to keep. Do **not** close as duplicate without confirmation (related ≠ duplicate).
+7. **Next work** — confirm the top open `priority:P0`, else `P1`, matches the current milestone intent; note it in the weekly wrap-up comment on the milestone or a short maintainer note.
+8. **Done clutter** — closed issues may linger on the board as Done; optional cleanup is fine, not required for a green weekly run.
+
+#### Human verification comment (stale / close-without-action)
+
+```markdown
+**Triage (YYYY-MM-DD):** Candidate to close without further action — please verify.
+
+Evidence:
+
+- <1–3 bullets: shipped release, docs path, maintainer status, superseded approach>
+
+Options:
+
+- Reply `close: completed` if done enough
+- Reply `close: not_planned` if abandoned
+- Reply `keep` + note if work remains (we will narrow acceptance criteria)
+
+No auto-close until you confirm.
+```
+
+#### Suggested commands
+
+```bash
+# Open issues (labels + milestone)
+gh issue list --repo betsalel-williamson/mdcp --state open --limit 100 \
+  --json number,title,labels,milestone,updatedAt
+
+# Priority queue
+gh issue list --repo betsalel-williamson/mdcp --state open --label "priority:P0"
+gh issue list --repo betsalel-williamson/mdcp --state open --label "priority:P1"
+
+# Current milestone
+gh issue list --repo betsalel-williamson/mdcp --milestone "v0.7" --state open
+```
+
+Compare the open-issue set to the board (Project UI filter, or GraphQL `projectV2.items`) and add gaps via [Add an issue to the board](#add-an-issue-to-the-board-gh).
 
 ### Load scope (pick what your agent has)
 
@@ -194,7 +335,8 @@ Parent skill QA and day-to-day helpers encode the same rule so plan-only agents 
 4. **Plan Atomic commit groups** — before waiting for human review / implementation, include numbered commit groups for multi-concern work (see [Git and delivery](#git-and-delivery)). After approval, land one group per commit.
 5. **Docs describe now** — update shards to match as-built behavior. Do not document superseded workflows in `docs/features/` or `docs/client/`; record consumer notice in the changeset (lands in package CHANGELOGs). Never link durable shards or ADRs to pending `.changeset/*.md` files.
 6. **Add a changeset** — run `pnpm changeset` (or manually create a `.changeset/*.md` file) if you changed published package behavior. This is required for release notes and versioning.
-7. **Triage priority** — when opening or reviewing issues, ensure exactly one `priority:*` label matches the template dropdown (see [Issue priority](#issue-priority-value-add)).
+7. **Issue intake** — when opening or first touching an issue, complete [New issue intake](#new-issue-intake-required) (labels, board, Track, Status, milestone).
+8. **Weekly triage** — once a week, run [Weekly triage run](#weekly-triage-run); prompt humans before closing stale or duplicate tickets.
 
 ### Example intake answers
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -139,21 +139,22 @@ All repo issues live on the public [MarkDown Context Protocol project board](htt
 
 #### Project fields
 
-| Field     | Values                                                                             | When to set                                     |
-| --------- | ---------------------------------------------------------------------------------- | ----------------------------------------------- |
-| Status    | Todo · In Progress · Done                                                          | Todo on intake; In Progress on branch start     |
-| Track     | 0.5 Spec & adoption · 1.0 Formalization · Maintenance · Performance · Future (V2+) | On intake ([Track selection](#track-selection)) |
-| Milestone | Current release milestone when the issue is in-scope for that cut (e.g. `v0.7`)    | When it clearly belongs on the next ship slice  |
+| Field     | Values                                                          | When to set                                     |
+| --------- | --------------------------------------------------------------- | ----------------------------------------------- |
+| Status    | Todo · In Progress · Done                                       | Todo on intake; In Progress on branch start     |
+| Track     | 1.0 Formalization · Maintenance · Performance · Future (V2+)    | On intake ([Track selection](#track-selection)) |
+| Milestone | Current open delivery milestone when the issue is in that scope | When it belongs on the next ship slice          |
 
 #### Track selection
 
-| Track               | Use for                                                                              |
-| ------------------- | ------------------------------------------------------------------------------------ |
-| 0.5 Spec & adoption | Residual items still tied to the historical 0.5 epic (prefer closing or retargeting) |
-| 1.0 Formalization   | Protocol ADR, normative spec, schemas, conformance (#44 program)                     |
-| Maintenance         | Bugs, compile/check correctness, agent-process hygiene, adoption polish              |
-| Performance         | SLOs, benchmarks, engine spikes (often `priority:defer`)                             |
-| Future (V2+)        | MCP server, hosted API, and other post-V1 delivery surfaces                          |
+| Track             | Use for                                                                 |
+| ----------------- | ----------------------------------------------------------------------- |
+| 1.0 Formalization | Protocol ADR, normative spec, schemas, conformance                      |
+| Maintenance       | Bugs, compile/check correctness, agent-process hygiene, adoption polish |
+| Performance       | SLOs, benchmarks, engine spikes (often `priority:defer`)                |
+| Future (V2+)      | MCP server, hosted API, and other post-V1 delivery surfaces             |
+
+If the board still shows other Track options, do **not** assign them to new work — use one of the rows above.
 
 ### Auth for board writes
 
@@ -197,8 +198,6 @@ Issue templates live under `.github/ISSUE_TEMPLATE/`. Adoption stories do not re
 | Component | `cli`, `compile`, `refs`, `sections`, `hooks`, `presets`, `lint` | When the work is localized to that surface |
 | Domain    | `protocol`                                                       | Spec / positioning / formalization work    |
 
-Do **not** rely on the historical `0.5` label for new work — prefer Track + milestone instead.
-
 ### New issue intake (required)
 
 Whenever you **open** an issue or find a brand-new open issue missing hygiene, finish this checklist before starting implementation. Same rules for humans and coding agents.
@@ -207,7 +206,7 @@ Whenever you **open** an issue or find a brand-new open issue missing hygiene, f
 2. **Type (+ component/domain)** — see [Other labels](#other-labels-apply-on-intake).
 3. **Project board** — add the issue to [project #4](https://github.com/users/betsalel-williamson/projects/4) if absent; set **Status = Todo**.
 4. **Track** — set per [Track selection](#track-selection).
-5. **Milestone** — attach the current delivery milestone when the issue is in that cut’s scope; leave empty for long-range / deferred work.
+5. **Milestone** — attach the current open delivery milestone when the issue is in that cut’s scope; leave empty for long-range or deferred work.
 6. **Sanity** — title is actionable; body has acceptance criteria or a clear problem statement.
 
 #### Add an issue to the board (`gh`)
@@ -257,10 +256,10 @@ Run **about once a week** (maintainer or coding agent with project scope). Goal:
 1. **Auth** — `gh auth status` shows `project` (or `read:project` at minimum for reads; writes need `project`). Switch to the owner account if needed.
 2. **Open vs board** — list open issues; add any missing ones (intake steps 3–5). Every open issue must appear on the board.
 3. **Label audit** — every open delivery issue has exactly one `priority:*` and a sensible type label; add component/domain when obvious.
-4. **Milestone hygiene** — close empty leftover milestones; keep the current cut (e.g. `v0.7`) populated only with in-scope issues.
-5. **Stale review** — candidates include: epic/goals already shipped in a release, ACs satisfied by existing docs/code, or no meaningful progress with superseded approach. On each candidate, **comment** asking the human to verify close-without-action ([Human verification comment](#human-verification-comment-stale--close-without-action)). Do **not** close until they reply.
+4. **Milestone hygiene** — keep only active delivery milestones open; attach in-scope issues to the current cut.
+5. **Stale review** — candidates: acceptance already met in the repo, superseded approach, or no remaining adopter value. On each candidate, **comment** asking the human to verify close-without-action ([Human verification comment](#human-verification-comment-stale--close-without-action)). Do **not** close until they reply.
 6. **Duplicate review** — if two issues share the same root cause, comment with the canonical issue and ask which to keep. Do **not** close as duplicate without confirmation (related ≠ duplicate).
-7. **Next work** — confirm the top open `priority:P0`, else `P1`, matches the current milestone intent; note it in the weekly wrap-up comment on the milestone or a short maintainer note.
+7. **Next work** — confirm the top open `priority:P0`, else `P1`, matches the current milestone intent; note it briefly for maintainers.
 8. **Done clutter** — closed issues may linger on the board as Done; optional cleanup is fine, not required for a green weekly run.
 
 #### Human verification comment (stale / close-without-action)
@@ -270,7 +269,7 @@ Run **about once a week** (maintainer or coding agent with project scope). Goal:
 
 Evidence:
 
-- <1–3 bullets: shipped release, docs path, maintainer status, superseded approach>
+- <1–3 bullets: current docs/code that satisfy ACs, superseded approach, or no remaining value>
 
 Options:
 
@@ -292,7 +291,7 @@ gh issue list --repo betsalel-williamson/mdcp --state open --limit 100 \
 gh issue list --repo betsalel-williamson/mdcp --state open --label "priority:P0"
 gh issue list --repo betsalel-williamson/mdcp --state open --label "priority:P1"
 
-# Current milestone
+# Issues on the current delivery milestone (replace title as needed)
 gh issue list --repo betsalel-williamson/mdcp --milestone "v0.7" --state open
 ```
 
@@ -343,12 +342,12 @@ Parent skill QA and day-to-day helpers encode the same rule so plan-only agents 
 When a subagent asks for scope, answers can look like:
 
 ```text
-WORK_ITEM=39
+WORK_ITEM=70
 WORK_ITEM_LOOKUP=docs/developer/agent-work-item-tracking.md
 ```
 
 ```text
-WORK_ITEM=default compile hooks
+WORK_ITEM=bare sibling link rewrite
 WORK_ITEM_LOOKUP=GitHub
 ```
 

--- a/docs/developer/agent-work-item-tracking.md
+++ b/docs/developer/agent-work-item-tracking.md
@@ -20,21 +20,22 @@ All repo issues live on the public [MarkDown Context Protocol project board](htt
 
 ### Project fields
 
-| Field     | Values                                                                             | When to set                                     |
-| --------- | ---------------------------------------------------------------------------------- | ----------------------------------------------- |
-| Status    | Todo · In Progress · Done                                                          | Todo on intake; In Progress on branch start     |
-| Track     | 0.5 Spec & adoption · 1.0 Formalization · Maintenance · Performance · Future (V2+) | On intake ([Track selection](#track-selection)) |
-| Milestone | Current release milestone when the issue is in-scope for that cut (e.g. `v0.7`)    | When it clearly belongs on the next ship slice  |
+| Field     | Values                                                          | When to set                                     |
+| --------- | --------------------------------------------------------------- | ----------------------------------------------- |
+| Status    | Todo · In Progress · Done                                       | Todo on intake; In Progress on branch start     |
+| Track     | 1.0 Formalization · Maintenance · Performance · Future (V2+)    | On intake ([Track selection](#track-selection)) |
+| Milestone | Current open delivery milestone when the issue is in that scope | When it belongs on the next ship slice          |
 
 ### Track selection
 
-| Track               | Use for                                                                              |
-| ------------------- | ------------------------------------------------------------------------------------ |
-| 0.5 Spec & adoption | Residual items still tied to the historical 0.5 epic (prefer closing or retargeting) |
-| 1.0 Formalization   | Protocol ADR, normative spec, schemas, conformance (#44 program)                     |
-| Maintenance         | Bugs, compile/check correctness, agent-process hygiene, adoption polish              |
-| Performance         | SLOs, benchmarks, engine spikes (often `priority:defer`)                             |
-| Future (V2+)        | MCP server, hosted API, and other post-V1 delivery surfaces                          |
+| Track             | Use for                                                                 |
+| ----------------- | ----------------------------------------------------------------------- |
+| 1.0 Formalization | Protocol ADR, normative spec, schemas, conformance                      |
+| Maintenance       | Bugs, compile/check correctness, agent-process hygiene, adoption polish |
+| Performance       | SLOs, benchmarks, engine spikes (often `priority:defer`)                |
+| Future (V2+)      | MCP server, hosted API, and other post-V1 delivery surfaces             |
+
+If the board still shows other Track options, do **not** assign them to new work — use one of the rows above.
 
 ## Auth for board writes
 
@@ -78,8 +79,6 @@ Issue templates live under `.github/ISSUE_TEMPLATE/`. Adoption stories do not re
 | Component | `cli`, `compile`, `refs`, `sections`, `hooks`, `presets`, `lint` | When the work is localized to that surface |
 | Domain    | `protocol`                                                       | Spec / positioning / formalization work    |
 
-Do **not** rely on the historical `0.5` label for new work — prefer Track + milestone instead.
-
 ## New issue intake (required)
 
 Whenever you **open** an issue or find a brand-new open issue missing hygiene, finish this checklist before starting implementation. Same rules for humans and coding agents.
@@ -88,7 +87,7 @@ Whenever you **open** an issue or find a brand-new open issue missing hygiene, f
 2. **Type (+ component/domain)** — see [Other labels](#other-labels-apply-on-intake).
 3. **Project board** — add the issue to [project #4](https://github.com/users/betsalel-williamson/projects/4) if absent; set **Status = Todo**.
 4. **Track** — set per [Track selection](#track-selection).
-5. **Milestone** — attach the current delivery milestone when the issue is in that cut’s scope; leave empty for long-range / deferred work.
+5. **Milestone** — attach the current open delivery milestone when the issue is in that cut’s scope; leave empty for long-range or deferred work.
 6. **Sanity** — title is actionable; body has acceptance criteria or a clear problem statement.
 
 ### Add an issue to the board (`gh`)
@@ -138,10 +137,10 @@ Run **about once a week** (maintainer or coding agent with project scope). Goal:
 1. **Auth** — `gh auth status` shows `project` (or `read:project` at minimum for reads; writes need `project`). Switch to the owner account if needed.
 2. **Open vs board** — list open issues; add any missing ones (intake steps 3–5). Every open issue must appear on the board.
 3. **Label audit** — every open delivery issue has exactly one `priority:*` and a sensible type label; add component/domain when obvious.
-4. **Milestone hygiene** — close empty leftover milestones; keep the current cut (e.g. `v0.7`) populated only with in-scope issues.
-5. **Stale review** — candidates include: epic/goals already shipped in a release, ACs satisfied by existing docs/code, or no meaningful progress with superseded approach. On each candidate, **comment** asking the human to verify close-without-action ([Human verification comment](#human-verification-comment-stale--close-without-action)). Do **not** close until they reply.
+4. **Milestone hygiene** — keep only active delivery milestones open; attach in-scope issues to the current cut.
+5. **Stale review** — candidates: acceptance already met in the repo, superseded approach, or no remaining adopter value. On each candidate, **comment** asking the human to verify close-without-action ([Human verification comment](#human-verification-comment-stale--close-without-action)). Do **not** close until they reply.
 6. **Duplicate review** — if two issues share the same root cause, comment with the canonical issue and ask which to keep. Do **not** close as duplicate without confirmation (related ≠ duplicate).
-7. **Next work** — confirm the top open `priority:P0`, else `P1`, matches the current milestone intent; note it in the weekly wrap-up comment on the milestone or a short maintainer note.
+7. **Next work** — confirm the top open `priority:P0`, else `P1`, matches the current milestone intent; note it briefly for maintainers.
 8. **Done clutter** — closed issues may linger on the board as Done; optional cleanup is fine, not required for a green weekly run.
 
 ### Human verification comment (stale / close-without-action)
@@ -151,7 +150,7 @@ Run **about once a week** (maintainer or coding agent with project scope). Goal:
 
 Evidence:
 
-- <1–3 bullets: shipped release, docs path, maintainer status, superseded approach>
+- <1–3 bullets: current docs/code that satisfy ACs, superseded approach, or no remaining value>
 
 Options:
 
@@ -173,7 +172,7 @@ gh issue list --repo betsalel-williamson/mdcp --state open --limit 100 \
 gh issue list --repo betsalel-williamson/mdcp --state open --label "priority:P0"
 gh issue list --repo betsalel-williamson/mdcp --state open --label "priority:P1"
 
-# Current milestone
+# Issues on the current delivery milestone (replace title as needed)
 gh issue list --repo betsalel-williamson/mdcp --milestone "v0.7" --state open
 ```
 
@@ -224,12 +223,12 @@ Parent skill QA and day-to-day helpers encode the same rule so plan-only agents 
 When a subagent asks for scope, answers can look like:
 
 ```text
-WORK_ITEM=39
+WORK_ITEM=70
 WORK_ITEM_LOOKUP=docs/developer/agent-work-item-tracking.md
 ```
 
 ```text
-WORK_ITEM=default compile hooks
+WORK_ITEM=bare sibling link rewrite
 WORK_ITEM_LOOKUP=GitHub
 ```
 

--- a/docs/developer/agent-work-item-tracking.md
+++ b/docs/developer/agent-work-item-tracking.md
@@ -16,7 +16,39 @@ Issue base URL=https://github.com/betsalel-williamson/mdcp/issues/
 WORK_ITEM=enough to resolve the issue — number, URL, or short name/description
 ```
 
-All repo issues live on the public [MarkDown Context Protocol project board](https://github.com/users/betsalel-williamson/projects/4). **Status** tracks delivery (Todo / In Progress / Done); **Track** groups work by roadmap area (0.5 Spec & adoption, 1.0 Formalization, Maintenance, Performance, Future V2+). Move items to **In Progress** when you start a branch; set **Done** when the issue closes. Every open issue should appear on that board.
+All repo issues live on the public [MarkDown Context Protocol project board](https://github.com/users/betsalel-williamson/projects/4). **Status** tracks delivery (Todo / In Progress / Done); **Track** groups work by roadmap area. Move items to **In Progress** when you start a branch; set **Done** when the issue closes. Every open issue should appear on that board.
+
+### Project fields
+
+| Field     | Values                                                                             | When to set                                     |
+| --------- | ---------------------------------------------------------------------------------- | ----------------------------------------------- |
+| Status    | Todo · In Progress · Done                                                          | Todo on intake; In Progress on branch start     |
+| Track     | 0.5 Spec & adoption · 1.0 Formalization · Maintenance · Performance · Future (V2+) | On intake ([Track selection](#track-selection)) |
+| Milestone | Current release milestone when the issue is in-scope for that cut (e.g. `v0.7`)    | When it clearly belongs on the next ship slice  |
+
+### Track selection
+
+| Track               | Use for                                                                              |
+| ------------------- | ------------------------------------------------------------------------------------ |
+| 0.5 Spec & adoption | Residual items still tied to the historical 0.5 epic (prefer closing or retargeting) |
+| 1.0 Formalization   | Protocol ADR, normative spec, schemas, conformance (#44 program)                     |
+| Maintenance         | Bugs, compile/check correctness, agent-process hygiene, adoption polish              |
+| Performance         | SLOs, benchmarks, engine spikes (often `priority:defer`)                             |
+| Future (V2+)        | MCP server, hosted API, and other post-V1 delivery surfaces                          |
+
+## Auth for board writes
+
+Issue CRUD needs the usual `repo` scope. **Adding or updating Project items needs `project` scope** on the token used by `gh` or GitHub MCP.
+
+```bash
+gh auth status
+# If Project GraphQL fails with INSUFFICIENT_SCOPES / missing read:project|project:
+gh auth refresh -s project
+# Multi-account: use the owner account that has project scope
+gh auth switch --user betsalel-williamson
+```
+
+Without `project` scope you can still triage labels and milestones; note board gaps in the issue comment and stop — do not invent a second tracker.
 
 ## Issue priority (value-add)
 
@@ -37,6 +69,115 @@ Use **one** mutually exclusive GitHub label so the board and `gh issue list` sta
 3. **What to work on next** — Prefer open issues labeled `priority:P0`, then `P1`. Skip `priority:defer` until the gate in the issue body is met.
 
 Issue templates live under `.github/ISSUE_TEMPLATE/`. Adoption stories do not require a priority dropdown (qualitative evidence, not a delivery backlog item).
+
+### Other labels (apply on intake)
+
+| Kind      | Labels                                                           | Rule                                       |
+| --------- | ---------------------------------------------------------------- | ------------------------------------------ |
+| Type      | `bug`, `enhancement`, `documentation`, `feedback`, `epic`        | At least one type that matches the issue   |
+| Component | `cli`, `compile`, `refs`, `sections`, `hooks`, `presets`, `lint` | When the work is localized to that surface |
+| Domain    | `protocol`                                                       | Spec / positioning / formalization work    |
+
+Do **not** rely on the historical `0.5` label for new work — prefer Track + milestone instead.
+
+## New issue intake (required)
+
+Whenever you **open** an issue or find a brand-new open issue missing hygiene, finish this checklist before starting implementation. Same rules for humans and coding agents.
+
+1. **Priority** — exactly one `priority:*` (from the form dropdown or triage judgment).
+2. **Type (+ component/domain)** — see [Other labels](#other-labels-apply-on-intake).
+3. **Project board** — add the issue to [project #4](https://github.com/users/betsalel-williamson/projects/4) if absent; set **Status = Todo**.
+4. **Track** — set per [Track selection](#track-selection).
+5. **Milestone** — attach the current delivery milestone when the issue is in that cut’s scope; leave empty for long-range / deferred work.
+6. **Sanity** — title is actionable; body has acceptance criteria or a clear problem statement.
+
+### Add an issue to the board (`gh`)
+
+Resolve the project and issue node IDs, then add the item (requires `project` scope):
+
+```bash
+# Project #4 under the user account
+PROJECT_ID=$(gh api graphql -f query='
+  query { user(login:"betsalel-williamson") {
+    projectV2(number:4) { id }
+  }}' --jq '.data.user.projectV2.id')
+
+ISSUE_NODE=$(gh api graphql -f query='
+  query($n:Int!) {
+    repository(owner:"betsalel-williamson", name:"mdcp") {
+      issue(number:$n) { id }
+    }
+  }' -F n=<N> --jq '.data.repository.issue.id')
+
+gh api graphql -f query='
+  mutation($project:ID!, $content:ID!) {
+    addProjectV2ItemById(input:{projectId:$project, contentId:$content}) {
+      item { id }
+    }
+  }' -f project="$PROJECT_ID" -f content="$ISSUE_NODE"
+```
+
+Set **Status** / **Track** in the GitHub Project UI, or via `updateProjectV2ItemFieldValue` after reading field and option IDs from `projectV2 { fields(...) }` (option IDs change if the field is rebuilt — always re-query; do not hard-code them in scripts committed to the repo).
+
+**GitHub MCP:** create/update the issue with labels, then add it to the user project (same project number **4**). If the MCP token lacks project scope, fall back to `gh` with a token that has `project`, or leave a comment listing the board gap for a maintainer.
+
+### Labels via CLI
+
+```bash
+gh issue edit <N> --add-label "priority:P1" --add-label "bug" --add-label "compile"
+# Replace priority: remove the old one when changing level
+gh issue edit <N> --remove-label "priority:P2" --add-label "priority:P1"
+```
+
+## Weekly triage run
+
+Run **about once a week** (maintainer or coding agent with project scope). Goal: board and labels match reality; stale or duplicate tickets get a **human verification prompt** — never silent close-without-action.
+
+### Checklist
+
+1. **Auth** — `gh auth status` shows `project` (or `read:project` at minimum for reads; writes need `project`). Switch to the owner account if needed.
+2. **Open vs board** — list open issues; add any missing ones (intake steps 3–5). Every open issue must appear on the board.
+3. **Label audit** — every open delivery issue has exactly one `priority:*` and a sensible type label; add component/domain when obvious.
+4. **Milestone hygiene** — close empty leftover milestones; keep the current cut (e.g. `v0.7`) populated only with in-scope issues.
+5. **Stale review** — candidates include: epic/goals already shipped in a release, ACs satisfied by existing docs/code, or no meaningful progress with superseded approach. On each candidate, **comment** asking the human to verify close-without-action ([Human verification comment](#human-verification-comment-stale--close-without-action)). Do **not** close until they reply.
+6. **Duplicate review** — if two issues share the same root cause, comment with the canonical issue and ask which to keep. Do **not** close as duplicate without confirmation (related ≠ duplicate).
+7. **Next work** — confirm the top open `priority:P0`, else `P1`, matches the current milestone intent; note it in the weekly wrap-up comment on the milestone or a short maintainer note.
+8. **Done clutter** — closed issues may linger on the board as Done; optional cleanup is fine, not required for a green weekly run.
+
+### Human verification comment (stale / close-without-action)
+
+```markdown
+**Triage (YYYY-MM-DD):** Candidate to close without further action — please verify.
+
+Evidence:
+
+- <1–3 bullets: shipped release, docs path, maintainer status, superseded approach>
+
+Options:
+
+- Reply `close: completed` if done enough
+- Reply `close: not_planned` if abandoned
+- Reply `keep` + note if work remains (we will narrow acceptance criteria)
+
+No auto-close until you confirm.
+```
+
+### Suggested commands
+
+```bash
+# Open issues (labels + milestone)
+gh issue list --repo betsalel-williamson/mdcp --state open --limit 100 \
+  --json number,title,labels,milestone,updatedAt
+
+# Priority queue
+gh issue list --repo betsalel-williamson/mdcp --state open --label "priority:P0"
+gh issue list --repo betsalel-williamson/mdcp --state open --label "priority:P1"
+
+# Current milestone
+gh issue list --repo betsalel-williamson/mdcp --milestone "v0.7" --state open
+```
+
+Compare the open-issue set to the board (Project UI filter, or GraphQL `projectV2.items`) and add gaps via [Add an issue to the board](#add-an-issue-to-the-board-gh).
 
 ## Load scope (pick what your agent has)
 
@@ -75,7 +216,8 @@ Parent skill QA and day-to-day helpers encode the same rule so plan-only agents 
 4. **Plan Atomic commit groups** — before waiting for human review / implementation, include numbered commit groups for multi-concern work (see [Git and delivery](#git-and-delivery)). After approval, land one group per commit.
 5. **Docs describe now** — update shards to match as-built behavior. Do not document superseded workflows in `docs/features/` or `docs/client/`; record consumer notice in the changeset (lands in package CHANGELOGs). Never link durable shards or ADRs to pending `.changeset/*.md` files.
 6. **Add a changeset** — run `pnpm changeset` (or manually create a `.changeset/*.md` file) if you changed published package behavior. This is required for release notes and versioning.
-7. **Triage priority** — when opening or reviewing issues, ensure exactly one `priority:*` label matches the template dropdown (see [Issue priority](#issue-priority-value-add)).
+7. **Issue intake** — when opening or first touching an issue, complete [New issue intake](#new-issue-intake-required) (labels, board, Track, Status, milestone).
+8. **Weekly triage** — once a week, run [Weekly triage run](#weekly-triage-run); prompt humans before closing stale or duplicate tickets.
 
 ## Example intake answers
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: 3.1.4
+
 importers:
 
   .:
@@ -2769,8 +2772,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6971,7 +6974,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7709,7 +7712,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,12 @@ packages:
 
 # pnpm supply-chain (2026 best practice)
 minimumReleaseAge: 10080
+# Security patch for GHSA-v2hh-gcrm-f6hx (ajv → fast-uri); published inside the age gate.
+minimumReleaseAgeExclude:
+  - fast-uri@3.1.4
 strictDepBuilds: true
 allowBuilds:
   esbuild: true
+# Pin the patched 3.x line (bare >=3.1.4 can float to vulnerable 4.1.0).
+overrides:
+  fast-uri: 3.1.4

--- a/scripts/pre-commit-affected.mjs
+++ b/scripts/pre-commit-affected.mjs
@@ -23,6 +23,7 @@ const rootConfigChanged = files.some(
   (f) =>
     f === 'package.json' ||
     f === 'pnpm-lock.yaml' ||
+    f === 'pnpm-workspace.yaml' ||
     f === 'eslint.config.mjs' ||
     (f.startsWith('tsconfig') && f.endsWith('.json')),
 );

--- a/scripts/pre-commit-affected.mjs
+++ b/scripts/pre-commit-affected.mjs
@@ -79,3 +79,17 @@ if (rootConfigChanged) {
   run('pnpm run typecheck');
   run('pnpm run format:check');
 }
+
+// CI runs `pnpm audit --audit-level=high` on every PR. Catch the same gate when
+// dependency manifests change — lint-staged / docs checks alone will not.
+const lockfileOrManifestChanged = files.some(
+  (f) =>
+    f === 'package.json' ||
+    f === 'pnpm-lock.yaml' ||
+    f === 'pnpm-workspace.yaml' ||
+    /^packages\/[^/]+\/package\.json$/.test(f),
+);
+
+if (lockfileOrManifestChanged) {
+  run('pnpm audit --audit-level=high');
+}


### PR DESCRIPTION
## Summary
- Expand developer work-item tracking with required new-issue intake (labels, project board, Track, Status, milestone) and `gh` recipes for project #4.
- Add a weekly triage checklist for board/label hygiene and stale/duplicate review (human verify before close-without-action).
- Point bug/feedback issue templates at the intake steps after priority selection.

Closes #158.

## Test plan
- [ ] Skim `docs/developer/agent-work-item-tracking.md` (or compiled `DEVELOPERS.md`) for intake + weekly run clarity
- [ ] Confirm issue templates link to the new intake anchor
- [ ] Optional: create a throwaway issue and walk the intake checklist against project #4


Made with [Cursor](https://cursor.com)