### PR TITLE
fix: skip changeset check for package.json devDependency-only bumps

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ examples/sample-guides/refs.json
 docs/guides.md
 docs/refs.json
 .agents/
+.worktrees/

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -844,18 +844,19 @@ Run `pnpm changeset` and commit the generated file under `.changeset/` when a PR
 
 - Root `README.md`, `docs/`, `examples/` only (when the PR does **not** change `skills/` or published package sources)
 - CI, Husky, or other tooling that does not change skill packs or npm package behavior
+- `devDependencies` bumps in root or `packages/*/package.json` (including `@types/*`) when no other package fields or sources change
 - Typo fixes in package READMEs with no behavior change (maintainer discretion)
 
-CI on pull requests runs `pnpm changeset:status` to catch missing changesets when **package sources** or **`skills/`** changed.
+CI on pull requests runs `pnpm changeset:status` to catch missing changesets when **package sources** or **`skills/`** changed. Package-level `devDependencies`-only bumps are treated as tooling and do not fail the check.
 
 ### Dependabot
 
-Dependabot does not add changesets. Treat its PRs like any other:
+Dependabot does not add changesets. **Non-dev dependency bumps need a human** — review the PR, add a changeset, then merge. Dev-only bumps should pass CI without one.
 
-| Dependabot PR type                                      | Changeset                                     |
-| ------------------------------------------------------- | --------------------------------------------- |
-| Production dependency bump in `packages/*/package.json` | Add a **patch** changeset before merge        |
-| Root dev-dependencies (grouped) or GitHub Actions only  | No changeset (CI `changeset` job should pass) |
+| Dependabot PR type                                                                         | Changeset / merge gate                                |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| `dependencies`, `peerDependencies`, or `optionalDependencies` in `packages/*/package.json` | **Human approval** + **patch** changeset before merge |
+| `devDependencies` only (root and/or `packages/*/package.json`), or GitHub Actions          | No changeset (CI `changeset` job should pass)         |
 
 ### Bump selection guide
 

--- a/docs/developer/versioning-and-releases.md
+++ b/docs/developer/versioning-and-releases.md
@@ -77,18 +77,19 @@ Run `pnpm changeset` and commit the generated file under `.changeset/` when a PR
 
 - Root `README.md`, `docs/`, `examples/` only (when the PR does **not** change `skills/` or published package sources)
 - CI, Husky, or other tooling that does not change skill packs or npm package behavior
+- `devDependencies` bumps in root or `packages/*/package.json` (including `@types/*`) when no other package fields or sources change
 - Typo fixes in package READMEs with no behavior change (maintainer discretion)
 
-CI on pull requests runs `pnpm changeset:status` to catch missing changesets when **package sources** or **`skills/`** changed.
+CI on pull requests runs `pnpm changeset:status` to catch missing changesets when **package sources** or **`skills/`** changed. Package-level `devDependencies`-only bumps are treated as tooling and do not fail the check.
 
 ## Dependabot
 
-Dependabot does not add changesets. Treat its PRs like any other:
+Dependabot does not add changesets. **Non-dev dependency bumps need a human** — review the PR, add a changeset, then merge. Dev-only bumps should pass CI without one.
 
