### PR TITLE
fix(core): walk up for repository .gitignore in coverage scan

### DIFF
--- a/.changeset/coverage-walk-up-gitignore.md
+++ b/.changeset/coverage-walk-up-gitignore.md
@@ -1,0 +1,6 @@
+---
+'@bwilliamson/mdcp-core': patch
+'@bwilliamson/mdcp-cli': patch
+---
+
+Fix coverage scan to walk up from `scan.root` and honor an ancestor repository `.gitignore` (so nested docs roots skip gitignored paths like `.caches/`).

--- a/.changeset/coverage-walk-up-gitignore.md
+++ b/.changeset/coverage-walk-up-gitignore.md
@@ -3,4 +3,4 @@
 '@bwilliamson/mdcp-cli': patch
 ---
 
-Fix coverage scan to walk up from `scan.root` and honor an ancestor repository `.gitignore` (so nested docs roots skip gitignored paths like `.caches/`).
+Fix coverage scan to honor the repository-root `.gitignore` when `scan.root` is nested inside a git working tree (bounded by `.git`), and never climb parent directories for `.gitignore` when not inside git.

--- a/docs/features/coverage-scan.md
+++ b/docs/features/coverage-scan.md
@@ -45,7 +45,7 @@ A standalone guide is register-only:
 
 ## What the scan skips
 
-The scan honors the repository `.gitignore` by default, so paths already excluded from version control (for example `node_modules`, `dist`, `build`, `_build`, `.caches`, `coverage`) are skipped with no extra config. When `scan.root` is nested below the repository root, the scan walks up from that root until it finds a `.gitignore` (or hits a `.git` directory / filesystem root). A small built-in default always skips `.git`, `node_modules`, and `.agents`, even when `.gitignore` does not list them.
+The scan honors the repository `.gitignore` by default, so paths already excluded from version control (for example `node_modules`, `dist`, `build`, `_build`, `.caches`, `coverage`) are skipped with no extra config. When `scan.root` is nested below the repository root, the scan locates the enclosing git working tree (a `.git` entry) and applies that repository's `.gitignore` — it never climbs past the git root. If `scan.root` is not inside a git working tree, only a `.gitignore` at `scan.root` itself is honored (parent directories are not searched). A small built-in default always skips `.git`, `node_modules`, and `.agents`, even when `.gitignore` does not list them.
 
 `scan.ignore` extends what is skipped, `scan.gitignore: false` turns off `.gitignore` honoring, and `scan.root` overrides the walk root (default: the invocation directory).
 
