### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs (#175)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: pnpm
@@ -58,14 +58,14 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: gitleaks/gitleaks-action@v3
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
 
@@ -54,7 +54,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           generate_release_notes: true
           tag_name: ${{ github.ref_name }}

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1261,7 +1261,7 @@ This checklist tracks our compliance with the [OWASP GitHub Actions Security Che
 | Secrets: inherit                        | `not a concern (2026-07-27)`                                                 | Not used.                                                                            |
 | Mask sensitive data                     | `reviewed (2026-07-27)`                                                      | GitHub auto-masks secrets; gitleaks enforces pre-merge scanning.                     |
 | **Workflows & Execution**               |                                                                              |                                                                                      |
-| Pin actions to commit SHA               | `open risk ([#175](https://github.com/betsalel-williamson/mdcp/issues/175))` | Currently using mutable tags (`@v7`, etc.).                                          |
+| Pin actions to commit SHA               | `reviewed (2026-07-27)`                                                      | All third-party actions pinned to full commit SHAs with tag comments in workflows.   |
 | Third-party actions caution             | `reviewed (2026-07-27)`                                                      | Documented current set.                                                              |
 | Sanitize untrusted context / input      | `reviewed (2026-07-27)`                                                      | Workflow contexts passed via env vars; no PR title/body in `run:` blocks.            |
 | `pull_request_target` trigger           | `not a concern (2026-07-27)`                                                 | Not used.                                                                            |

--- a/docs/developer/github-actions-security-checklist.md
+++ b/docs/developer/github-actions-security-checklist.md
@@ -16,7 +16,7 @@ This checklist tracks our compliance with the [OWASP GitHub Actions Security Che
 | Secrets: inherit                        | `not a concern (2026-07-27)`                                                 | Not used.                                                                            |
 | Mask sensitive data                     | `reviewed (2026-07-27)`                                                      | GitHub auto-masks secrets; gitleaks enforces pre-merge scanning.                     |
 | **Workflows & Execution**               |                                                                              |                                                                                      |
-| Pin actions to commit SHA               | `open risk ([#175](https://github.com/betsalel-williamson/mdcp/issues/175))` | Currently using mutable tags (`@v7`, etc.).                                          |
+| Pin actions to commit SHA               | `reviewed (2026-07-27)`                                                      | All third-party actions pinned to full commit SHAs with tag comments in workflows.   |
 | Third-party actions caution             | `reviewed (2026-07-27)`                                                      | Documented current set.                                                              |
 | Sanitize untrusted context / input      | `reviewed (2026-07-27)`                                                      | Workflow contexts passed via env vars; no PR title/body in `run:` blocks.            |
 | `pull_request_target` trigger           | `not a concern (2026-07-27)`                                                 | Not used.                                                                            |


### PR DESCRIPTION
## Summary

- Pin all third-party GitHub Actions in `.github/workflows/*.yml` to full commit SHAs with trailing tag comments (e.g. `# v7`).
- Update OWASP checklist row "Pin actions to commit SHA" to `reviewed (2026-07-27)`.

## Pinned actions

| Action | Tag | Commit SHA |
| --- | --- | --- |
| `actions/checkout` | v7 | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| `pnpm/action-setup` | v6 | `0ebf47130e4866e96fce0953f49152a61190b271` |
| `actions/setup-node` | v7 | `820762786026740c76f36085b0efc47a31fe5020` |
| `softprops/action-gh-release` | v3 | `3d0d9888cb7fd7b750713d6e236d1fcb99157228` |
| `gitleaks/gitleaks-action` | v3 | `e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e` |

SHAs resolved via GitHub API for the tags previously in use.

## Dependabot

The existing `github-actions` Dependabot ecosystem should keep these SHA pins updated when upstream tags move.

## Test plan

- [ ] CI passes on this PR (workflows still resolve pinned actions correctly)

Closes #175

Parent: #173

Made with [Cursor](https://cursor.com)