### PR TITLE
fix(ci): add 7-day Dependabot cooldown for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
       interval: weekly
     labels:
       - dependencies
+    cooldown:
+      default-days: 7

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1238,7 +1238,7 @@ This checklist tracks our compliance with the [OWASP GitHub Actions Security Che
 | Branch protection baseline              | `reviewed (2026-07-27)`                                                      | Main branch protected with PR and status checks.                                     |
 | Require approval for external           | `open risk ([#182](https://github.com/betsalel-williamson/mdcp/issues/182))` | Missing CODEOWNERS and approval requirement.                                         |
 | Dependabot for Actions                  | `reviewed (2026-07-27)`                                                      | Configured for weekly updates.                                                       |
-| Dependabot cooldown                     | `open risk ([#181](https://github.com/betsalel-williamson/mdcp/issues/181))` | Missing cooldown period for actions ecosystem.                                       |
+| Dependabot cooldown                     | `reviewed (2026-07-27)`                                                      | Explicit 7-day cooldown on `github-actions`.                                         |
 | Artifact / cache poisoning              | `open risk ([#183](https://github.com/betsalel-williamson/mdcp/issues/183))` | `release.yml` uses `cache: pnpm` on the publish path.                                |
 | Secret scanning                         | `reviewed (2026-07-27)`                                                      | Gitleaks workflow is active.                                                         |
 | Static analysis (CodeQL/Zizmor)         | `open risk ([#174](https://github.com/betsalel-williamson/mdcp/issues/174))` | Missing workflow and code scanning.                                                  |

--- a/docs/developer/github-actions-security-checklist.md
+++ b/docs/developer/github-actions-security-checklist.md
@@ -33,7 +33,7 @@ This checklist tracks our compliance with the [OWASP GitHub Actions Security Che
 | Branch protection baseline              | `reviewed (2026-07-27)`                                                      | Main branch protected with PR and status checks.                                     |
 | Require approval for external           | `open risk ([#182](https://github.com/betsalel-williamson/mdcp/issues/182))` | Missing CODEOWNERS and approval requirement.                                         |
 | Dependabot for Actions                  | `reviewed (2026-07-27)`                                                      | Configured for weekly updates.                                                       |
-| Dependabot cooldown                     | `open risk ([#181](https://github.com/betsalel-williamson/mdcp/issues/181))` | Missing cooldown period for actions ecosystem.                                       |
+| Dependabot cooldown                     | `reviewed (2026-07-27)`                                                      | `github-actions` ecosystem uses explicit 7-day cooldown (stricter than 3-day default). |
 | Artifact / cache poisoning              | `open risk ([#183](https://github.com/betsalel-williamson/mdcp/issues/183))` | `release.yml` uses `cache: pnpm` on the publish path.                                |
 | Secret scanning                         | `reviewed (2026-07-27)`                                                      | Gitleaks workflow is active.                                                         |
 | Static analysis (CodeQL/Zizmor)         | `open risk ([#174](https://github.com/betsalel-williamson/mdcp/issues/174))` | Missing workflow and code scanning.                                                  |

--- a/docs/developer/github-actions-security-checklist.md
+++ b/docs/developer/github-actions-security-checklist.md
@@ -33,7 +33,7 @@ This checklist tracks our compliance with the [OWASP GitHub Actions Security Che
 | Branch protection baseline              | `reviewed (2026-07-27)`                                                      | Main branch protected with PR and status checks.                                     |
 | Require approval for external           | `open risk ([#182](https://github.com/betsalel-williamson/mdcp/issues/182))` | Missing CODEOWNERS and approval requirement.                                         |
 | Dependabot for Actions                  | `reviewed (2026-07-27)`                                                      | Configured for weekly updates.                                                       |
-| Dependabot cooldown                     | `reviewed (2026-07-27)`                                                      | `github-actions` ecosystem uses explicit 7-day cooldown (stricter than 3-day default). |
+| Dependabot cooldown                     | `reviewed (2026-07-27)`                                                      | Explicit 7-day cooldown on `github-actions`.                                         |
 | Artifact / cache poisoning              | `open risk ([#183](https://github.com/betsalel-williamson/mdcp/issues/183))` | `release.yml` uses `cache: pnpm` on the publish path.                                |
 | Secret scanning                         | `reviewed (2026-07-27)`                                                      | Gitleaks workflow is active.                                                         |
 | Static analysis (CodeQL/Zizmor)         | `open risk ([#174](https://github.com/betsalel-williamson/mdcp/issues/174))` | Missing workflow and code scanning.                                                  |


### PR DESCRIPTION
## Summary
- Add explicit `cooldown.default-days: 7` to the `github-actions` ecosystem in `.github/dependabot.yml` (stricter than the platform 3-day default).
- Mark the OWASP checklist "Dependabot cooldown" row as reviewed.

Closes #181
Parent: #173

## Test plan
- [x] Verified `dependabot.yml` syntax matches GitHub docs for `cooldown.default-days`.
- [x] Checklist row updated to `reviewed (2026-07-27)` with note.
- [ ] Dependabot validates config on merge (no local validator in repo).


Made with [Cursor](https://cursor.com)