### PR TITLE
fix: clear DOMPurify audit noise and document security triage

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -904,11 +904,12 @@ Changesets writes per-package `CHANGELOG.md` files under `packages/*/` when you 
 
 ### Supported versions
 
-Security fixes target the **latest minor** on npm. See [SECURITY.md](SECURITY.md) for the supported-versions table — update that table when cutting a new minor line.
+Security fixes target the **latest minor** on npm. See [SECURITY.md](SECURITY.md) for the supported-versions table — update that table when cutting a new minor line. After a security patch ships, follow [Security-incident triage](#security-incident-triage) when deciding whether to `npm deprecate` (or rarely unpublish) a bad version.
 
 ### Related docs
 
 - [Publishing](#publishing) — first publish, Trusted Publishing, npm commands
+- [Security-incident triage](#security-incident-triage) — audit impact class, deprecate vs unpublish
 - [Agent Skill](#agent-skill-development) — skill pack, WIP `internal` flag, skills.sh
 - [.changeset/README.md](.changeset/README.md) — quick changeset reference
 
@@ -1028,9 +1029,76 @@ Changesets config: [`.changeset/config.json`](.changeset/config.json) — all th
 
 Each package runs `prepublishOnly` to build (or verify) before publish.
 
-See [SECURITY.md](SECURITY.md) for vulnerability reporting.
+See [SECURITY.md](SECURITY.md) for vulnerability reporting. For advisory triage, deprecate-vs-unpublish, and when a finding is only transitive **dev** tooling: [Security-incident triage](#security-incident-triage).
 
 <!-- mdcp-shard: end docs/developer/publishing.md -->
+
+<!-- mdcp-shard: start docs/developer/security-incident-triage.md -->
+
+## Security-incident triage
+
+Maintainer runbook for dependency advisories and “burn a bad release” decisions on `@bwilliamson/mdcp-*`. Vulnerability **reporting** stays in [SECURITY.md](SECURITY.md); this shard covers **triage and remediation**.
+
+### Classify impact first
+
+Before changing lockfiles, deprecating versions, or cutting a release, decide where the finding lands:
+
+| Impact class                    | Typical signal                                                                                | Default response                                                                                       |
+| ------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Published / prod**            | Affects `@bwilliamson/mdcp-*` runtime deps or ships in the npm tarball                        | Patch, release, and (when consumers may have installed a bad version) deprecate that version           |
+| **Transitive dev-only tooling** | Only under root `devDependencies` (e.g. Slidev, lint/test helpers); `pnpm audit --prod` clean | Prefer a workspace **override** or upstream bump; do **not** deprecate or unpublish published packages |
+
+Quick checks:
+
+```bash
+pnpm audit --prod                 # published-package surface
+pnpm audit --audit-level=moderate # full tree including presentation tooling
+pnpm why <package>                # which path pulls the vulnerable package
+```
+
+CI gates on `pnpm audit --audit-level=high` (see [Packages and tests](#packages-and-tests)). Moderate noise in **dev-only** trees is hygiene, not an automatic security release of `@bwilliamson/mdcp-*`.
+
+Workspace overrides for this monorepo live under `overrides:` in [`pnpm-workspace.yaml`](pnpm-workspace.yaml) (pnpm 11+ no longer reads `package.json` → `pnpm.overrides`).
+
+### Prefer patch + deprecate over unpublish
+
+When a **published** version is unsafe or badly broken for consumers:
+
+1. **Ship a fixed release** (usually a **patch**) via the normal Changesets path — [Versioning and releases](#versioning-and-releases) and [Publishing](#publishing).
+2. **`npm deprecate`** the bad versions with a short reason and the safe replacement range. Deprecation warns installers without rewriting registry history.
+3. **Announce** via GitHub Security Advisory / release notes when disclosure timing requires it ([SECURITY.md](SECURITY.md)).
+
+Do **not** unpublish solely to silence an advisory when a patched successor exists. Unpublish breaks lockfiles and CI that pin exact versions.
+
+Example deprecate (maintainer machine, 2FA as required by npm):
+
+```bash
+npm deprecate @bwilliamson/mdcp-cli@<bad-version> "Security issue; use >=<fixed-version>"
+# Repeat for mdcp-core / mdcp-presets when those versions share the defect
+```
+
+### When unpublish (or npm Support) is appropriate
+
+Unpublish is rare. Prefer it only when **all** of the following hold (or npm’s current policy requires it):
+
+- The version must not remain installable (e.g. secrets or malware in the tarball), **and**
+- Deprecation alone is insufficient for the risk, **and**
+- You are within npm’s unpublish window / policy for that package and version
+
+Otherwise:
+
+- Use **deprecate** + patched release for ordinary vulnerabilities and broken builds.
+- Contact **npm Support** when the version is outside the self-serve unpublish window, the package was compromised, or you need a registry-side takedown.
+
+Never unpublish a version that other packages or consumers legitimately depend on unless the alternative is worse (credential leak, malware). Document the decision in the advisory, not in durable product shards.
+
+### Related docs
+
+- [SECURITY.md](SECURITY.md) — reporting and maintainer security practices
+- [Versioning and releases](#versioning-and-releases) — cutting fixed releases
+- [Publishing](#publishing) — npm publish mechanics and Trusted Publishing
+
+<!-- mdcp-shard: end docs/developer/security-incident-triage.md -->
 
 <!-- mdcp-shard: start docs/glossary/domain-glossary.md -->
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,3 +26,5 @@ We follow coordinated disclosure: we will confirm receipt, work on a fix, and pu
 - Gitleaks on commit and in CI
 - `pnpm audit --audit-level=high` in CI
 - Frozen lockfile installs in CI
+
+Triage (prod vs dev-only impact, prefer deprecate over unpublish): [docs/developer/security-incident-triage.md](docs/developer/security-incident-triage.md).

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -13,3 +13,4 @@
   - [Live skill evals](./live-skill-evals.md)
   - [Versioning and releases](./versioning-and-releases.md)
   - [Publishing](./publishing.md)
+  - [Security-incident triage](./security-incident-triage.md)

--- a/docs/developer/publishing.md
+++ b/docs/developer/publishing.md
@@ -110,4 +110,4 @@ Changesets config: [`.changeset/config.json`](../../.changeset/config.json) — 
 
 Each package runs `prepublishOnly` to build (or verify) before publish.
 
-See [SECURITY.md](../../SECURITY.md) for vulnerability reporting.
+See [SECURITY.md](../../SECURITY.md) for vulnerability reporting. For advisory triage, deprecate-vs-unpublish, and when a finding is only transitive **dev** tooling: [Security-incident triage](./security-incident-triage.md).

--- a/docs/developer/security-incident-triage.md
+++ b/docs/developer/security-incident-triage.md
@@ -1,0 +1,62 @@
+# Security-incident triage
+
+Maintainer runbook for dependency advisories and “burn a bad release” decisions on `@bwilliamson/mdcp-*`. Vulnerability **reporting** stays in [SECURITY.md](../../SECURITY.md); this shard covers **triage and remediation**.
+
+## Classify impact first
+
+Before changing lockfiles, deprecating versions, or cutting a release, decide where the finding lands:
+
+| Impact class                    | Typical signal                                                                                | Default response                                                                                       |
+| ------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Published / prod**            | Affects `@bwilliamson/mdcp-*` runtime deps or ships in the npm tarball                        | Patch, release, and (when consumers may have installed a bad version) deprecate that version           |
+| **Transitive dev-only tooling** | Only under root `devDependencies` (e.g. Slidev, lint/test helpers); `pnpm audit --prod` clean | Prefer a workspace **override** or upstream bump; do **not** deprecate or unpublish published packages |
+
+Quick checks:
+
+```bash
+pnpm audit --prod                 # published-package surface
+pnpm audit --audit-level=moderate # full tree including presentation tooling
+pnpm why <package>                # which path pulls the vulnerable package
+```
+
+CI gates on `pnpm audit --audit-level=high` (see [Packages and tests](./packages-and-tests.md)). Moderate noise in **dev-only** trees is hygiene, not an automatic security release of `@bwilliamson/mdcp-*`.
+
+Workspace overrides for this monorepo live under `overrides:` in [`pnpm-workspace.yaml`](../../pnpm-workspace.yaml) (pnpm 11+ no longer reads `package.json` → `pnpm.overrides`).
+
+## Prefer patch + deprecate over unpublish
+
+When a **published** version is unsafe or badly broken for consumers:
+
+1. **Ship a fixed release** (usually a **patch**) via the normal Changesets path — [Versioning and releases](./versioning-and-releases.md) and [Publishing](./publishing.md).
+2. **`npm deprecate`** the bad versions with a short reason and the safe replacement range. Deprecation warns installers without rewriting registry history.
+3. **Announce** via GitHub Security Advisory / release notes when disclosure timing requires it ([SECURITY.md](../../SECURITY.md)).
+
+Do **not** unpublish solely to silence an advisory when a patched successor exists. Unpublish breaks lockfiles and CI that pin exact versions.
+
+Example deprecate (maintainer machine, 2FA as required by npm):
+
+```bash
+npm deprecate @bwilliamson/mdcp-cli@<bad-version> "Security issue; use >=<fixed-version>"
+# Repeat for mdcp-core / mdcp-presets when those versions share the defect
+```
+
+## When unpublish (or npm Support) is appropriate
+
+Unpublish is rare. Prefer it only when **all** of the following hold (or npm’s current policy requires it):
+
+- The version must not remain installable (e.g. secrets or malware in the tarball), **and**
+- Deprecation alone is insufficient for the risk, **and**
+- You are within npm’s unpublish window / policy for that package and version
+
+Otherwise:
+
+- Use **deprecate** + patched release for ordinary vulnerabilities and broken builds.
+- Contact **npm Support** when the version is outside the self-serve unpublish window, the package was compromised, or you need a registry-side takedown.
+
+Never unpublish a version that other packages or consumers legitimately depend on unless the alternative is worse (credential leak, malware). Document the decision in the advisory, not in durable product shards.
+
+## Related docs
+
+- [SECURITY.md](../../SECURITY.md) — reporting and maintainer security practices
+- [Versioning and releases](./versioning-and-releases.md) — cutting fixed releases
+- [Publishing](./publishing.md) — npm publish mechanics and Trusted Publishing

--- a/docs/developer/versioning-and-releases.md
+++ b/docs/developer/versioning-and-releases.md
@@ -137,10 +137,11 @@ Changesets writes per-package `CHANGELOG.md` files under `packages/*/` when you 
 
 ## Supported versions
 
-Security fixes target the **latest minor** on npm. See [SECURITY.md](../../SECURITY.md) for the supported-versions table — update that table when cutting a new minor line.
+Security fixes target the **latest minor** on npm. See [SECURITY.md](../../SECURITY.md) for the supported-versions table — update that table when cutting a new minor line. After a security patch ships, follow [Security-incident triage](./security-incident-triage.md) when deciding whether to `npm deprecate` (or rarely unpublish) a bad version.
 
 ## Related docs
 
 - [Publishing](./publishing.md) — first publish, Trusted Publishing, npm commands
+- [Security-incident triage](./security-incident-triage.md) — audit impact class, deprecate vs unpublish
 - [Agent Skill](./agent-skill.md) — skill pack, WIP `internal` flag, skills.sh
 - [.changeset/README.md](../../.changeset/README.md) — quick changeset reference

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   brace-expansion@<5.0.8: 5.0.8
   postcss@<8.5.18: 8.5.18
   js-yaml@5: 5.2.2
+  dompurify: ^3.4.0
 
 importers:
 
@@ -2671,9 +2672,6 @@ packages:
   domhandler@6.0.1:
     resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
     engines: {node: '>=20.19.0'}
-
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
   dompurify@3.4.11:
     resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
@@ -7901,10 +7899,6 @@ snapshots:
     dependencies:
       domelementtype: 3.0.0
 
-  dompurify@3.2.7:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
   dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -9218,7 +9212,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.11
       marked: 14.0.0
 
   mri@1.2.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,3 +26,6 @@ overrides:
   # GHSA-pm4m-ph32-ghv5: vulnerable >=5.0.0 <=5.2.1, patched >=5.2.2.
   # Scope to the 5.x line so js-yaml 3.x/4.x consumers stay on their major.
   js-yaml@5: 5.2.2
+  # Slidev → monaco-editor → dompurify (dev-only presentation tooling).
+  # GHSA-v2wj-7wpq-c8vv / GHSA-h7mw-gpvr-xq4m / GHSA-crv5-9vww-q3g8: patched >=3.4.0.
+  dompurify: ^3.4.0


### PR DESCRIPTION
## Summary
- Force `dompurify` to `^3.4.0` via `pnpm-workspace.yaml` overrides (pnpm 11 home for overrides; clears Slidev → monaco-editor moderate DOMPurify advisories).
- Add maintainer [security-incident triage](docs/developer/security-incident-triage.md): prod vs dev-only impact, prefer patch + `npm deprecate` over unpublish, with pointers from `SECURITY.md`, publishing, and versioning docs.

Closes #163

## Test plan
- [x] `pnpm audit --audit-level=moderate` — no DOMPurify findings (residual: Slidev `@hono/node-server` moderate + 2 low; out of scope)
- [x] `pnpm audit --prod` — clean
- [x] `pnpm docs:check` — passes
- [ ] Optional: `pnpm presentation:serve` / resolve smoke if reviewing presentation tooling


Made with [Cursor](https://cursor.com)