### PR TITLE
fix(ci): remove pnpm cache from release workflow (#183)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
       - run: npm install -g npm@latest
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1279,7 +1279,7 @@ This checklist tracks our compliance with the [OWASP GitHub Actions Security Che
 | Require approval for external           | `reviewed (2026-07-27)`                                                      | CODEOWNERS added; require-code-owner reviews are maintainer ops.                     |
 | Dependabot for Actions                  | `reviewed (2026-07-27)`                                                      | Configured for weekly updates.                                                       |
 | Dependabot cooldown                     | `reviewed (2026-07-27)`                                                      | Explicit 7-day cooldown on `github-actions`.                                         |
-| Artifact / cache poisoning              | `open risk ([#183](https://github.com/betsalel-williamson/mdcp/issues/183))` | `release.yml` uses `cache: pnpm` on the publish path.                                |
+| Artifact / cache poisoning              | `reviewed (2026-07-27)`                                                      | Removed `cache: pnpm` from `release.yml`; CI jobs still cache.                       |
 | Secret scanning                         | `reviewed (2026-07-27)`                                                      | Gitleaks workflow is active.                                                         |
 | Static analysis (CodeQL/Zizmor)         | `open risk ([#174](https://github.com/betsalel-williamson/mdcp/issues/174))` | Missing workflow and code scanning.                                                  |
 | AI-in-CI                                | `not a concern (2026-07-27)`                                                 | No AI assistants used in CI.                                                         |

--- a/docs/developer/github-actions-security-checklist.md
+++ b/docs/developer/github-actions-security-checklist.md
@@ -34,7 +34,7 @@ This checklist tracks our compliance with the [OWASP GitHub Actions Security Che
 | Require approval for external           | `reviewed (2026-07-27)`                                                      | CODEOWNERS added; require-code-owner reviews are maintainer ops.                     |
 | Dependabot for Actions                  | `reviewed (2026-07-27)`                                                      | Configured for weekly updates.                                                       |
 | Dependabot cooldown                     | `reviewed (2026-07-27)`                                                      | Explicit 7-day cooldown on `github-actions`.                                         |
-| Artifact / cache poisoning              | `open risk ([#183](https://github.com/betsalel-williamson/mdcp/issues/183))` | `release.yml` uses `cache: pnpm` on the publish path.                                |
+| Artifact / cache poisoning              | `reviewed (2026-07-27)`                                                      | Removed `cache: pnpm` from `release.yml`; CI jobs still cache.                       |
 | Secret scanning                         | `reviewed (2026-07-27)`                                                      | Gitleaks workflow is active.                                                         |
 | Static analysis (CodeQL/Zizmor)         | `open risk ([#174](https://github.com/betsalel-williamson/mdcp/issues/174))` | Missing workflow and code scanning.                                                  |
 | AI-in-CI                                | `not a concern (2026-07-27)`                                                 | No AI assistants used in CI.                                                         |


### PR DESCRIPTION
## Summary

- Remove `cache: pnpm` from `actions/setup-node` in `.github/workflows/release.yml` only
- CI jobs in `ci.yml` retain pnpm caching for faster builds
- Mark "Artifact / cache poisoning" checklist row as reviewed

Closes #183
Parent: #173

## Test plan

- [x] `pnpm build` and `pnpm docs:compile:repo` pass locally
- [ ] Release workflow runs cleanly on next tag (no cache restore step on publish path)


Made with [Cursor](https://cursor.com)