### PR TITLE
fix(ci): set workflow permissions to empty with job grants (#177)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,13 @@ on:
     # Any target branch (stacked feature PRs, not only main).
     # Changeset checks use github.event.pull_request.base.sha — never a hardcoded branch name.
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       # Harden-Runner: audit mode only — logs egress; block mode is follow-up (#179).
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -52,6 +56,8 @@ jobs:
   changeset:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
     steps:
       # Harden-Runner: audit mode only — logs egress; block mode is follow-up (#179).
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       # Harden-Runner: audit mode only — logs egress; block mode is follow-up (#179).
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -5,9 +5,14 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       # Harden-Runner: audit mode only — logs egress; block mode is follow-up (#179).
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,14 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       # Harden-Runner: audit mode only — logs egress; block mode is follow-up (#179).
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1253,7 +1253,7 @@ This checklist tracks our compliance with the [OWASP GitHub Actions Security Che
 | Treat CI/CD as critical production code | `reviewed (2026-07-27)`                                                      | Security posture docs, full `pnpm run check` gate, and checklist tracked under #173. |
 | **Authentication & Authorization**      |                                                                              |                                                                                      |
 | Default `GITHUB_TOKEN` permissions      | `reviewed (2026-07-27)`                                                      | Repo default is read-only.                                                           |
-| Workflow-level `permissions: {}`        | `open risk ([#177](https://github.com/betsalel-williamson/mdcp/issues/177))` | Missing on `ci.yml` and `gitleaks.yml`.                                              |
+| Workflow-level `permissions: {}`        | `reviewed (2026-07-27)`                                                      | Empty top-level on ci/gitleaks/release; job-scoped writes.                           |
 | `persist-credentials: false`            | `reviewed (2026-07-27)`                                                      | Set on all `actions/checkout` steps.                                                 |
 | Eliminate static credentials            | `reviewed (2026-07-27)`                                                      | No PATs or static cloud keys; npm publish uses OIDC Trusted Publishing.              |
 | OIDC for cloud providers                | `reviewed (2026-07-27)`                                                      | Used for npm Trusted Publishing.                                                     |

--- a/docs/developer/github-actions-security-checklist.md
+++ b/docs/developer/github-actions-security-checklist.md
@@ -8,7 +8,7 @@ This checklist tracks our compliance with the [OWASP GitHub Actions Security Che
 | Treat CI/CD as critical production code | `reviewed (2026-07-27)`                                                      | Security posture docs, full `pnpm run check` gate, and checklist tracked under #173. |
 | **Authentication & Authorization**      |                                                                              |                                                                                      |
 | Default `GITHUB_TOKEN` permissions      | `reviewed (2026-07-27)`                                                      | Repo default is read-only.                                                           |
-| Workflow-level `permissions: {}`        | `open risk ([#177](https://github.com/betsalel-williamson/mdcp/issues/177))` | Missing on `ci.yml` and `gitleaks.yml`.                                              |
+| Workflow-level `permissions: {}`        | `reviewed (2026-07-27)`                                                      | Empty top-level on ci/gitleaks/release; job-scoped writes.                           |
 | `persist-credentials: false`            | `reviewed (2026-07-27)`                                                      | Set on all `actions/checkout` steps.                                                 |
 | Eliminate static credentials            | `reviewed (2026-07-27)`                                                      | No PATs or static cloud keys; npm publish uses OIDC Trusted Publishing.              |
 | OIDC for cloud providers                | `reviewed (2026-07-27)`                                                      | Used for npm Trusted Publishing.                                                     |


### PR DESCRIPTION
## Summary

- Add `permissions: {}` at workflow level in `ci.yml` and `gitleaks.yml` per OWASP least-privilege guidance.
- Grant job-level permissions: `contents: read` for CI check/changeset and gitleaks scan; `pull-requests: write` on gitleaks so PR scan comments still work.
- Mark checklist row "Workflow-level permissions: {}" as reviewed.

Closes #177

Parent: #173

## Test plan

- [ ] CI workflow runs on this PR (check + changeset jobs)
- [ ] Gitleaks workflow runs on this PR
- [ ] No permission errors in workflow logs


Made with [Cursor](https://cursor.com)