@@ -88,13 +88,13 @@ The orphan check stays a hard error because a shard in a guide directory is clea
 }
 ```
 
-| Knob               | Default                                    | Role                                                            |
-| ------------------ | ------------------------------------------ | --------------------------------------------------------------- |
-| `standaloneGuides` | `[]`                                       | Files or globs registered as standalone (captured)              |
-| `scan.gitignore`   | `true`                                     | Honor nearest ancestor `.gitignore` (walks up from `scan.root`) |
-| `scan.ignore`      | built-in `.git`, `node_modules`, `.agents` | Extra directories or globs to skip                              |
-| `scan.root`        | invocation directory                       | Root the scan walks for markdown files                          |
-| `scan.strict`      | `false`                                    | Fail `mdcp check` on coverage gaps                              |
+| Knob               | Default                                    | Role                                                              |
+| ------------------ | ------------------------------------------ | ----------------------------------------------------------------- |
+| `standaloneGuides` | `[]`                                       | Files or globs registered as standalone (captured)                |
+| `scan.gitignore`   | `true`                                     | Honor repo-root `.gitignore` inside git; scan-root only otherwise |
+| `scan.ignore`      | built-in `.git`, `node_modules`, `.agents` | Extra directories or globs to skip                                |
+| `scan.root`        | invocation directory                       | Root the scan walks for markdown files                            |
+| `scan.strict`      | `false`                                    | Fail `mdcp check` on coverage gaps                                |
 
 ## Coverage scan acceptance criteria
 
@@ -103,7 +103,7 @@ The orphan check stays a hard error because a shard in a guide directory is clea
 - A guide output target (`compile.outputFile` and top-level `outputFile`) is captured.
 - A `standaloneGuides[]` entry is captured, including glob matches.
 - A markdown file outside every guide and outside `standaloneGuides[]` is reported as uncaptured.
-- The scan honors `.gitignore` by default (walking up from `scan.root` to the repository `.gitignore`); `scan.gitignore: false` disables it.
+- The scan honors `.gitignore` by default (repo-root `.gitignore` when inside a git working tree; `scan.root` `.gitignore` only when not); `scan.gitignore: false` disables it.
 - Built-in defaults (`.git`, `node_modules`, `.agents`) are always skipped; `scan.ignore` extends them.
 - A `standaloneGuides[]` entry matching no file is reported as missing.
 - `mdcp check` prints uncaptured and missing-standalone paths; with `scan.strict: true` those gaps fail the gate.

--- a/docs/features/coverage-scan.md
+++ b/docs/features/coverage-scan.md
@@ -45,7 +45,7 @@ A standalone guide is register-only:
 
 ## What the scan skips
 
-The scan honors the repository `.gitignore` by default, so paths already excluded from version control (for example `node_modules`, `dist`, `build`, `_build`, `.caches`, `coverage`) are skipped with no extra config. A small built-in default always skips `.git`, `node_modules`, and `.agents`, even when `.gitignore` does not list them.
+The scan honors the repository `.gitignore` by default, so paths already excluded from version control (for example `node_modules`, `dist`, `build`, `_build`, `.caches`, `coverage`) are skipped with no extra config. When `scan.root` is nested below the repository root, the scan walks up from that root until it finds a `.gitignore` (or hits a `.git` directory / filesystem root). A small built-in default always skips `.git`, `node_modules`, and `.agents`, even when `.gitignore` does not list them.
 
 `scan.ignore` extends what is skipped, `scan.gitignore: false` turns off `.gitignore` honoring, and `scan.root` overrides the walk root (default: the invocation directory).
 
@@ -88,13 +88,13 @@ The orphan check stays a hard error because a shard in a guide directory is clea
 }
 ```
 
-| Knob               | Default                                    | Role                                               |
-| ------------------ | ------------------------------------------ | -------------------------------------------------- |
-| `standaloneGuides` | `[]`                                       | Files or globs registered as standalone (captured) |
-| `scan.gitignore`   | `true`                                     | Honor the repository `.gitignore` when walking     |
-| `scan.ignore`      | built-in `.git`, `node_modules`, `.agents` | Extra directories or globs to skip                 |
-| `scan.root`        | invocation directory                       | Root the scan walks for markdown files             |
-| `scan.strict`      | `false`                                    | Fail `mdcp check` on coverage gaps                 |
+| Knob               | Default                                    | Role                                                            |
+| ------------------ | ------------------------------------------ | --------------------------------------------------------------- |
+| `standaloneGuides` | `[]`                                       | Files or globs registered as standalone (captured)              |
+| `scan.gitignore`   | `true`                                     | Honor nearest ancestor `.gitignore` (walks up from `scan.root`) |
+| `scan.ignore`      | built-in `.git`, `node_modules`, `.agents` | Extra directories or globs to skip                              |
+| `scan.root`        | invocation directory                       | Root the scan walks for markdown files                          |
+| `scan.strict`      | `false`                                    | Fail `mdcp check` on coverage gaps                              |
 
 ## Coverage scan acceptance criteria
 
@@ -103,7 +103,7 @@ The orphan check stays a hard error because a shard in a guide directory is clea
 - A guide output target (`compile.outputFile` and top-level `outputFile`) is captured.
 - A `standaloneGuides[]` entry is captured, including glob matches.
 - A markdown file outside every guide and outside `standaloneGuides[]` is reported as uncaptured.
