### PR TITLE
fix(ci): clear remaining pedantic zizmor findings (#174)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: weekly
     labels:
       - dependencies
+    cooldown:
+      default-days: 7
     groups:
       dev-dependencies:
         dependency-type: development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,15 @@ on:
     # Any target branch (stacked feature PRs, not only main).
     # Changeset checks use github.event.pull_request.base.sha — never a hardcoded branch name.
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
   check:
+    name: Check
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -54,6 +59,7 @@ jobs:
         run: git diff --exit-code
 
   changeset:
+    name: Changeset
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,11 +27,11 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f081e69141f6ea0aa740920b0c7012cd81a4fbe6 # v3.37.3
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f081e69141f6ea0aa740920b0c7012cd81a4fbe6 # v3.37.3
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
         with:
           category: '/language:javascript-typescript'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     # Any target branch (stacked feature PRs, not only main).
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -13,7 +17,7 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
+      security-events: write # Upload CodeQL SARIF results
       contents: read
 
     steps:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -5,10 +5,15 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
   scan:
+    name: Scan
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,19 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
   publish:
+    name: Publish
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
+      contents: write # Create GitHub Release for the tag
+      id-token: write # npm OIDC Trusted Publishing
     steps:
       # Harden-Runner: audit mode only — logs egress; block mode is follow-up (#179).
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1285,7 +1285,7 @@ This checklist tracks our compliance with the [OWASP GitHub Actions Security Che
 | Branch protection baseline              | `reviewed (2026-07-27)`                                                      | Main branch protected with PR and status checks.                                     |
 | Require approval for external           | `reviewed (2026-07-27)`                                                      | CODEOWNERS added; require-code-owner reviews are maintainer ops.                     |
 | Dependabot for Actions                  | `reviewed (2026-07-27)`                                                      | Configured for weekly updates.                                                       |
-| Dependabot cooldown                     | `reviewed (2026-07-27)`                                                      | Explicit 7-day cooldown on `github-actions`.                                         |
+| Dependabot cooldown                     | `reviewed (2026-07-27)`                                                      | Explicit 7-day cooldown on `npm` and `github-actions`.                               |
 | Artifact / cache poisoning              | `reviewed (2026-07-27)`                                                      | Removed `cache: pnpm` from `release.yml`; CI jobs still cache.                       |
 | Secret scanning                         | `reviewed (2026-07-27)`                                                      | Gitleaks workflow is active.                                                         |
 | Static analysis (CodeQL/Zizmor)         | `reviewed (2026-07-27)`                                                      | CodeQL + Zizmor workflows; Zizmor fails the job on findings.                         |

--- a/docs/developer/github-actions-security-checklist.md
+++ b/docs/developer/github-actions-security-checklist.md
@@ -33,7 +33,7 @@ This checklist tracks our compliance with the [OWASP GitHub Actions Security Che
 | Branch protection baseline              | `reviewed (2026-07-27)`                                                      | Main branch protected with PR and status checks.                                     |
 | Require approval for external           | `reviewed (2026-07-27)`                                                      | CODEOWNERS added; require-code-owner reviews are maintainer ops.                     |
 | Dependabot for Actions                  | `reviewed (2026-07-27)`                                                      | Configured for weekly updates.                                                       |
-| Dependabot cooldown                     | `reviewed (2026-07-27)`                                                      | Explicit 7-day cooldown on `github-actions`.                                         |
+| Dependabot cooldown                     | `reviewed (2026-07-27)`                                                      | Explicit 7-day cooldown on `npm` and `github-actions`.                               |
 | Artifact / cache poisoning              | `reviewed (2026-07-27)`                                                      | Removed `cache: pnpm` from `release.yml`; CI jobs still cache.                       |
 | Secret scanning                         | `reviewed (2026-07-27)`                                                      | Gitleaks workflow is active.                                                         |
 | Static analysis (CodeQL/Zizmor)         | `reviewed (2026-07-27)`                                                      | CodeQL + Zizmor workflows; Zizmor fails the job on findings.                         |


### PR DESCRIPTION
## Summary
- Clear remaining pedantic Zizmor findings and the online CI failures they exposed on this stacked branch.
- Add workflow concurrency, job display names, and permission comments.
- Pin CodeQL actions to the peeled `v3.37.3` commit; add npm Dependabot 7-day cooldown.

Closes nothing (parent PR #187 closes #174).

## Finding → fix trail
See the PR comment: **Zizmor finding → fix trail (this PR)** for the full table (what / why / fix) covering `29efd4e` and `8b6a1c6`. Parent baseline remediations are on #187 / #194.

## Test plan
- [x] `zizmor -o --pedantic --collect=all .github/workflows .github/dependabot.yml` → no findings
- [x] Zizmor CI job green after online pin/cooldown fixes
- [ ] Remaining CI (Check / CodeQL Analyze) green on latest push