-| Dependabot PR type                                      | Changeset                                     |
-| ------------------------------------------------------- | --------------------------------------------- |
-| Production dependency bump in `packages/*/package.json` | Add a **patch** changeset before merge        |
-| Root dev-dependencies (grouped) or GitHub Actions only  | No changeset (CI `changeset` job should pass) |
+| Dependabot PR type                                                                         | Changeset / merge gate                                |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| `dependencies`, `peerDependencies`, or `optionalDependencies` in `packages/*/package.json` | **Human approval** + **patch** changeset before merge |
+| `devDependencies` only (root and/or `packages/*/package.json`), or GitHub Actions          | No changeset (CI `changeset` job should pass)         |
 
 ## Bump selection guide
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "pnpm@11.13.0",
   "scripts": {
     "build": "pnpm -r run build",
-    "test": "pnpm -r run test",
+    "test": "pnpm -r run test && node --test scripts/**/*.test.mjs",
     "typecheck": "pnpm -r run typecheck",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/scripts/changeset-status.mjs
+++ b/scripts/changeset-status.mjs
@@ -3,7 +3,10 @@
  * Require a pending changeset when package sources or skills/ changed since base.
  *
  * 1. Runs `changeset status --since=<base>` (packages).
- * 2. If `skills/` changed since base and there is no pending `.changeset/*.md`
+ * 2. If that fails only because packages/<name>/package.json `devDependencies`
+ *    changed (no other package fields/files), skips the package check — tooling
+ *    bumps do not need a release note.
+ * 3. If `skills/` changed since base and there is no pending `.changeset/*.md`
  *    (other than README.md / config.json), fails — unless this PR consumed
  *    changesets (release versioning deleted `.changeset/*.md`).
  *
@@ -16,6 +19,7 @@
 import { spawnSync, execSync } from 'node:child_process';
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { isDevDependencyOnlyPackageChange } from './lib/dev-dep-only-package-changes.mjs';
 
 function tryExec(cmd) {
   try {
@@ -63,6 +67,22 @@ function changesetsConsumed(since) {
   return deleted.split('\n').filter((p) => p.endsWith('.md') && !p.endsWith('README.md')).length;
 }
 
+function readPackageJsonPair(since, path) {
+  const beforeRaw = tryExec(`git show ${since}:${path}`);
+  const afterRaw = tryExec(`git show HEAD:${path}`);
+  if (!beforeRaw || !afterRaw) return null;
+  try {
+    return { before: JSON.parse(beforeRaw), after: JSON.parse(afterRaw) };
+  } catch {
+    return null;
+  }
+}
+
+function onlyDevDependencyPackageChanges(since) {
+  const changed = listChanged(since, 'packages/');
+  return isDevDependencyOnlyPackageChange(changed, (path) => readPackageJsonPair(since, path));
+}
+
 const since = resolveSince();
 console.log(`changeset status --since=${since}`);
 const result = spawnSync('pnpm', ['exec', 'changeset', 'status', `--since=${since}`], {
@@ -75,6 +95,11 @@ if (exitCode !== 0) {
   if (consumed > 0) {
     console.log(
       'Changesets consumed in this PR (release versioning) — skipping package changeset check.',
+    );
+    exitCode = 0;
+  } else if (onlyDevDependencyPackageChanges(since)) {
+    console.log(
+      'Only packages/<name>/package.json devDependencies changed since base — skipping package changeset check.',
     );
     exitCode = 0;
   }

--- a/scripts/lib/dev-dep-only-package-changes.mjs
+++ b/scripts/lib/dev-dep-only-package-changes.mjs
@@ -1,0 +1,52 @@
+/**
+ * Detect whether package changes are limited to packages/<name>/package.json
+ * `devDependencies` (tooling / types). Those do not require a release changeset.
+ */
+
+const PACKAGES_PACKAGE_JSON = /^packages\/[^/]+\/package\.json$/;
+
+/** @param {string} path */
+export function isPackagesPackageJsonPath(path) {
+  return PACKAGES_PACKAGE_JSON.test(path);
+}
+
+/**
+ * @param {Record<string, unknown>} pkg
+ * @returns {Record<string, unknown>}
+ */
+function withoutDevDependencies(pkg) {
+  const rest = { ...pkg };
+  delete rest.devDependencies;
+  return rest;
+}
+
+/**
+ * True when every non-`devDependencies` field is deeply equal.
+ * Identical objects (including unchanged `devDependencies`) also return true —
+ * a no-op / formatting-only touch is still “dev-dep only” for skip purposes.
+ *
+ * @param {Record<string, unknown>} before
+ * @param {Record<string, unknown>} after
+ */
+export function onlyDevDependenciesDiffer(before, after) {
+  return (
+    JSON.stringify(withoutDevDependencies(before)) === JSON.stringify(withoutDevDependencies(after))
+  );
+}
+
+/**
+ * @param {string[]} changedPaths paths under packages/ (repo-relative)
+ * @param {(path: string) => { before: Record<string, unknown>, after: Record<string, unknown> } | null} readPair
+ */
+export function isDevDependencyOnlyPackageChange(changedPaths, readPair) {
+  if (changedPaths.length === 0) return false;
+
+  for (const path of changedPaths) {
+    if (!isPackagesPackageJsonPath(path)) return false;
+    const pair = readPair(path);
+    if (!pair) return false;
+    if (!onlyDevDependenciesDiffer(pair.before, pair.after)) return false;
+  }
+
+  return true;
+}

--- a/scripts/lib/dev-dep-only-package-changes.test.mjs
+++ b/scripts/lib/dev-dep-only-package-changes.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  isPackagesPackageJsonPath,
+  onlyDevDependenciesDiffer,
+  isDevDependencyOnlyPackageChange,
+} from './dev-dep-only-package-changes.mjs';
+
+describe('isPackagesPackageJsonPath', () => {
+  it('accepts packages/<name>/package.json', () => {
+    assert.equal(isPackagesPackageJsonPath('packages/mdcp-core/package.json'), true);
+    assert.equal(isPackagesPackageJsonPath('packages/mdcp-cli/package.json'), true);
+  });
+
+  it('rejects other paths', () => {
+    assert.equal(isPackagesPackageJsonPath('package.json'), false);
+    assert.equal(isPackagesPackageJsonPath('packages/mdcp-core/src/index.ts'), false);
+    assert.equal(isPackagesPackageJsonPath('packages/mdcp-core/README.md'), false);
+    assert.equal(isPackagesPackageJsonPath('packages/nested/pkg/package.json'), false);
+  });
+});
+
+describe('onlyDevDependenciesDiffer', () => {
+  const base = {
+    name: '@bwilliamson/mdcp-core',
+    version: '0.6.1',
+    dependencies: { zod: '^4.4.3' },
+    devDependencies: { '@types/node': '^25.9.3' },
+  };
+
+  it('returns true when only devDependencies change', () => {
+    const next = {
+      ...base,
+      devDependencies: { '@types/node': '^26.1.1' },
+    };
+    assert.equal(onlyDevDependenciesDiffer(base, next), true);
+  });
+
+  it('returns false when dependencies change', () => {
+    const next = {
+      ...base,
+      dependencies: { zod: '^4.5.0' },
+      devDependencies: { '@types/node': '^26.1.1' },
+    };
+    assert.equal(onlyDevDependenciesDiffer(base, next), false);
+  });
+
+  it('returns false when peerDependencies change', () => {
+    const before = { ...base, peerDependencies: { typescript: '^5' } };
+    const next = { ...before, peerDependencies: { typescript: '^6' } };
+    assert.equal(onlyDevDependenciesDiffer(before, next), false);
+  });
+
+  it('returns false when optionalDependencies change', () => {
+    const before = { ...base, optionalDependencies: { fsevents: '^2.3.0' } };
+    const next = { ...before, optionalDependencies: { fsevents: '^2.3.3' } };
+    assert.equal(onlyDevDependenciesDiffer(before, next), false);
+  });
+
+  it('returns false when non-dependency fields change', () => {
+    const next = { ...base, version: '0.6.2' };
+    assert.equal(onlyDevDependenciesDiffer(base, next), false);
+  });
+
+  it('returns true when packages are identical (formatting-only / no-op)', () => {
+    assert.equal(onlyDevDependenciesDiffer(base, { ...base }), true);
+  });
+});
+
+describe('isDevDependencyOnlyPackageChange', () => {
+  const pkgs = {
+    'packages/mdcp-core/package.json': {
+      before: {
+        name: '@bwilliamson/mdcp-core',
+        dependencies: { zod: '^4.4.3' },
+        devDependencies: { '@types/node': '^25.9.3' },
+      },
+      after: {
+        name: '@bwilliamson/mdcp-core',
+        dependencies: { zod: '^4.4.3' },
+        devDependencies: { '@types/node': '^26.1.1' },
+      },
+    },
+    'packages/mdcp-cli/package.json': {
+      before: {
+        name: '@bwilliamson/mdcp-cli',
+        dependencies: { commander: '^15.0.0' },
+        devDependencies: { '@types/node': '^25.9.3' },
+      },
+      after: {
+        name: '@bwilliamson/mdcp-cli',
+        dependencies: { commander: '^15.0.0' },
+        devDependencies: { '@types/node': '^26.1.1' },
+      },
+    },
+  };
+
+  function readPair(path) {
+    return pkgs[path] ?? null;
+  }
+
+  it('returns true for package.json-only devDependency bumps', () => {
+    assert.equal(
+      isDevDependencyOnlyPackageChange(
+        ['packages/mdcp-core/package.json', 'packages/mdcp-cli/package.json'],
+        readPair,
+      ),
+      true,
+    );
+  });
+
+  it('returns false when a non-package.json file under packages/ changed', () => {
+    assert.equal(
+      isDevDependencyOnlyPackageChange(
+        ['packages/mdcp-core/package.json', 'packages/mdcp-core/src/index.ts'],
+        readPair,
+      ),
+      false,
+    );
+  });
+
+  it('returns false when a production dependency changed', () => {
+    const read = (path) => {
+      if (path === 'packages/mdcp-core/package.json') {
+        return {
+          before: pkgs['packages/mdcp-core/package.json'].before,
+          after: {
+            ...pkgs['packages/mdcp-core/package.json'].after,
+            dependencies: { zod: '^4.5.0' },
+          },
+        };
+      }
+      return readPair(path);
+    };
+    assert.equal(
+      isDevDependencyOnlyPackageChange(['packages/mdcp-core/package.json'], read),
+      false,
+    );
+  });
+
+  it('returns false when package.json is missing at base or head', () => {
+    assert.equal(
+      isDevDependencyOnlyPackageChange(['packages/mdcp-core/package.json'], () => null),
+      false,
+    );
+  });
+
+  it('returns false for an empty change list', () => {
+    assert.equal(isDevDependencyOnlyPackageChange([], readPair), false);
+  });
+});


### PR DESCRIPTION
## Summary
- Allow CI `changeset:status` to pass when the only `packages/` changes are `packages/<name>/package.json` files whose diff is limited to `devDependencies` (covers Dependabot grouped bumps like `@types/node` on [#172](https://github.com/betsalel-williamson/mdcp/pull/172)).
- Document that Dependabot non-dev package dependency bumps need **human approval** plus a **patch** changeset; dev-only / Actions bumps need none.
- Add unit tests for the skip helpers and wire them into root `pnpm test`.

## Test plan
- [ ] `node --test scripts/lib/dev-dep-only-package-changes.test.mjs` passes
- [ ] `pnpm test` includes the new script tests
- [ ] After merge to `main`, rebase [#172](https://github.com/betsalel-williamson/mdcp/pull/172) (`@dependabot rebase`) and confirm the `changeset` job passes without adding a changeset
- [ ] Sanity: a PR that bumps `dependencies` / `peerDependencies` / `optionalDependencies` in `packages/*/package.json` still fails `changeset` without a changeset


Made with [Cursor](https://cursor.com)