-- The scan honors `.gitignore` by default; `scan.gitignore: false` disables it.
+- The scan honors `.gitignore` by default (walking up from `scan.root` to the repository `.gitignore`); `scan.gitignore: false` disables it.
 - Built-in defaults (`.git`, `node_modules`, `.agents`) are always skipped; `scan.ignore` extends them.
 - A `standaloneGuides[]` entry matching no file is reported as missing.
 - `mdcp check` prints uncaptured and missing-standalone paths; with `scan.strict: true` those gaps fail the gate.

--- a/packages/mdcp-core/src/config/schema.ts
+++ b/packages/mdcp-core/src/config/schema.ts
@@ -94,7 +94,7 @@ export const MdcpConfigSchema = z.object({
   /** Repository-wide markdown coverage scan options. */
   scan: z
     .object({
-      /** Honor nearest ancestor `.gitignore` (walks up from scan.root; default true). */
+      /** Honor `.gitignore` (repo-root inside git; scan-root only otherwise; default true). */
       gitignore: z.boolean().default(true),
       /** Extra ignore globs beyond the built-in defaults. */
       ignore: z.array(z.string()).default([]),

--- a/packages/mdcp-core/src/config/schema.ts
+++ b/packages/mdcp-core/src/config/schema.ts
@@ -94,7 +94,7 @@ export const MdcpConfigSchema = z.object({
   /** Repository-wide markdown coverage scan options. */
   scan: z
     .object({
-      /** Honor the repository `.gitignore` when walking (default true). */
+      /** Honor nearest ancestor `.gitignore` (walks up from scan.root; default true). */
       gitignore: z.boolean().default(true),
       /** Extra ignore globs beyond the built-in defaults. */
       ignore: z.array(z.string()).default([]),

--- a/packages/mdcp-core/src/validate/coverage.ts
+++ b/packages/mdcp-core/src/validate/coverage.ts
@@ -25,7 +25,7 @@ export interface CoverageOptions {
   standaloneGuides: string[];
   /** Extra ignore globs; built-in defaults are always added internally. */
   ignore: string[];
-  /** Honor the nearest ancestor `.gitignore` (walks up from the scan root). */
+  /** Honor `.gitignore`: repo-root when inside git; scan-root only otherwise. */
   gitignore: boolean;
 }
 
@@ -47,19 +47,14 @@ function isUnder(dir: string, absPath: string): boolean {
 }
 
 /**
- * Walk up from `start` to find a `.gitignore`, stopping at the git repo root
- * (a `.git` entry) or the filesystem root. Returns the directory that owns the
- * file and its contents, or null when none is found.
+ * Walk up from `start` looking for a `.git` entry (directory or file, as in
+ * worktrees). Returns the repository root, or null when `start` is not inside
+ * a git working tree.
  */
-function findAncestorGitignore(start: string): { dir: string; content: string } | null {
+function findGitRoot(start: string): string | null {
   let dir = resolve(start);
   for (;;) {
-    const gitignorePath = resolve(dir, '.gitignore');
-    if (existsSync(gitignorePath)) {
-      return { dir, content: readFileSync(gitignorePath, 'utf-8') };
-    }
-    // Do not walk out of the repository.
-    if (existsSync(resolve(dir, '.git'))) return null;
+    if (existsSync(resolve(dir, '.git'))) return dir;
     const parent = dirname(dir);
     if (parent === dir) return null;
     dir = parent;
@@ -67,11 +62,29 @@ function findAncestorGitignore(start: string): { dir: string; content: string } 
 }
 
 /**
- * Filter scan-root-relative POSIX paths through the nearest ancestor
- * `.gitignore` (repository root when nested under `scan.root`).
+ * Locate the `.gitignore` that should apply to `start`.
+ *
+ * - Inside a git repo: use the repository-root `.gitignore` only (never walk
+ *   above the `.git` boundary).
+ * - Outside a git repo: honor `.gitignore` at `start` itself only — do not
+ *   climb parents, which would escape the project root into unrelated trees.
+ */
+function findApplicableGitignore(start: string): { dir: string; content: string } | null {
+  const root = resolve(start);
+  const gitRoot = findGitRoot(root);
+  // Inside git: repo-root `.gitignore`. Outside git: scan-root only (no parent climb).
+  const ignoreDir = gitRoot ?? root;
+  const gitignorePath = resolve(ignoreDir, '.gitignore');
+  if (!existsSync(gitignorePath)) return null;
+  return { dir: ignoreDir, content: readFileSync(gitignorePath, 'utf-8') };
+}
+
+/**
+ * Filter scan-root-relative POSIX paths through the applicable `.gitignore`
+ * (repo-root when inside git; scan-root only otherwise).
  */
 function gitignoreFilter(root: string, relPaths: string[]): string[] {
-  const found = findAncestorGitignore(root);
+  const found = findApplicableGitignore(root);
   if (!found) return relPaths;
   const matcher = ignoreFactory().add(found.content);
   return relPaths.filter((rel) => {

--- a/packages/mdcp-core/src/validate/coverage.ts
+++ b/packages/mdcp-core/src/validate/coverage.ts
@@ -1,4 +1,4 @@
-import { relative, resolve, sep } from 'node:path';
+import { dirname, relative, resolve, sep } from 'node:path';
 import fg from 'fast-glob';
 import ignoreFactory from 'ignore';
 import { readFileSync, existsSync } from 'node:fs';
@@ -25,7 +25,7 @@ export interface CoverageOptions {
   standaloneGuides: string[];
   /** Extra ignore globs; built-in defaults are always added internally. */
   ignore: string[];
-  /** Honor the root `.gitignore` when walking. */
+  /** Honor the nearest ancestor `.gitignore` (walks up from the scan root). */
   gitignore: boolean;
 }
 
@@ -46,12 +46,40 @@ function isUnder(dir: string, absPath: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !rel.startsWith(`..${sep}`));
 }
 
-/** Filter root-relative POSIX paths through the root `.gitignore`, when present. */
+/**
+ * Walk up from `start` to find a `.gitignore`, stopping at the git repo root
+ * (a `.git` entry) or the filesystem root. Returns the directory that owns the
+ * file and its contents, or null when none is found.
+ */
+function findAncestorGitignore(start: string): { dir: string; content: string } | null {
+  let dir = resolve(start);
+  for (;;) {
+    const gitignorePath = resolve(dir, '.gitignore');
+    if (existsSync(gitignorePath)) {
+      return { dir, content: readFileSync(gitignorePath, 'utf-8') };
+    }
+    // Do not walk out of the repository.
+    if (existsSync(resolve(dir, '.git'))) return null;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * Filter scan-root-relative POSIX paths through the nearest ancestor
+ * `.gitignore` (repository root when nested under `scan.root`).
+ */
 function gitignoreFilter(root: string, relPaths: string[]): string[] {
-  const gitignorePath = resolve(root, '.gitignore');
-  if (!existsSync(gitignorePath)) return relPaths;
-  const matcher = ignoreFactory().add(readFileSync(gitignorePath, 'utf-8'));
-  return relPaths.filter((rel) => !matcher.ignores(rel));
+  const found = findAncestorGitignore(root);
+  if (!found) return relPaths;
+  const matcher = ignoreFactory().add(found.content);
+  return relPaths.filter((rel) => {
+    const abs = resolve(root, rel);
+    const fromIgnoreRoot = toPosix(relative(found.dir, abs));
+    if (fromIgnoreRoot === '' || fromIgnoreRoot.startsWith('..')) return true;
+    return !matcher.ignores(fromIgnoreRoot);
+  });
 }
 
 /**

--- a/packages/mdcp-core/test/coverage.test.ts
+++ b/packages/mdcp-core/test/coverage.test.ts
@@ -75,6 +75,24 @@ describe('computeCoverage', () => {
     expect(result.captured).not.toContain('dist/generated.md');
   });
 
+  it('walks up from scan.root to honor an ancestor repository .gitignore', () => {
+    write('.gitignore', '.caches/\n');
+    write('docs/guide/index.md');
+    write('docs/.caches/mdcp/prompts/legacy.prompt.md');
+    write('docs/stray.md');
+    const result = computeCoverage({
+      root: join(work.path, 'docs'),
+      guideDirs: [join(work.path, 'docs/guide')],
+      outputFiles: [],
+      standaloneGuides: [],
+      ignore: [],
+      gitignore: true,
+    });
+    expect(result.uncaptured).not.toContain('.caches/mdcp/prompts/legacy.prompt.md');
+    expect(result.uncaptured).toContain('stray.md');
+    expect(result.captured).toContain('guide/index.md');
+  });
+
   it('does not honor .gitignore when gitignore is false', () => {
     const opts = { ...setup(), gitignore: false };
     write('.gitignore', 'dist/\n');

--- a/packages/mdcp-core/test/coverage.test.ts
+++ b/packages/mdcp-core/test/coverage.test.ts
@@ -68,6 +68,7 @@ describe('computeCoverage', () => {
 
   it('honors .gitignore by default', () => {
     const opts = setup();
+    write('.git'); // mark repo root (file or dir both count)
     write('.gitignore', 'dist/\n');
     write('dist/generated.md');
     const result = computeCoverage(opts);
@@ -76,6 +77,7 @@ describe('computeCoverage', () => {
   });
 
   it('walks up from scan.root to honor an ancestor repository .gitignore', () => {
+    write('.git');
     write('.gitignore', '.caches/\n');
     write('docs/guide/index.md');
     write('docs/.caches/mdcp/prompts/legacy.prompt.md');
@@ -91,6 +93,39 @@ describe('computeCoverage', () => {
     expect(result.uncaptured).not.toContain('.caches/mdcp/prompts/legacy.prompt.md');
     expect(result.uncaptured).toContain('stray.md');
     expect(result.captured).toContain('guide/index.md');
+  });
+
+  it('does not walk above scan.root for .gitignore when not inside a git repo', () => {
+    // Parent has a .gitignore but no .git — must not escape the project root.
+    write('.gitignore', '.caches/\n');
+    write('docs/guide/index.md');
+    write('docs/.caches/mdcp/prompts/legacy.prompt.md');
+    write('docs/stray.md');
+    const result = computeCoverage({
+      root: join(work.path, 'docs'),
+      guideDirs: [join(work.path, 'docs/guide')],
+      outputFiles: [],
+      standaloneGuides: [],
+      ignore: [],
+      gitignore: true,
+    });
+    expect(result.uncaptured).toContain('.caches/mdcp/prompts/legacy.prompt.md');
+    expect(result.uncaptured).toContain('stray.md');
+  });
+
+  it('still honors .gitignore at scan.root when not inside a git repo', () => {
+    write('.gitignore', 'dist/\n');
+    write('dist/generated.md');
+    write('guide/index.md');
+    const result = computeCoverage({
+      root: work.path,
+      guideDirs: [join(work.path, 'guide')],
+      outputFiles: [],
+      standaloneGuides: [],
+      ignore: [],
+      gitignore: true,
+    });
+    expect(result.uncaptured).not.toContain('dist/generated.md');
   });
 
   it('does not honor .gitignore when gitignore is false', () => {


### PR DESCRIPTION
## Summary
- Coverage only read `.gitignore` inside `scan.root`, so nested roots (e.g. `examples/sample-guides`) ignored the repo `.gitignore` and flagged local `.caches/**` under `scan.strict`.
- Walk up from `scan.root` to the nearest ancestor `.gitignore` (stop at `.git` / filesystem root) and match paths relative to that file.
- Docs + changeset updated; smoke: `mdcp check` on sample-guides now passes with leftover `.caches` prompts present.

## Test plan
- [x] `pnpm --filter @bwilliamson/mdcp-core exec vitest run test/coverage.test.ts`
- [x] `mdcp check --config examples/sample-guides/mdcp.config.json --docs-root examples/sample-guides --skip-vale` passes with local `.caches/mdcp/prompts` present
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)