### PR TITLE
chore(deps): pin TypeScript to 6.x (ignore major)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
+    # Stay on TypeScript 6 until typescript-eslint / ESLint support TS 7.
+    # Revisit in Q4 2026 — https://github.com/betsalel-williamson/mdcp/issues/169
+    ignore:
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Summary
- Ignore Dependabot major updates for `typescript` so we stay on 6.x until `typescript-eslint` / ESLint support TS 7
- Tracking revisit: https://github.com/betsalel-williamson/mdcp/issues/169
- Related: declined TS 7 in https://github.com/betsalel-williamson/mdcp/pull/167 via `@dependabot ignore typescript major version`

## Test plan
- [ ] Confirm Dependabot closes or recreates #167 without the TypeScript 7 bump
- [ ] Confirm package ranges remain `typescript@^6.0.3` (already latest 6.x)


Made with [Cursor](https://cursor.com)