### PR TITLE
docs: make skill install paths host-agnostic (#207)

### DIFF
--- a/.changeset/host-agnostic-skill-paths.md
+++ b/.changeset/host-agnostic-skill-paths.md
@@ -1,0 +1,5 @@
+---
+'@bwilliamson/mdcp-cli': patch
+---
+
+Document skill install paths as host-agnostic: `npx skills` places skills in each agent's directory (not only `.agents/skills/`).

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -625,7 +625,7 @@ _Note: GitHub and GitHub Flavored Markdown are trademarks of GitHub, Inc. This p
 
 ## Agent Skill development
 
-Zero-friction MDCP delivery for AI agents uses the portable **parent** Agent Skill. Upstream source of truth is [`skills/mdcp/SKILL.md`](skills/mdcp/SKILL.md). After install (or local dogfood), agents load it from `.agents/skills/mdcp/`. Complementary helper skills under `skills/mdcp-*` (except WIP archetypes) ship in the same pack and are listed in [`skills.sh.json`](skills.sh.json) under **Documentation system**. Archetype skills (`skills/mdcp-arch-*`) are **not ready to release**: they carry `metadata.internal: true` and stay **out** of `skills.sh.json` until intentionally published. Maintainers can surface them locally with `INSTALL_INTERNAL_SKILLS=1`.
+Zero-friction MDCP delivery for AI agents uses the portable **parent** Agent Skill. Upstream source of truth is [`skills/mdcp/SKILL.md`](skills/mdcp/SKILL.md). After install (or local dogfood in **this** monorepo), agents load it from `.agents/skills/mdcp/` — that path is this repo's vendor-managed dogfood layout, not the universal consumer install path (consumers get an agent-specific directory via `npx skills add`; see [Agent Skill](docs/features/agent-skill.md)). Complementary helper skills under `skills/mdcp-*` (except WIP archetypes) ship in the same pack and are listed in [`skills.sh.json`](skills.sh.json) under **Documentation system**. Archetype skills (`skills/mdcp-arch-*`) are **not ready to release**: they carry `metadata.internal: true` and stay **out** of `skills.sh.json` until intentionally published. Maintainers can surface them locally with `INSTALL_INTERNAL_SKILLS=1`.
 
 ### Local dogfood
 
@@ -701,7 +701,7 @@ Complementary `skills/mdcp-arch-*` packs remain WIP (`metadata.internal: true`) 
 
 There is no skills.sh submit API. The [repo page](https://skills.sh/betsalel-williamson/mdcp) appears from install telemetry after consumers (or maintainers) run an install without `DISABLE_TELEMETRY=1`. Release tagging syncs `metadata.version` on all skills under `skills/` — see [Versioning and releases](#versioning-and-releases). Do not hand-edit those versions in feature PRs; add a changeset when `skills/` changes so release notes capture the work.
 
-Documented consumer install path: `.agents/skills/`. Avoid Cursor-only or Marketplace-only packaging for this work.
+Documented consumer install path: your agent's skills directory ([Supported Agents](https://github.com/vercel-labs/skills#supported-agents)). Avoid Cursor-only or Marketplace-only packaging for this work.
 
 ### `skills.sh.json` (repo page layout)
 
@@ -859,7 +859,7 @@ There is **no calendar cadence**. Releases are **event-driven**:
 3. When ready, a maintainer runs **`pnpm release:tag:push`** to version, tag, and push.
 4. CI publishes to npm when the **`v*`** tag lands on GitHub.
 
-**Agent Skills** live under `skills/` (not npm). They ship from Git via `npx skills add` into `.agents/skills/`. On each release, `pnpm release:tag` sets every `skills/*/SKILL.md` `metadata.version` to match the tag (other frontmatter such as `metadata.internal` is preserved). Feature PRs that change `skills/` must add a changeset and must **not** hand-bump those versions. See [Agent Skill](#agent-skill-development).
+**Agent Skills** live under `skills/` (not npm). They ship from Git via `npx skills add` into each host's skills directory (this monorepo dogfoods under `.agents/skills/` via `pnpm skill:update`). On each release, `pnpm release:tag` sets every `skills/*/SKILL.md` `metadata.version` to match the tag (other frontmatter such as `metadata.internal` is preserved). Feature PRs that change `skills/` must add a changeset and must **not** hand-bump those versions. See [Agent Skill](#agent-skill-development).
 
 Typical rhythm for an active dev project: **a few releases per month**, batched when there is something worth shipping — not on a fixed weekly/monthly schedule.
 
@@ -1387,7 +1387,7 @@ When a glossary grows beyond a comfortable manifest size, group entries in sub-i
 
 ## Agent Skills
 
-Portable packages of agent instructions (`SKILL.md` and companions) that hosts discover and load — the delivery model for MDCP’s **documentation system** guardrails. Upstream source in this monorepo is `skills/mdcp/`; consumers vendor via `npx skills add` into `.agents/skills/mdcp/` so agents learn how to shard, compile, validate, and maintain docs one piece at a time — across Cursor, Copilot, Claude Code, and similar hosts.
+Portable packages of agent instructions (`SKILL.md` and companions) that hosts discover and load — the delivery model for MDCP’s **documentation system** guardrails. Upstream source in this monorepo is `skills/mdcp/`; consumers vendor via `npx skills add` into the **agent-specific** skills directory the skills CLI chooses so agents learn how to shard, compile, validate, and maintain docs one piece at a time — across Cursor, Copilot, Claude Code, and similar hosts. Per-agent install paths: [Supported Agents](https://github.com/vercel-labs/skills#supported-agents).
 
 Verification: agentskills.io validation (`pnpm skill:validate` / skills-ref) in CI; [live skill eval](#live-skill-eval) is the optional local skill-creator loop.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install the core documentation-system Agent Skill into your repository:
 npx skills add betsalel-williamson/mdcp --skill mdcp
 ```
 
-_(This copies the skill into `.agents/skills/mdcp/` in your repository. Commit it to git so every teammate and agent shares the same documentation discipline)._
+_(This copies the skill into your agent's skills directory (chosen by the [`skills` CLI](https://www.skills.sh/docs/cli) via `--agent` or auto-detect). Commit it to git so every teammate and agent shares the same documentation discipline. Per-agent paths: [Supported Agents](https://github.com/vercel-labs/skills#supported-agents).)_
 
 Then start a bootstrap session:
 

--- a/docs/developer/agent-skill.md
+++ b/docs/developer/agent-skill.md
@@ -1,6 +1,6 @@
 # Agent Skill development
 
-Zero-friction MDCP delivery for AI agents uses the portable **parent** Agent Skill. Upstream source of truth is [`skills/mdcp/SKILL.md`](../../skills/mdcp/SKILL.md). After install (or local dogfood), agents load it from `.agents/skills/mdcp/`. Complementary helper skills under `skills/mdcp-*` (except WIP archetypes) ship in the same pack and are listed in [`skills.sh.json`](../../skills.sh.json) under **Documentation system**. Archetype skills (`skills/mdcp-arch-*`) are **not ready to release**: they carry `metadata.internal: true` and stay **out** of `skills.sh.json` until intentionally published. Maintainers can surface them locally with `INSTALL_INTERNAL_SKILLS=1`.
+Zero-friction MDCP delivery for AI agents uses the portable **parent** Agent Skill. Upstream source of truth is [`skills/mdcp/SKILL.md`](../../skills/mdcp/SKILL.md). After install (or local dogfood in **this** monorepo), agents load it from `.agents/skills/mdcp/` — that path is this repo's vendor-managed dogfood layout, not the universal consumer install path (consumers get an agent-specific directory via `npx skills add`; see [Agent Skill](../features/agent-skill.md)). Complementary helper skills under `skills/mdcp-*` (except WIP archetypes) ship in the same pack and are listed in [`skills.sh.json`](../../skills.sh.json) under **Documentation system**. Archetype skills (`skills/mdcp-arch-*`) are **not ready to release**: they carry `metadata.internal: true` and stay **out** of `skills.sh.json` until intentionally published. Maintainers can surface them locally with `INSTALL_INTERNAL_SKILLS=1`.
 
 ## Local dogfood
 
@@ -76,7 +76,7 @@ Complementary `skills/mdcp-arch-*` packs remain WIP (`metadata.internal: true`) 
 
 There is no skills.sh submit API. The [repo page](https://skills.sh/betsalel-williamson/mdcp) appears from install telemetry after consumers (or maintainers) run an install without `DISABLE_TELEMETRY=1`. Release tagging syncs `metadata.version` on all skills under `skills/` — see [Versioning and releases](./versioning-and-releases.md). Do not hand-edit those versions in feature PRs; add a changeset when `skills/` changes so release notes capture the work.
 
-Documented consumer install path: `.agents/skills/`. Avoid Cursor-only or Marketplace-only packaging for this work.
+Documented consumer install path: your agent's skills directory ([Supported Agents](https://github.com/vercel-labs/skills#supported-agents)). Avoid Cursor-only or Marketplace-only packaging for this work.
 
 ## `skills.sh.json` (repo page layout)
 

--- a/docs/developer/versioning-and-releases.md
+++ b/docs/developer/versioning-and-releases.md
@@ -19,7 +19,7 @@ There is **no calendar cadence**. Releases are **event-driven**:
 3. When ready, a maintainer runs **`pnpm release:tag:push`** to version, tag, and push.
 4. CI publishes to npm when the **`v*`** tag lands on GitHub.
 
-**Agent Skills** live under `skills/` (not npm). They ship from Git via `npx skills add` into `.agents/skills/`. On each release, `pnpm release:tag` sets every `skills/*/SKILL.md` `metadata.version` to match the tag (other frontmatter such as `metadata.internal` is preserved). Feature PRs that change `skills/` must add a changeset and must **not** hand-bump those versions. See [Agent Skill](./agent-skill.md).
+**Agent Skills** live under `skills/` (not npm). They ship from Git via `npx skills add` into each host's skills directory (this monorepo dogfoods under `.agents/skills/` via `pnpm skill:update`). On each release, `pnpm release:tag` sets every `skills/*/SKILL.md` `metadata.version` to match the tag (other frontmatter such as `metadata.internal` is preserved). Feature PRs that change `skills/` must add a changeset and must **not** hand-bump those versions. See [Agent Skill](./agent-skill.md).
 
 Typical rhythm for an active dev project: **a few releases per month**, batched when there is something worth shipping — not on a fixed weekly/monthly schedule.
 

--- a/docs/features/agent-skill.md
+++ b/docs/features/agent-skill.md
@@ -10,7 +10,7 @@ Agent Skills give:
 - **Host interoperability** — Cursor, Copilot, Claude Code, VS Code, and CLI hosts
 - **Simpler maintenance** — markdown skill directories agents load from the repo
 - **Composition** — parent skill plus complementary helpers (catalog: [Helper Skills](./protocol/agent-task-prompts.md); hardened boundaries: [helper skill shards](./protocol/skills/mdcp-getting-started.md); archetype skills are WIP)
-- **Reviewable instructions** — vendored under `.agents/skills/` and committed with the project
+- **Reviewable instructions** — vendored in your agent's skills directory and committed with the project
 
 ## Parent skill and complementary skills
 
@@ -20,13 +20,13 @@ Agent Skills give:
 - [`skills/mdcp-arch-oss-library/`](../../skills/mdcp-arch-oss-library/) — OSS library documentation architecture (**WIP**, not ready for consumer install)
 - [`skills/mdcp-arch-product-docs-site/`](../../skills/mdcp-arch-product-docs-site/) — product docs site architecture (**WIP**, not ready for consumer install)
 
-**Consumer install target** after `npx skills add`: `.agents/skills/<name>/` (vendored into the consumer repo).
+**Consumer install target** after `npx skills add`: the **agent-specific** skills directory the [`skills` CLI](https://www.skills.sh/docs/cli) chooses (`--agent` or auto-detect) — vendored into your repo. Per-agent paths: [Supported Agents](https://github.com/vercel-labs/skills#supported-agents).
 
 ## Format and location
 
 - **Format:** `SKILL.md` per the [Agent Skills](https://agentskills.io) open standard (progressive disclosure: lean activation body; depth in `references/` and `scripts/`).
 - **Upstream path:** [`skills/mdcp/SKILL.md`](../../skills/mdcp/SKILL.md).
-- **Install path:** `.agents/skills/mdcp/` (also discovered: `.github/skills/`, `.claude/skills/`). Prefer documenting `.agents/skills/` for consumers.
+- **Install path:** your agent's skills directory after `npx skills add` (not one universal folder — the CLI maps each host to its own tree; see [Supported Agents](https://github.com/vercel-labs/skills#supported-agents)).
 - **Frontmatter:** `license`, `compatibility` (Node.js 18+ / `@bwilliamson/mdcp-cli`), and `metadata.version` (lockstep with npm/git tags). WIP complementary skills also set `metadata.internal: true` so they stay off default skills CLI discovery until ready.
 
 Skill `scripts/` are thin wrappers into the CLI — see [`skills/mdcp/references/cli-and-scripts.md`](../../skills/mdcp/references/cli-and-scripts.md) for what **compile** (build docs), **check** (validate the tree), and **refs** (cross-link registry) mean.
@@ -35,7 +35,7 @@ Skill `scripts/` are thin wrappers into the CLI — see [`skills/mdcp/references
 
 Agent Skills use a **vendoring** approach: skill files live in the project and are versioned with Git.
 
-1. **Commit to Git:** When you run `npx skills add`, the skill's files are copied into your project's `.agents/skills/` directory and tracked in your own source control.
+1. **Commit to Git:** When you run `npx skills add`, the skill's files are copied into your agent's skills directory and tracked in your own source control.
 2. **Docs-as-code Evolution:** The skill version is tied to the commit in your repository. Agent instruction changes are reviewable in Pull Requests alongside the code or configuration changes they support.
 3. **Upgrading:** To upgrade a skill, re-run `npx skills add` (or manually copy the updated folder), review the resulting `git diff`, and commit the changes.
 4. **Authoring/Maintainer Versioning:** Upstream skills live under `skills/` and evolve on `main`, tagged alongside npm package releases. `pnpm release:tag` sets `metadata.version` on every `skills/*/SKILL.md` to match the tag (preserves `metadata.internal`). Consumers can point `npx skills add` to specific tags if necessary.
@@ -52,7 +52,7 @@ Then start bootstrap:
 /mdcp help me get started
 ```
 
-Zero-install: copy `skills/mdcp/` from this repository into the consumer's `.agents/skills/mdcp/`. Do not document complementary archetype install commands until those skills are ready for use.
+Zero-install: copy `skills/mdcp/` from this repository into the skills directory your host discovers ([Supported Agents](https://github.com/vercel-labs/skills#supported-agents)). Do not document complementary archetype install commands until those skills are ready for use.
 
 Qualitative checks of skill behavior (with vs without the skill) are maintainer workflow — see [Live skill evals](../developer/live-skill-evals.md). The static CI gate is `pnpm skill:validate`.
 

--- a/docs/features/feature-catalog.md
+++ b/docs/features/feature-catalog.md
@@ -18,7 +18,7 @@ Heading-slug **registry** for validation after compile — see [Refs registry pa
 
 ## Agent Skill
 
-Parent Agent Skill at `skills/mdcp/SKILL.md` (install target `.agents/skills/mdcp/`). See [Agent Skill](./agent-skill.md).
+Parent Agent Skill at `skills/mdcp/SKILL.md` (install via `npx skills add` into your agent's skills directory). See [Agent Skill](./agent-skill.md).
 
 Helper skills extend the parent for specific authoring jobs — catalog and intake:
 [Helper Skills](./protocol/agent-task-prompts.md). Hardened is/isn’t boundaries:

--- a/docs/features/protocol/00-vision-and-roadmap.md
+++ b/docs/features/protocol/00-vision-and-roadmap.md
@@ -24,11 +24,11 @@ Filter for new capabilities: [Direct value bar](../design-constraints/direct-val
 
 ## Phased delivery
 
-| Phase  | Surface                                                                                                           | Access model                  |
-| ------ | ----------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| **V1** | **Agent Skills** pack (`skills/mdcp`, install to `.agents/skills/mdcp`) + `mdcp compile`/`check` + task subagents | Repo access (SSH, clone, IDE) |
-| **V2** | MDCP MCP server (shard read, glossary search)                                                                     | Repo access                   |
-| **V3** | Hosted context API (OpenAPI spec, API keys, polyglot clients)                                                     | Opt-in publish                |
+| Phase  | Surface                                                                                            | Access model                  |
+| ------ | -------------------------------------------------------------------------------------------------- | ----------------------------- |
+| **V1** | **Agent Skills** pack (`skills/mdcp` via `npx skills add`) + `mdcp compile`/`check` + task helpers | Repo access (SSH, clone, IDE) |
+| **V2** | MDCP MCP server (shard read, glossary search)                                                      | Repo access                   |
+| **V3** | Hosted context API (OpenAPI spec, API keys, polyglot clients)                                      | Opt-in publish                |
 
 ```text
   V1 authoring     shards → compile → check → Agent Skill (/mdcp)

--- a/docs/features/protocol/extensions-and-archetypes.md
+++ b/docs/features/protocol/extensions-and-archetypes.md
@@ -16,7 +16,7 @@ MDCP separates:
 
 ## Do not hand-edit agent entrypoints for repo-specific guidance
 
-The parent **Agent Skill** (`skills/mdcp/` → `.agents/skills/mdcp/`) is the portable agent entrypoint.
+The parent **Agent Skill** (`skills/mdcp/` → your agent's skills directory after `npx skills add`) is the portable agent entrypoint.
 
 | Rule                                                                       | Detail                                                  |
 | -------------------------------------------------------------------------- | ------------------------------------------------------- |
@@ -53,11 +53,11 @@ Published and community extensions live as complementary skills under `skills/md
 - **Contribute back** via PR when an extension is broadly useful — we want shared archetypes to grow.
 - **No obligation** — mdcp uses **MIT**; local-only proprietary extensions are explicitly encouraged when they encode competitive or regulated workflow detail.
 
-**Bootstrap:** Install the parent skill with `npx skills add betsalel-williamson/mdcp --skill mdcp`. Commit `.agents/skills/mdcp/` in consumer repos so agents share the same instructions.
+**Bootstrap:** Install the parent skill with `npx skills add betsalel-williamson/mdcp --skill mdcp`. Commit the vendored skill in your agent's skills directory so agents share the same instructions.
 
 **Security:** Agent Skills operate with identical permissions to the user. Treat third-party Agent Skills as untrusted. Future work: trusted-source allowlist and sandboxed execution.
 
-Built-in subagents (such as the `mdcp` feature and doc-only subagents) resolve directly via the `.agents/skills/` directory. Each Agent Skill is an isolated, independent entity.
+Built-in subagents (such as the `mdcp` feature and doc-only subagents) resolve via the skills directory your host discovers. Each Agent Skill is an isolated, independent entity.
 
 ## Archetypes ("Battery Types")
 

--- a/docs/features/protocol/usage-model.md
+++ b/docs/features/protocol/usage-model.md
@@ -4,7 +4,7 @@ Operational roles for Markdown as Context. Parent: [GitHub #45](https://github.c
 
 ## Agent entrypoint
 
-Agents should load the parent **Agent Skill** (`/mdcp`, install target `.agents/skills/mdcp/`) first. That skill teaches how to query with smallest context — discover one shard at a time — without loading entire guides. See [Agent Skill](../../features/agent-skill.md).
+Agents should load the parent **Agent Skill** (`/mdcp`, installed in your agent's skills directory via `npx skills add`) first. That skill teaches how to query with smallest context — discover one shard at a time — without loading entire guides. See [Agent Skill](../../features/agent-skill.md).
 
 ## Actors and obligations
 

--- a/docs/glossary/agent-skills.md
+++ b/docs/glossary/agent-skills.md
@@ -1,5 +1,5 @@
 # Agent Skills
 
-Portable packages of agent instructions (`SKILL.md` and companions) that hosts discover and load — the delivery model for MDCP’s **documentation system** guardrails. Upstream source in this monorepo is `skills/mdcp/`; consumers vendor via `npx skills add` into `.agents/skills/mdcp/` so agents learn how to shard, compile, validate, and maintain docs one piece at a time — across Cursor, Copilot, Claude Code, and similar hosts.
+Portable packages of agent instructions (`SKILL.md` and companions) that hosts discover and load — the delivery model for MDCP’s **documentation system** guardrails. Upstream source in this monorepo is `skills/mdcp/`; consumers vendor via `npx skills add` into the **agent-specific** skills directory the skills CLI chooses so agents learn how to shard, compile, validate, and maintain docs one piece at a time — across Cursor, Copilot, Claude Code, and similar hosts. Per-agent install paths: [Supported Agents](https://github.com/vercel-labs/skills#supported-agents).
 
 Verification: agentskills.io validation (`pnpm skill:validate` / skills-ref) in CI; [live skill eval](./live-skill-eval.md) is the optional local skill-creator loop.

--- a/docs/presentation-la-devops/04-plan-to-enact.md
+++ b/docs/presentation-la-devops/04-plan-to-enact.md
@@ -13,7 +13,7 @@
 
 ## Getting Started: Agent Skills
 
-Install the MDCP Agent Skill in your repo (`.agents/skills/mdcp/SKILL.md`):
+Install the MDCP Agent Skill in your repo (your agent's `SKILL.md` after `npx skills add`):
 
 ```bash
 npx skills add betsalel-williamson/mdcp --skill mdcp
@@ -37,7 +37,7 @@ This isn't a magic bullet that instantly understands your legacy codebase. It's 
 
 - Open **Cursor** (or any LLM tool) in a repo.
 - Install the skill, then type: `/mdcp help me get started`
-- The agent reads `.agents/skills/mdcp/SKILL.md` and the getting-started subagent.
+- The agent reads the installed parent skill and the getting-started subagent.
 - Watch it set up your documentation shards and capture intent _before_ writing code.
 
 ---

--- a/docs/repo-readme/get-started.md
+++ b/docs/repo-readme/get-started.md
@@ -10,7 +10,7 @@ Install the core documentation-system Agent Skill into your repository:
 npx skills add betsalel-williamson/mdcp --skill mdcp
 ```
 
-_(This copies the skill into `.agents/skills/mdcp/` in your repository. Commit it to git so every teammate and agent shares the same documentation discipline)._
+_(This copies the skill into your agent's skills directory (chosen by the [`skills` CLI](https://www.skills.sh/docs/cli) via `--agent` or auto-detect). Commit it to git so every teammate and agent shares the same documentation discipline. Per-agent paths: [Supported Agents](https://github.com/vercel-labs/skills#supported-agents).)_
 
 Then start a bootstrap session:
 

--- a/presentations/la-devops-2026.md
+++ b/presentations/la-devops-2026.md
@@ -384,7 +384,7 @@ Your docs must capture:
 
 ### Getting Started: Agent Skills
 
-Install the MDCP Agent Skill in your repo (`.agents/skills/mdcp/SKILL.md`):
+Install the MDCP Agent Skill in your repo (your agent's `SKILL.md` after `npx skills add`):
 
 ```bash
 npx skills add betsalel-williamson/mdcp --skill mdcp
@@ -408,7 +408,7 @@ This isn't a magic bullet that instantly understands your legacy codebase. It's 
 
 - Open **Cursor** (or any LLM tool) in a repo.
 - Install the skill, then type: `/mdcp help me get started`
-- The agent reads `.agents/skills/mdcp/SKILL.md` and the getting-started subagent.
+- The agent reads the installed parent skill and the getting-started subagent.
 - Watch it set up your documentation shards and capture intent _before_ writing code.
 
 ---

--- a/skills/mdcp-getting-started/references/first-feature-tutorial.md
+++ b/skills/mdcp-getting-started/references/first-feature-tutorial.md
@@ -32,8 +32,9 @@ before advancing. Atomic commit groups apply **inside** each day-to-day helper
 | 3     | `mdcp-ux`                  | Client journey / end-user value under `docs/client/` |
 | 4     | `mdcp-doc-only`            | Polish: glossary, indexes, consistency               |
 
-For each phase: open the matching installed skill under `.agents/skills/` (or
-`skills/`), complete that helper’s intake if values are missing, follow its
+For each phase: open the matching installed skill in your agent’s skills
+directory (for example `.agents/skills/` in Cursor/Amp, or `skills/` in this
+monorepo), complete that helper’s intake if values are missing, follow its
 Process, validate, then announce the next phase.
 
 ## Recommended example: hello-greeting

--- a/skills/mdcp/SKILL.md
+++ b/skills/mdcp/SKILL.md
@@ -42,9 +42,9 @@ What compile / check / refs mean and CLI commands:
 ## Hard rules
 
 - **NEVER** invent MDCP workflow when this skill already defines it — follow the skill first.
-- **NEVER** hand-edit vendored skill files under `.agents/skills/` for
-  repo-specific guidance — use complementary skills, `docs/extensions/`, or
-  normative shards.
+- **NEVER** hand-edit files in a vendor-managed install under your agent’s skills
+  directory (for example `.agents/skills/` in Cursor/Amp) for repo-specific
+  guidance — use complementary skills, `docs/extensions/`, or normative shards.
 - **NEVER** edit generated compile output (`docs/_build/`, compiled publish
   targets) — fix shards and recompile.
 - **NEVER** dump whole monoliths into context — discover with host search (`rg`,
@@ -217,10 +217,13 @@ Bootstrap example:
 Hosts that can fork work (Task tool, `context: fork`, and similar) may run the chosen helper in an isolated agent; otherwise follow it in the main session.
 
 When no `mdcp.config.json` yet: create docs root + config + guide dirs, install
-the parent skill under `.agents/skills/mdcp/`, optionally add
+the parent skill via `npx skills add betsalel-williamson/mdcp --skill mdcp`
+(see [references/install.md](references/install.md)), optionally add
 `@bwilliamson/mdcp-presets`, then compile and check.
 
 ## Zero-install
 
-Copy `.agents/skills/mdcp/` into the consumer repo (portable default). Hosts may
-also read `.github/skills/` or `.claude/skills/`.
+Copy the `mdcp` skill folder into the skills directory **your agent discovers**
+(see [skills CLI Supported Agents](https://github.com/vercel-labs/skills#supported-agents)).
+For example `.agents/skills/mdcp/` for Cursor/Amp project installs — not a
+universal portable path.

--- a/skills/mdcp/references/install.md
+++ b/skills/mdcp/references/install.md
@@ -6,18 +6,28 @@
 npx skills add betsalel-williamson/mdcp --skill mdcp
 ```
 
-That copies the skill into your repo under `.agents/skills/mdcp/` (the install
-target).
+Use `-a` / `--agent` to target a specific host when you have more than one agent
+installed (for example `-a cursor` or `-a claude-code`).
 
-Zero-install: copy the `mdcp` skill folder into
-`.agents/skills/mdcp/` in your repository.
+The [skills CLI](https://github.com/vercel-labs/skills) copies or symlinks the
+skill into the **selected agent’s project (or global) skills directory**. Exact
+paths depend on the agent — see [Supported Agents](https://github.com/vercel-labs/skills#supported-agents)
+(for example `.agents/skills/` for Cursor/Amp project installs, `.claude/skills/`
+for Claude Code, `.windsurf/skills/` for Windsurf).
 
-Prefer `.agents/skills/` as the portable install path. Some hosts also discover
-`.github/skills/` or `.claude/skills/`.
+**Zero-install:** copy the `mdcp` skill folder into the skills directory **your
+agent discovers** (same Supported Agents list), not a single fixed path.
 
 ## After install
 
-The `mdcp` parent skill provides the core system. To perform specific tasks, you should install the helper skills alongside it (e.g., `mdcp-getting-started`, `mdcp-feature-level`, `mdcp-doc-only`, `mdcp-design-architecture`, `mdcp-ux`).
+The `mdcp` parent skill provides the core system. To perform specific tasks, you should install the helper skills alongside it (e.g., `mdcp-getting-started`, `mdcp-feature-level`, `mdcp-doc-only`, `mdcp-design-architecture`, `mdcp-ux`):
+
+```bash
+npx skills add betsalel-williamson/mdcp --skill mdcp-getting-started
+```
+
+Use the same `-a` / `--agent` flag when targeting a host. Replace the skill name
+for other helpers.
 
 Start a bootstrap session with a natural-language turn under the getting-started helper skill:
 


### PR DESCRIPTION
## Summary
- Stop documenting `.agents/skills/` as the universal portable install path for MDCP Agent Skills
- Point consumers at `npx skills` / [Supported Agents](https://github.com/vercel-labs/skills#supported-agents) for per-host directories (Cursor, Claude, Gemini, Windsurf, …)
- Keep this monorepo’s dogfood layout (`.agents/skills/` via `pnpm skill:update`) clearly scoped as maintainer-local

Closes #207

## Test plan
- [x] `pnpm docs:compile:repo` / `pnpm docs:check` (pre-commit + local)
- [ ] Spot-check README get-started note and `skills/mdcp/references/install.md`
- [ ] Confirm developer dogfood shards still mention `.agents/skills/` for this repo only


Made with [Cursor](https://cursor.com)