### PR TITLE
docs: Cursor Cloud environment setup and limitations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,11 @@ scripts — use those rather than duplicating them here.
   edit the compiled files. CI fails on `git diff` if they are stale.
 - Node on this VM is v22 (satisfies `engines >=18`); CI uses Node 24. Do not
   switch Node via nvm/`.nvmrc` unless a version-specific issue appears.
-- `gitleaks` is not installed; the pre-commit hook prints a warning and
-  continues (CI runs the real scan).
+- `gitleaks` is a **peer binary** (not an npm dep), installed at
+  `/usr/local/bin/gitleaks` (v8.30.1) and persisted in the VM snapshot; the
+  pre-commit hook runs `gitleaks protect --staged`. If it goes missing,
+  reinstall from the gitleaks GitHub release (`gitleaks_8.30.1_linux_x64.tar.gz`
+  → `/usr/local/bin`), same as Vale. CI runs its own scan via `gitleaks-action`.
 
 ### Cloud-agent limitations & workarounds
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,28 @@ scripts — use those rather than duplicating them here.
 - `gitleaks` is not installed; the pre-commit hook prints a warning and
   continues (CI runs the real scan).
 
+### Cloud-agent limitations & workarounds
+
+Human-facing detail: **Cursor Cloud environment** in `DEVELOPERS.md`
+(compiled from `docs/developer/cursor-cloud-environment.md`). Key constraints
+for agents in this environment:
+
+- `gh` is **read-only** — it cannot create or modify issues or PRs. Use the
+  dedicated PR tooling for PRs and PR comments; a human creates GitHub issues
+  from agent-supplied text (add `Closes #N` afterward).
+- **No GitHub MCP**, and we do not add one in the cloud. MCP servers load at
+  session start, `.cursor/*` (except `environment.json`) is gitignored, and a
+  GitHub PAT in Secrets is not wired to `gh` or any tool — so it does not
+  enable issue creation. Do not rely on it.
+- The agent **cannot merge PRs** or push to protected `main` (a human merges).
+  It may merge one working branch into another locally to unblock CI (for
+  example, a dependency-fix branch into a feature branch).
+- CI runs `pnpm audit --audit-level=high` **before** build/test; a new advisory
+  on a pre-existing devDependency fails it and masks otherwise-green gates. Fix
+  by pinning patched versions via `pnpm-workspace.yaml` `overrides`.
+- Merge commits need a **conventional subject** (`chore: merge …`) or commitlint
+  rejects them.
+
 ### Full verification gate
 
 `pnpm run check` runs typecheck → lint → format:check → build → test →

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -129,10 +129,11 @@ A fresh cloud VM needs the same toolchain as [Local setup](#local-setup), plus a
 
 1. **Startup update script.** `.cursor/environment.json` holds the `install` command that runs on every VM start: it fetches remote refs, then runs `pnpm install`. That committed file is the source of truth and overrides any dashboard-saved environment. Keep it minimal — dependency refresh only, no service startup or build steps.
 2. **Vale peer binary.** Vale is a peer binary, not an npm dependency. Install version 3.15.1 to `/usr/local/bin` (it persists in the VM snapshot); the exact release command is in [`.github/workflows/ci.yml`](.github/workflows/ci.yml). `pnpm docs:check` needs Vale on `PATH`.
-3. **Build before docs or CLI.** `dist/` is gitignored and is not produced by the update script. Run `pnpm build` after a fresh checkout before `pnpm docs:check`, `pnpm docs:compile`, or invoking the `mdcp` CLI.
-4. **Sync Vale styles once.** Run `pnpm vale:sync` before the first `docs:check` on a fresh clone (network required); synced styles then persist in the snapshot.
-5. **Node version.** The VM runs Node 22 (satisfies `engines >=18`); CI uses Node 24. Do not switch Node unless a version-specific issue appears.
-6. **Full gate.** `pnpm check` mirrors CI (typecheck, lint, format, build, test, skill:validate, docs:check).
+3. **gitleaks peer binary.** gitleaks is also a peer binary, not an npm dependency; the pre-commit hook runs `gitleaks protect --staged` when it is on `PATH`. Install version 8.30.1 to `/usr/local/bin` (persists in the VM snapshot). If it goes missing, reinstall from the [gitleaks releases](https://github.com/gitleaks/gitleaks/releases): download `gitleaks_8.30.1_linux_x64.tar.gz` and extract the `gitleaks` binary into `/usr/local/bin` (same pattern as Vale). CI runs its own scan via `gitleaks-action`, so the local install is defense-in-depth.
+4. **Build before docs or CLI.** `dist/` is gitignored and is not produced by the update script. Run `pnpm build` after a fresh checkout before `pnpm docs:check`, `pnpm docs:compile`, or invoking the `mdcp` CLI.
+5. **Sync Vale styles once.** Run `pnpm vale:sync` before the first `docs:check` on a fresh clone (network required); synced styles then persist in the snapshot.
+6. **Node version.** The VM runs Node 22 (satisfies `engines >=18`); CI uses Node 24. Do not switch Node unless a version-specific issue appears.
+7. **Full gate.** `pnpm check` mirrors CI (typecheck, lint, format, build, test, skill:validate, docs:check).
 
 #### Platform limitations and workarounds
 
@@ -147,7 +148,6 @@ These are cloud-agent constraints discovered in practice. Plan work around them 
 | CI runs `pnpm audit --audit-level=high` **before** the build and test gates                     | A new advisory on a pre-existing devDependency fails audit and masks otherwise-green gates. Pin patched versions via `pnpm-workspace.yaml` overrides.   |
 | The pre-commit hook runs `pnpm audit` when dependency manifests change                          | Resolve advisories (overrides) before committing manifest changes, rather than bypassing the hook.                                                      |
 | commitlint rejects non-conventional subjects, including merge commits                           | Give merge commits a conventional subject such as `chore: merge …`, not `merge: …`.                                                                     |
-| `gitleaks` is not installed on the VM                                                           | The pre-commit hook prints a warning and continues; CI runs the real secret scan.                                                                       |
 
 #### Recording issues without issue-creation access
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -115,6 +115,46 @@ CI runs the full gate: `pnpm run check`.
 
 <!-- mdcp-shard: end docs/developer/local-setup.md -->
 
+<!-- mdcp-shard: start docs/developer/cursor-cloud-environment.md -->
+
+### Cursor Cloud environment
+
+How this repository behaves inside Cursor cloud agents: how to stand up a new cloud environment, and the platform limitations to plan around. For the standard local toolchain and daily commands, read [Local setup](#local-setup) — this section only adds cloud-specific setup and constraints.
+
+Durable, machine-facing notes for future agents also live in the repository `AGENTS.md` under "Cursor Cloud specific instructions". Keep the two in sync: this guide is the human-facing explanation; `AGENTS.md` is the short agent checklist.
+
+#### Setting up a new cloud environment
+
+A fresh cloud VM needs the same toolchain as [Local setup](#local-setup), plus a few cloud-specific steps:
+
+1. **Startup update script.** `.cursor/environment.json` holds the `install` command that runs on every VM start: it fetches remote refs, then runs `pnpm install`. That committed file is the source of truth and overrides any dashboard-saved environment. Keep it minimal — dependency refresh only, no service startup or build steps.
+2. **Vale peer binary.** Vale is a peer binary, not an npm dependency. Install version 3.15.1 to `/usr/local/bin` (it persists in the VM snapshot); the exact release command is in [`.github/workflows/ci.yml`](.github/workflows/ci.yml). `pnpm docs:check` needs Vale on `PATH`.
+3. **Build before docs or CLI.** `dist/` is gitignored and is not produced by the update script. Run `pnpm build` after a fresh checkout before `pnpm docs:check`, `pnpm docs:compile`, or invoking the `mdcp` CLI.
+4. **Sync Vale styles once.** Run `pnpm vale:sync` before the first `docs:check` on a fresh clone (network required); synced styles then persist in the snapshot.
+5. **Node version.** The VM runs Node 22 (satisfies `engines >=18`); CI uses Node 24. Do not switch Node unless a version-specific issue appears.
+6. **Full gate.** `pnpm check` mirrors CI (typecheck, lint, format, build, test, skill:validate, docs:check).
+
+#### Platform limitations and workarounds
+
+These are cloud-agent constraints discovered in practice. Plan work around them rather than fighting them.
+
+| Limitation                                                                                      | Workaround                                                                                                                                              |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The `gh` CLI is **read-only** for the agent; it cannot create or modify issues or pull requests | Use the dedicated pull-request tooling for PRs and PR comments. A human creates GitHub issues from agent-supplied text; add `Closes #N` afterward.      |
+| **No GitHub MCP** is available, and we do not add one in the cloud                              | Accept it. MCP servers load at session start and `.cursor/*` (except `environment.json`) is gitignored, so an agent cannot self-enable one mid-run.     |
+| A GitHub **PAT in Secrets is not wired** to `gh` or any agent tool                              | Do not rely on a PAT to unblock issue creation in the cloud; it does not help. Issue creation stays a human step.                                       |
+| The agent **cannot merge PRs** or push to protected `main`                                      | A human merges. The agent may merge one working branch into another locally to unblock CI (for example, a dependency-fix branch into a feature branch). |
+| CI runs `pnpm audit --audit-level=high` **before** the build and test gates                     | A new advisory on a pre-existing devDependency fails audit and masks otherwise-green gates. Pin patched versions via `pnpm-workspace.yaml` overrides.   |
+| The pre-commit hook runs `pnpm audit` when dependency manifests change                          | Resolve advisories (overrides) before committing manifest changes, rather than bypassing the hook.                                                      |
+| commitlint rejects non-conventional subjects, including merge commits                           | Give merge commits a conventional subject such as `chore: merge …`, not `merge: …`.                                                                     |
+| `gitleaks` is not installed on the VM                                                           | The pre-commit hook prints a warning and continues; CI runs the real secret scan.                                                                       |
+
+#### Recording issues without issue-creation access
+
+Because the agent cannot open GitHub issues, capture work items as ready-to-paste issue text (title, body with acceptance criteria, labels, and project fields per [Agent work-item tracking](#agent-work-item-tracking)) inside the pull request that delivers the work. A maintainer creates the issue and links it with `Closes #N`.
+
+<!-- mdcp-shard: end docs/developer/cursor-cloud-environment.md -->
+
 <!-- mdcp-shard: start docs/developer/agent-work-item-tracking.md -->
 
 ## Agent work-item tracking

--- a/docs/developer/cursor-cloud-environment.md
+++ b/docs/developer/cursor-cloud-environment.md
@@ -10,10 +10,11 @@ A fresh cloud VM needs the same toolchain as [Local setup](#local-setup), plus a
 
 1. **Startup update script.** `.cursor/environment.json` holds the `install` command that runs on every VM start: it fetches remote refs, then runs `pnpm install`. That committed file is the source of truth and overrides any dashboard-saved environment. Keep it minimal — dependency refresh only, no service startup or build steps.
 2. **Vale peer binary.** Vale is a peer binary, not an npm dependency. Install version 3.15.1 to `/usr/local/bin` (it persists in the VM snapshot); the exact release command is in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml). `pnpm docs:check` needs Vale on `PATH`.
-3. **Build before docs or CLI.** `dist/` is gitignored and is not produced by the update script. Run `pnpm build` after a fresh checkout before `pnpm docs:check`, `pnpm docs:compile`, or invoking the `mdcp` CLI.
-4. **Sync Vale styles once.** Run `pnpm vale:sync` before the first `docs:check` on a fresh clone (network required); synced styles then persist in the snapshot.
-5. **Node version.** The VM runs Node 22 (satisfies `engines >=18`); CI uses Node 24. Do not switch Node unless a version-specific issue appears.
-6. **Full gate.** `pnpm check` mirrors CI (typecheck, lint, format, build, test, skill:validate, docs:check).
+3. **gitleaks peer binary.** gitleaks is also a peer binary, not an npm dependency; the pre-commit hook runs `gitleaks protect --staged` when it is on `PATH`. Install version 8.30.1 to `/usr/local/bin` (persists in the VM snapshot). If it goes missing, reinstall from the [gitleaks releases](https://github.com/gitleaks/gitleaks/releases): download `gitleaks_8.30.1_linux_x64.tar.gz` and extract the `gitleaks` binary into `/usr/local/bin` (same pattern as Vale). CI runs its own scan via `gitleaks-action`, so the local install is defense-in-depth.
+4. **Build before docs or CLI.** `dist/` is gitignored and is not produced by the update script. Run `pnpm build` after a fresh checkout before `pnpm docs:check`, `pnpm docs:compile`, or invoking the `mdcp` CLI.
+5. **Sync Vale styles once.** Run `pnpm vale:sync` before the first `docs:check` on a fresh clone (network required); synced styles then persist in the snapshot.
+6. **Node version.** The VM runs Node 22 (satisfies `engines >=18`); CI uses Node 24. Do not switch Node unless a version-specific issue appears.
+7. **Full gate.** `pnpm check` mirrors CI (typecheck, lint, format, build, test, skill:validate, docs:check).
 
 ### Platform limitations and workarounds
 
@@ -28,7 +29,6 @@ These are cloud-agent constraints discovered in practice. Plan work around them 
 | CI runs `pnpm audit --audit-level=high` **before** the build and test gates                     | A new advisory on a pre-existing devDependency fails audit and masks otherwise-green gates. Pin patched versions via `pnpm-workspace.yaml` overrides.   |
 | The pre-commit hook runs `pnpm audit` when dependency manifests change                          | Resolve advisories (overrides) before committing manifest changes, rather than bypassing the hook.                                                      |
 | commitlint rejects non-conventional subjects, including merge commits                           | Give merge commits a conventional subject such as `chore: merge …`, not `merge: …`.                                                                     |
-| `gitleaks` is not installed on the VM                                                           | The pre-commit hook prints a warning and continues; CI runs the real secret scan.                                                                       |
 
 ### Recording issues without issue-creation access
 

--- a/docs/developer/cursor-cloud-environment.md
+++ b/docs/developer/cursor-cloud-environment.md
@@ -1,0 +1,35 @@
+## Cursor Cloud environment
+
+How this repository behaves inside Cursor cloud agents: how to stand up a new cloud environment, and the platform limitations to plan around. For the standard local toolchain and daily commands, read [Local setup](#local-setup) — this section only adds cloud-specific setup and constraints.
+
+Durable, machine-facing notes for future agents also live in the repository `AGENTS.md` under "Cursor Cloud specific instructions". Keep the two in sync: this guide is the human-facing explanation; `AGENTS.md` is the short agent checklist.
+
+### Setting up a new cloud environment
+
+A fresh cloud VM needs the same toolchain as [Local setup](#local-setup), plus a few cloud-specific steps:
+
+1. **Startup update script.** `.cursor/environment.json` holds the `install` command that runs on every VM start: it fetches remote refs, then runs `pnpm install`. That committed file is the source of truth and overrides any dashboard-saved environment. Keep it minimal — dependency refresh only, no service startup or build steps.
+2. **Vale peer binary.** Vale is a peer binary, not an npm dependency. Install version 3.15.1 to `/usr/local/bin` (it persists in the VM snapshot); the exact release command is in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml). `pnpm docs:check` needs Vale on `PATH`.
+3. **Build before docs or CLI.** `dist/` is gitignored and is not produced by the update script. Run `pnpm build` after a fresh checkout before `pnpm docs:check`, `pnpm docs:compile`, or invoking the `mdcp` CLI.
+4. **Sync Vale styles once.** Run `pnpm vale:sync` before the first `docs:check` on a fresh clone (network required); synced styles then persist in the snapshot.
+5. **Node version.** The VM runs Node 22 (satisfies `engines >=18`); CI uses Node 24. Do not switch Node unless a version-specific issue appears.
+6. **Full gate.** `pnpm check` mirrors CI (typecheck, lint, format, build, test, skill:validate, docs:check).
+
+### Platform limitations and workarounds
+
+These are cloud-agent constraints discovered in practice. Plan work around them rather than fighting them.
+
+| Limitation                                                                                      | Workaround                                                                                                                                              |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The `gh` CLI is **read-only** for the agent; it cannot create or modify issues or pull requests | Use the dedicated pull-request tooling for PRs and PR comments. A human creates GitHub issues from agent-supplied text; add `Closes #N` afterward.      |
+| **No GitHub MCP** is available, and we do not add one in the cloud                              | Accept it. MCP servers load at session start and `.cursor/*` (except `environment.json`) is gitignored, so an agent cannot self-enable one mid-run.     |
+| A GitHub **PAT in Secrets is not wired** to `gh` or any agent tool                              | Do not rely on a PAT to unblock issue creation in the cloud; it does not help. Issue creation stays a human step.                                       |
+| The agent **cannot merge PRs** or push to protected `main`                                      | A human merges. The agent may merge one working branch into another locally to unblock CI (for example, a dependency-fix branch into a feature branch). |
+| CI runs `pnpm audit --audit-level=high` **before** the build and test gates                     | A new advisory on a pre-existing devDependency fails audit and masks otherwise-green gates. Pin patched versions via `pnpm-workspace.yaml` overrides.   |
+| The pre-commit hook runs `pnpm audit` when dependency manifests change                          | Resolve advisories (overrides) before committing manifest changes, rather than bypassing the hook.                                                      |
+| commitlint rejects non-conventional subjects, including merge commits                           | Give merge commits a conventional subject such as `chore: merge …`, not `merge: …`.                                                                     |
+| `gitleaks` is not installed on the VM                                                           | The pre-commit hook prints a warning and continues; CI runs the real secret scan.                                                                       |
+
+### Recording issues without issue-creation access
+
+Because the agent cannot open GitHub issues, capture work items as ready-to-paste issue text (title, body with acceptance criteria, labels, and project fields per [Agent work-item tracking](#agent-work-item-tracking)) inside the pull request that delivers the work. A maintainer creates the issue and links it with `Closes #N`.

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -4,6 +4,7 @@
   - [About this guide](./about-this-guide.md)
   - [Glossary](../glossary/index.md)
   - [Local setup](./local-setup.md)
+  - [Cursor Cloud environment](./cursor-cloud-environment.md)
   - [Agent work-item tracking](./agent-work-item-tracking.md)
   - [Repository layout](./repository-layout.md)
   - [Packages and tests](./packages-and-tests.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Working in Cursor cloud agents has real constraints (and a specific new-environment setup) that were rediscovered the hard way this session. Capture them as durable dev docs so future contributors/agents can follow the setup and plan around the limits instead of re-deriving them.

## What

New developer-guide shard `docs/developer/cursor-cloud-environment.md` (compiled into `DEVELOPERS.md`, linked from the developer `index.md`):

- **Setting up a new cloud environment** — the `.cursor/environment.json` update script, **Vale** and **gitleaks** as peer binaries (installed to `/usr/local/bin`, persisted in the snapshot), build-before-docs, `pnpm vale:sync` on first run, Node 22 vs CI's 24, and the `pnpm check` gate. References [Local setup] rather than duplicating standard commands.
- **Platform limitations & workarounds** (table): read-only `gh` (no issue/PR creation), **no GitHub MCP and we don't add one in the cloud**, a GitHub PAT in Secrets isn't wired to any tool (doesn't enable issue creation), agent can't merge PRs / push to protected `main`, CI runs `pnpm audit --audit-level=high` before build/test (fix via `pnpm-workspace.yaml` overrides), and commitlint needs conventional merge subjects.
- **Recording issues without issue-creation access** — capture ready-to-paste issue text in the delivering PR; a maintainer opens the issue and links `Closes #N`.

Also updates `AGENTS.md`: mirrors the key agent-facing constraints under "Cloud-agent limitations & workarounds", and moves `gitleaks` from "not installed" to a provisioned peer binary.

## gitleaks now provisioned

Installed **gitleaks 8.30.1** to `/usr/local/bin` (peer binary, same pattern as Vale) so the pre-commit `gitleaks protect --staged` hook runs locally instead of printing a "not installed" warning — verified running in this branch's commit hook. CI continues to run its own scan via `gitleaks-action`. Not added to the update script (system deps stay out of it); persists via the VM snapshot with a documented reinstall command as fallback.

## Notes

Docs-only (no package/skill changes → no changeset). `pnpm docs:check` green; compiled outputs regenerated and in sync.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f0a080d-fa68-4562-9d0f-ac7579ad4eb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f0a080d-fa68-4562-9d0f-ac7579ad4eb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

