### PR TITLE
fix(deps): pin @hono/node-server 2.0.10 for Dependabot #2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   postcss@<8.5.18: 8.5.18
   js-yaml@5: 5.2.2
   dompurify: ^3.4.0
+  '@hono/node-server@<2.0.10': 2.0.10
 
 importers:
 
@@ -659,9 +660,9 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -5652,7 +5653,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.30)':
+  '@hono/node-server@2.0.10(hono@4.12.30)':
     dependencies:
       hono: 4.12.30
 
@@ -5763,7 +5764,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.30)
+      '@hono/node-server': 2.0.10(hono@4.12.30)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,7 @@ overrides:
   # Slidev → monaco-editor → dompurify (dev-only presentation tooling).
   # GHSA-v2wj-7wpq-c8vv / GHSA-h7mw-gpvr-xq4m / GHSA-crv5-9vww-q3g8: patched >=3.4.0.
   dompurify: ^3.4.0
+  # Slidev → MCP SDK → @hono/node-server (dev-only presentation tooling).
+  # GHSA-frvp-7c67-39w9: path traversal <2.0.5; GHSA-9mqv-5hh9-4cgg: DoS <=2.0.9.
+  # Pin >=2.0.10 (2.0.11+ still inside minimumReleaseAge).
+  '@hono/node-server@<2.0.10': 2.0.10


### PR DESCRIPTION
## Summary
- Pin transitive `@hono/node-server` (Slidev → MCP SDK, **dev-only**) to `2.0.10` via `pnpm-workspace.yaml` overrides.
- Clears [Dependabot #2](https://github.com/betsalel-williamson/mdcp/security/dependabot/2) / [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) (Windows `serve-static` path traversal) and [GHSA-9mqv-5hh9-4cgg](https://github.com/advisories/GHSA-9mqv-5hh9-4cgg) (WebSocket handshake DoS in `<=2.0.9`).
- Does not affect published `mdcp` packages; MCP SDK only uses `getRequestListener` / `serve`, not the vulnerable `serve-static` path.

## Test plan
- [x] `pnpm install` resolves `@hono/node-server@2.0.10`
- [x] `pnpm audit --audit-level=high` exits 0 (no remaining hono advisories)
- [ ] Confirm Dependabot alert #2 auto-dismisses after merge


Made with [Cursor](https://cursor.com)