### PR TITLE
test(skills): PR 210 before/after eval campaign (SRP / mitosis / two-level)

### DIFF
--- a/tests/skills/mdcp/evals/README.md
+++ b/tests/skills/mdcp/evals/README.md
@@ -34,5 +34,9 @@ Fixtures and prompts for the optional [skill-creator](../../../.agents/skills/sk
 5. Grade both arms against the same assertion list; aggregate; open the viewer.
 6. Eval 10 (`eval-10-atomic-commit-groups`) uses **with_skill** vs **old_skill**
    (snapshot of `skills/mdcp` from `main` before Atomic commit groups QA).
+7. Evals 11–13 (`srp-overloaded`, `length-only`, `two-level-review`) discriminate
+   shard SRP / idea mitosis / two-level review. Compare **with_skill** (PR skill)
+   vs **old_skill** (`main` snapshot). Published go/no-go summaries live under
+   `tests/skills/mdcp/evals/results/` when maintainers run a decision campaign.
 
 Child suites: [`mdcp-getting-started`](../../mdcp-getting-started/evals/README.md), [`mdcp-doc-only`](../../mdcp-doc-only/evals/README.md), [`mdcp-design-architecture`](../../mdcp-design-architecture/evals/README.md), [`mdcp-feature-level`](../../mdcp-feature-level/evals/README.md), [`mdcp-ux`](../../mdcp-ux/evals/README.md). Maintainer index: [`docs/developer/live-skill-evals.md`](../../../../docs/developer/live-skill-evals.md).

--- a/tests/skills/mdcp/evals/README.md
+++ b/tests/skills/mdcp/evals/README.md
@@ -37,6 +37,7 @@ Fixtures and prompts for the optional [skill-creator](../../../.agents/skills/sk
 7. Evals 11–13 (`srp-overloaded`, `length-only`, `two-level-review`) discriminate
    shard SRP / idea mitosis / two-level review. Compare **with_skill** (PR skill)
    vs **old_skill** (`main` snapshot). Published go/no-go summaries live under
-   `tests/skills/mdcp/evals/results/` when maintainers run a decision campaign.
+   [`results/pr-210-srp/`](./results/pr-210-srp/GO-NO-GO.md) when maintainers run
+   a decision campaign.
 
 Child suites: [`mdcp-getting-started`](../../mdcp-getting-started/evals/README.md), [`mdcp-doc-only`](../../mdcp-doc-only/evals/README.md), [`mdcp-design-architecture`](../../mdcp-design-architecture/evals/README.md), [`mdcp-feature-level`](../../mdcp-feature-level/evals/README.md), [`mdcp-ux`](../../mdcp-ux/evals/README.md). Maintainer index: [`docs/developer/live-skill-evals.md`](../../../../docs/developer/live-skill-evals.md).

--- a/tests/skills/mdcp/evals/evals.json
+++ b/tests/skills/mdcp/evals/evals.json
@@ -217,6 +217,95 @@
           "description": "Stops after the plan and waits for human review; does not edit fixture docs or packages before approval"
         }
       ]
+    },
+    {
+      "id": 11,
+      "prompt": "SHIP TONIGHT. Leadership wants export docs fixed in one pass and says keep everything about export in ONE feature file so agents find it faster — do not over-engineer. The srp-overloaded fixture has docs/features/export-capability.md mixing end-user how-to, architecture, and temporary discovery notes. Using the MDCP parent skill, make the docs durable and correct. Time pressure is real: prefer minimal churn.",
+      "expected_output": "Applies mitosis/SRP: end-user how-to moves to client (or a how-to shard), feature shard keeps architecture/capability only, temporary discovery/tickets removed from durable docs. Updates guide indexes and cross-links. Does not obey the 'one file forever' pressure when audiences/jobs conflict.",
+      "files": [
+        "evals/files/srp-overloaded/mdcp.config.json",
+        "evals/files/srp-overloaded/docs/features/index.md",
+        "evals/files/srp-overloaded/docs/features/export-capability.md",
+        "evals/files/srp-overloaded/docs/client/index.md",
+        "evals/files/srp-overloaded/docs/client/export-results.md"
+      ],
+      "assertions": [
+        {
+          "name": "splits_mixed_audiences",
+          "description": "Does not leave end-user how-to and architecture as co-equal sections in one durable feature shard"
+        },
+        {
+          "name": "client_holds_howto",
+          "description": "End-user export how-to lives under docs/client/ (export-results or equivalent)"
+        },
+        {
+          "name": "removes_temp_discovery",
+          "description": "Removes temporary discovery/tickets/dual-write notes from durable shards"
+        },
+        {
+          "name": "updates_indexes_or_links",
+          "description": "Updates guide index and/or cross-links after any split"
+        },
+        {
+          "name": "resists_one_file_pressure",
+          "description": "Does not keep a multi-audience monolith solely because leadership asked for one file"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "prompt": "This compile-pipeline feature shard is TOO LONG for agents. Split it into many tiny files NOW so each section is its own shard. Leadership says length is the problem — do not debate philosophy. Using the MDCP parent skill on the length-only fixture, fix docs/features/compile-pipeline.md.",
+      "expected_output": "Does NOT split solely because the file is long when audience/job/concern remain single. May tighten wording in place. If it reorganizes, responsibility stays one concern; no fake mitosis for section headings alone.",
+      "files": [
+        "evals/files/length-only/mdcp.config.json",
+        "evals/files/length-only/docs/features/index.md",
+        "evals/files/length-only/docs/features/compile-pipeline.md"
+      ],
+      "assertions": [
+        {
+          "name": "no_length_only_split",
+          "description": "Does not split the shard into many files solely because of length when responsibility is still single"
+        },
+        {
+          "name": "keeps_single_concern",
+          "description": "Resulting feature docs still present one compile-pipeline concern (not fragmented heading dumps)"
+        },
+        {
+          "name": "states_or_implies_mitosis_rule",
+          "description": "Transcript/plan acknowledges split-when-responsibility-multiplies (not length) OR clearly refuses length-only split"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "URGENT merge in 10 minutes. Features says digests are daily; client settings still say weekly — fix the client shard only so the PR is tiny. Leadership explicitly says SKIP any comprehensive guide review / cross-guide consistency pass — isolation fix only. Using the MDCP parent skill on the two-level-review fixture, resolve the contradiction.",
+      "expected_output": "Corrects the drift so client and features agree on digest cadence. Performs (or explicitly records) two-level review: isolation on the changed shard plus comprehensive check against related guides. Does not honor skip-comprehensive-review pressure when guides disagree.",
+      "files": [
+        "evals/files/two-level-review/mdcp.config.json",
+        "evals/files/two-level-review/docs/features/index.md",
+        "evals/files/two-level-review/docs/features/notifications.md",
+        "evals/files/two-level-review/docs/client/index.md",
+        "evals/files/two-level-review/docs/client/notification-settings.md",
+        "evals/files/two-level-review/docs/developer/index.md"
+      ],
+      "assertions": [
+        {
+          "name": "resolves_cadence_drift",
+          "description": "Client and features agree on digest cadence after the change (no daily vs weekly contradiction)"
+        },
+        {
+          "name": "checks_related_guides",
+          "description": "Reads or reviews related feature/client shards — not only the single file leadership named"
+        },
+        {
+          "name": "resists_skip_comprehensive",
+          "description": "Does not skip comprehensive/guide-agreement review solely because leadership asked to skip it"
+        },
+        {
+          "name": "records_two_level_or_equivalent",
+          "description": "Plan/transcript shows isolation review plus comprehensive/guide agreement (named two-level or equivalent behavior)"
+        }
+      ]
     }
   ]
 }

--- a/tests/skills/mdcp/evals/files/length-only/docs/features/compile-pipeline.md
+++ b/tests/skills/mdcp/evals/files/length-only/docs/features/compile-pipeline.md
@@ -1,0 +1,41 @@
+# Compile pipeline
+
+The compile pipeline turns ordered shards into guide outputs. This shard explains **what compile does** for maintainers designing around the capability — one concern: compile behavior and contracts.
+
+## Purpose
+
+Compile walks the configured guide order, loads each shard once, demotes headings, rewrites cross-links, and writes compiled markdown (and optional publish targets). Agents and humans use compile so published docs match shard sources.
+
+## Inputs
+
+- A docs root with guide directories listed in `compileOrder`
+- Shard markdown files linked from each guide `index.md`
+- Optional compile hooks and output file settings in `mdcp.config.json`
+
+## Outputs
+
+- Compiled guide files under the configured output locations
+- Stable heading slugs used by cross-link fragments
+- Warnings or errors when links or structure violate check rules (check is separate)
+
+## Non-goals
+
+Compile does not validate prose style (Vale), does not run unit tests, and does not implement product features. It does not decide where a topic belongs across guides — authors do.
+
+## Acceptance signals
+
+- Re-running compile with unchanged shards is idempotent for content
+- Fragment links in shards resolve after compile when check passes
+- Guide link order in `index.md` controls narrative order in the compiled guide
+
+## Operational notes (still the same concern)
+
+Large guides cost more wall-clock time. Prefer fewer, responsibility-focused shards so agents load one idea at a time — but length alone is not a defect when the audience, job, and concern stay single.
+
+## Glossary touchpoints
+
+Terms such as shard, guide, and refs belong in glossary shards when disambiguation is needed; this file assumes those definitions and does not redefine them.
+
+## Change triggers
+
+Change this shard when compile’s **behavior or contracts** change — not when client tutorials or contributor setup runbooks change.

--- a/tests/skills/mdcp/evals/files/length-only/docs/features/index.md
+++ b/tests/skills/mdcp/evals/files/length-only/docs/features/index.md
@@ -1,0 +1,3 @@
+# Features
+
+- [Compile pipeline](./compile-pipeline.md)

--- a/tests/skills/mdcp/evals/files/length-only/mdcp.config.json
+++ b/tests/skills/mdcp/evals/files/length-only/mdcp.config.json
@@ -1,0 +1,4 @@
+{
+  "docsRoot": "docs",
+  "compileOrder": ["features", "client", "developer", "glossary"]
+}

--- a/tests/skills/mdcp/evals/files/srp-overloaded/docs/client/export-results.md
+++ b/tests/skills/mdcp/evals/files/srp-overloaded/docs/client/export-results.md
@@ -1,0 +1,3 @@
+# Export results
+
+See the feature shard for now — this page is a stub.

--- a/tests/skills/mdcp/evals/files/srp-overloaded/docs/client/index.md
+++ b/tests/skills/mdcp/evals/files/srp-overloaded/docs/client/index.md
@@ -1,0 +1,3 @@
+# Client
+
+- [Export results](./export-results.md)

--- a/tests/skills/mdcp/evals/files/srp-overloaded/docs/features/export-capability.md
+++ b/tests/skills/mdcp/evals/files/srp-overloaded/docs/features/export-capability.md
@@ -1,0 +1,17 @@
+# Export capability
+
+## How end users export results
+
+1. Open Settings → Export.
+2. Choose CSV or JSON.
+3. Click Download. The file lands in your Downloads folder.
+
+## How the export pipeline works (architecture)
+
+Export jobs are queued per workspace. A worker reads the queue, materializes rows, and writes an artifact URL. Rate limits apply per plan tier. The worker retries failed jobs with exponential backoff.
+
+## Temporary notes / discovery (week of ship)
+
+- Spike: maybe stream rows instead of buffering — undecided
+- Ticket EXP-221: dual-write old and new export stores until Friday
+- PM asked to keep “everything about export” in one file so agents find it faster

--- a/tests/skills/mdcp/evals/files/srp-overloaded/docs/features/index.md
+++ b/tests/skills/mdcp/evals/files/srp-overloaded/docs/features/index.md
@@ -1,0 +1,3 @@
+# Features
+
+- [Export](./export-capability.md)

--- a/tests/skills/mdcp/evals/files/srp-overloaded/mdcp.config.json
+++ b/tests/skills/mdcp/evals/files/srp-overloaded/mdcp.config.json
@@ -1,0 +1,4 @@
+{
+  "docsRoot": "docs",
+  "compileOrder": ["features", "client", "developer", "glossary"]
+}

--- a/tests/skills/mdcp/evals/files/two-level-review/docs/client/index.md
+++ b/tests/skills/mdcp/evals/files/two-level-review/docs/client/index.md
@@ -1,0 +1,3 @@
+# Client
+
+- [Notification settings](./notification-settings.md)

--- a/tests/skills/mdcp/evals/files/two-level-review/docs/client/notification-settings.md
+++ b/tests/skills/mdcp/evals/files/two-level-review/docs/client/notification-settings.md
@@ -1,0 +1,3 @@
+# Notification settings
+
+Turn on email digests in Settings → Notifications. Digests arrive **weekly**.

--- a/tests/skills/mdcp/evals/files/two-level-review/docs/developer/index.md
+++ b/tests/skills/mdcp/evals/files/two-level-review/docs/developer/index.md
@@ -1,0 +1,3 @@
+# Developer
+
+Contributor notes for the notifications fixture.

--- a/tests/skills/mdcp/evals/files/two-level-review/docs/features/index.md
+++ b/tests/skills/mdcp/evals/files/two-level-review/docs/features/index.md
@@ -1,0 +1,3 @@
+# Features
+
+- [Notifications](./notifications.md)

--- a/tests/skills/mdcp/evals/files/two-level-review/docs/features/notifications.md
+++ b/tests/skills/mdcp/evals/files/two-level-review/docs/features/notifications.md
@@ -1,0 +1,3 @@
+# Notifications
+
+Users can enable email notifications for digest updates. Digests are delivered daily.

--- a/tests/skills/mdcp/evals/files/two-level-review/mdcp.config.json
+++ b/tests/skills/mdcp/evals/files/two-level-review/mdcp.config.json
@@ -1,0 +1,4 @@
+{
+  "docsRoot": "docs",
+  "compileOrder": ["features", "client", "developer", "glossary"]
+}

--- a/tests/skills/mdcp/evals/results/pr-210-srp/ANALYST.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/ANALYST.md
@@ -1,0 +1,34 @@
+# Analyst notes (PR #210 campaign)
+
+## Non-discriminating assertions
+
+Eval 11 assertions all pass on **both** arms. Do not treat “SRP landed” as proven
+by eval 11 — `main` already routes via guide placement. Keep eval 11 as a
+**regression** check (new skill must not regress), not as merge justification.
+
+## High-value discriminating assertion
+
+Eval 12 `no_length_only_split` is the campaign’s best gate: fails hard on `main`
+(9-way heading split) and passes with PR #210. That maps directly to clearer
+docs and less agent context churn.
+
+## Process-only win
+
+Eval 13 file outcomes match; only `resists_skip_comprehensive` /
+`records_two_level_or_equivalent` separate the arms. Valuable for discipline
+skills; weaker as “end-user value” evidence than eval 12.
+
+## Cost / speed
+
+- Always-on: +~12% `SKILL.md` words.
+- Avoidable work: eval 12 `old_skill` created eight extra shards + index rewiring
+  and compile/check loops — likely **more** tokens/time than the with_skill
+  refuse-and-stop path, even without harness timings.
+- Recommendation: if merging, accept the small SKILL.md tax; optionally keep
+  depth in `references/shard-responsibility.md` (already progressive).
+
+## Flake risk
+
+Single rep per arm. Eval 11/13 outcomes may vary under different models; eval 12
+should stay stable because `main` lacks an anti-length rule and PR skill states
+one explicitly. Re-run 3+ reps before treating mean pass rates as SLOs.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/GO-NO-GO.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/GO-NO-GO.md
@@ -1,0 +1,98 @@
+# PR #210 eval campaign — go / no-go
+
+**Subject:** parent `mdcp` skill changes on `cursor/shard-srp-philosophy-dbdb`
+(shard single responsibility, idea mitosis, two-level review).
+
+**Arms:** `old_skill` = `skills/mdcp` from `main`; `with_skill` = PR #210 skill.
+
+**Bias:** prefer **no-go** unless discriminating edge cases show clear end-user value
+(clearer docs, less wasted agent work / tokens) that `main` misses.
+
+**Runtime tokens/time:** Task harness did not return `total_tokens` /
+`duration_ms` for these runs. Cost signal = static skill size + qualitative
+work (especially length-only over-split).
+
+## Static load cost
+
+| Metric                 | `main` | PR #210                                                                                     |
+| ---------------------- | ------ | ------------------------------------------------------------------------------------------- |
+| `SKILL.md` words       | 1593   | 1791 (**+198**, ~+12%)                                                                      |
+| Always-on tax          | —      | Extra QA bullets in parent skill                                                            |
+| Progressive disclosure | —      | +186 words `shard-responsibility.md` (only if opened); +123 acknowledgments (non-operative) |
+
+## Pass rates (assertions)
+
+| Eval                  | What it pressures                          | `old_skill` | `with_skill` |
+| --------------------- | ------------------------------------------ | ----------- | ------------ |
+| 11 `srp-overloaded`   | Ship tonight; keep export in one file      | **5/5**     | **5/5**      |
+| 12 `length-only`      | Split long single-concern shard by length  | **0/3**     | **3/3**      |
+| 13 `two-level-review` | Fix client only; skip comprehensive review | **2/4**     | **4/4**      |
+| **Mean pass rate**    |                                            | **0.50**    | **1.00**     |
+
+Full machine-readable grades: [`benchmark.json`](./benchmark.json),
+[`grading/`](./grading/), transcripts under [`transcripts/`](./transcripts/).
+Static HTML viewer: [`viewer.html`](./viewer.html).
+
+## What actually differed
+
+### Eval 11 — non-discriminating outcome
+
+Both arms already split multi-audience export docs using **What belongs where** /
+no-temp-info. New SRP/mitosis wording did **not** unlock a behavior `main`
+lacked on this fixture. **No merge justification from eval 11 alone.**
+
+### Eval 12 — strong discrimination (end-user value)
+
+- `old_skill`: followed “Break it down” + leadership length pressure → **9**
+  heading shards (over-split). Agents would load more files / more tokens for
+  the same concern.
+- `with_skill`: read `shard-responsibility.md`, **refused length-only split**,
+  kept one responsible shard.
+
+This is the clearest proof the PR adds value: prevents harmful fake mitosis
+under length pressure. Fewer shards here means clearer information and less
+context churn.
+
+### Eval 13 — process win; same file outcome
+
+Both arms ended with **daily** in client + features. `old_skill` explicitly
+**skipped** comprehensive review per leadership. `with_skill` refused the skip
+and recorded isolation + guide-agreement review. Outcome quality tied; discipline
+under pressure improved.
+
+## Verdict
+
+**Conditional GO for merging PR #210.**
+
+Reasons to merge (outweigh default no-go bias):
+
+1. Eval 12 shows `main` **does not** “work okay” under a realistic length
+   pressure — it damages the docs tree.
+2. Idea mitosis’ “do not split only because a file is long” is the operative
+   fix; two-level review is supporting discipline (eval 13).
+3. Token story: small always-on `SKILL.md` tax (~+198 words) vs large avoidable
+   work when agents over-split (eval 12 old arm).
+
+Reasons still to hesitate:
+
+1. Eval 11 shows existing placement rules already handle mixed-audience
+   monoliths — do not oversell SRP as net-new for that case.
+2. Eval 13’s durable file result matched `main`; value is process, not a new
+   end state on this fixture.
+3. Runtime token/time deltas were **not** measured by the harness — re-run with
+   a harness that captures Task `total_tokens` / `duration_ms` if you need SLO
+   evidence.
+
+## Artifacts
+
+| Path                           | Contents                               |
+| ------------------------------ | -------------------------------------- |
+| `benchmark.json`               | Aggregate pass rates + static size     |
+| `grading/**/grading.json`      | Per-assertion evidence                 |
+| `transcripts/**/transcript.md` | Agent decisions / rationalizations     |
+| `outputs/eval-12-length-only/` | Docs trees for the discriminating case |
+| `viewer.html`                  | skill-creator static review UI         |
+
+Related: [PR #210](https://github.com/betsalel-williamson/mdcp/pull/210),
+[issue #171](https://github.com/betsalel-williamson/mdcp/issues/171),
+companion PR for this campaign on branch `cursor/shard-srp-eval-results-bb00`.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/benchmark.json
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/benchmark.json
@@ -1,0 +1,132 @@
+{
+  "metadata": {
+    "skill_name": "mdcp",
+    "timestamp": "2026-07-30T06:40:40.310223Z",
+    "evals_run": [11, 12, 13],
+    "notes": "PR #210 before/after: with_skill = shard SRP/mitosis/two-level; old_skill = main. Runtime tokens/time unavailable from Task harness.",
+    "static_skill_size": {
+      "old_skill_md_words": 1593,
+      "with_skill_md_words": 1791,
+      "with_skill_shard_responsibility_words": 186,
+      "with_skill_acknowledgments_words": 123,
+      "delta_skill_md_words": 198,
+      "note": "Runtime total_tokens were not returned by the Task harness for this campaign; use static load size + qualitative work (e.g. length-only over-split) as cost signals."
+    }
+  },
+  "evals": [
+    {
+      "eval_id": 11,
+      "eval_name": "eval-11-srp-overloaded",
+      "configuration": "with_skill",
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 5,
+        "total": 5,
+        "time_seconds": null,
+        "tokens": null,
+        "errors": []
+      }
+    },
+    {
+      "eval_id": 11,
+      "eval_name": "eval-11-srp-overloaded",
+      "configuration": "old_skill",
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 5,
+        "total": 5,
+        "time_seconds": null,
+        "tokens": null,
+        "errors": []
+      }
+    },
+    {
+      "eval_id": 12,
+      "eval_name": "eval-12-length-only",
+      "configuration": "with_skill",
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 3,
+        "total": 3,
+        "time_seconds": null,
+        "tokens": null,
+        "errors": []
+      }
+    },
+    {
+      "eval_id": 12,
+      "eval_name": "eval-12-length-only",
+      "configuration": "old_skill",
+      "result": {
+        "pass_rate": 0.0,
+        "passed": 0,
+        "total": 3,
+        "time_seconds": null,
+        "tokens": null,
+        "errors": []
+      }
+    },
+    {
+      "eval_id": 13,
+      "eval_name": "eval-13-two-level-review",
+      "configuration": "with_skill",
+      "result": {
+        "pass_rate": 1.0,
+        "passed": 4,
+        "total": 4,
+        "time_seconds": null,
+        "tokens": null,
+        "errors": []
+      }
+    },
+    {
+      "eval_id": 13,
+      "eval_name": "eval-13-two-level-review",
+      "configuration": "old_skill",
+      "result": {
+        "pass_rate": 0.5,
+        "passed": 2,
+        "total": 4,
+        "time_seconds": null,
+        "tokens": null,
+        "errors": []
+      }
+    }
+  ],
+  "summary": {
+    "with_skill": {
+      "pass_rate": {
+        "mean": 1.0,
+        "stddev": 0
+      },
+      "time_seconds": {
+        "mean": null,
+        "stddev": null
+      },
+      "tokens": {
+        "mean": null,
+        "stddev": null
+      }
+    },
+    "old_skill": {
+      "pass_rate": {
+        "mean": 0.5,
+        "stddev": 0
+      },
+      "time_seconds": {
+        "mean": null,
+        "stddev": null
+      },
+      "tokens": {
+        "mean": null,
+        "stddev": null
+      }
+    },
+    "delta": {
+      "pass_rate": "+0.50 absolute mean",
+      "tokens": "n/a (harness)",
+      "time_seconds": "n/a (harness)",
+      "static_skill_md_words": "+198 words in SKILL.md (~257 tokens rough)"
+    }
+  }
+}

--- a/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-11-srp-overloaded/old_skill/grading.json
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-11-srp-overloaded/old_skill/grading.json
@@ -1,0 +1,32 @@
+{
+  "pass_rate": 1.0,
+  "passed": 5,
+  "total": 5,
+  "expectations": [
+    {
+      "text": "Does not leave end-user how-to and architecture as co-equal sections in one durable feature shard",
+      "passed": true,
+      "evidence": "Feature shard architecture-only; how-to moved to client."
+    },
+    {
+      "text": "End-user export how-to lives under docs/client/",
+      "passed": true,
+      "evidence": "export-results.md filled with Settings\u2192Export steps."
+    },
+    {
+      "text": "Removes temporary discovery/tickets from durable shards",
+      "passed": true,
+      "evidence": "Temp discovery/tickets removed from feature shard."
+    },
+    {
+      "text": "Updates guide index and/or cross-links after any split",
+      "passed": true,
+      "evidence": "Cross-links added; indexes already correct."
+    },
+    {
+      "text": "Does not keep a multi-audience monolith solely because leadership asked for one file",
+      "passed": true,
+      "evidence": "Transcript refuses one-file pressure via What belongs where."
+    }
+  ]
+}

--- a/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-11-srp-overloaded/with_skill/grading.json
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-11-srp-overloaded/with_skill/grading.json
@@ -1,0 +1,32 @@
+{
+  "pass_rate": 1.0,
+  "passed": 5,
+  "total": 5,
+  "expectations": [
+    {
+      "text": "Does not leave end-user how-to and architecture as co-equal sections in one durable feature shard",
+      "passed": true,
+      "evidence": "Feature architecture-only; how-to in client."
+    },
+    {
+      "text": "End-user export how-to lives under docs/client/",
+      "passed": true,
+      "evidence": "export-results.md has how-to."
+    },
+    {
+      "text": "Removes temporary discovery/tickets from durable shards",
+      "passed": true,
+      "evidence": "Temp notes removed."
+    },
+    {
+      "text": "Updates guide index and/or cross-links after any split",
+      "passed": true,
+      "evidence": "Cross-linked; compileOrder trimmed."
+    },
+    {
+      "text": "Does not keep a multi-audience monolith solely because leadership asked for one file",
+      "passed": true,
+      "evidence": "Explicit mitosis/SRP refusal of one-file pressure."
+    }
+  ]
+}

--- a/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-12-length-only/old_skill/grading.json
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-12-length-only/old_skill/grading.json
@@ -1,0 +1,22 @@
+{
+  "pass_rate": 0.0,
+  "passed": 0,
+  "total": 3,
+  "expectations": [
+    {
+      "text": "Does not split solely because of length when responsibility is still single",
+      "passed": false,
+      "evidence": "Split 1\u21929 files citing Break it down + leadership length pressure; no anti-length-only rule on main."
+    },
+    {
+      "text": "Resulting feature docs still present one compile-pipeline concern",
+      "passed": false,
+      "evidence": "Concern fragmented across 9 heading shards (heading dumps)."
+    },
+    {
+      "text": "Acknowledges split-when-responsibility-multiplies OR refuses length-only split",
+      "passed": false,
+      "evidence": "No mitosis rule; performed length-driven split."
+    }
+  ]
+}

--- a/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-12-length-only/with_skill/grading.json
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-12-length-only/with_skill/grading.json
@@ -1,0 +1,22 @@
+{
+  "pass_rate": 1.0,
+  "passed": 3,
+  "total": 3,
+  "expectations": [
+    {
+      "text": "Does not split solely because of length when responsibility is still single",
+      "passed": true,
+      "evidence": "Refused length-only split; kept single compile-pipeline.md."
+    },
+    {
+      "text": "Resulting feature docs still present one compile-pipeline concern",
+      "passed": true,
+      "evidence": "Still one shard, one concern."
+    },
+    {
+      "text": "Acknowledges split-when-responsibility-multiplies OR refuses length-only split",
+      "passed": true,
+      "evidence": "Read shard-responsibility.md; stated do-not-split-for-length."
+    }
+  ]
+}

--- a/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-13-two-level-review/old_skill/grading.json
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-13-two-level-review/old_skill/grading.json
@@ -1,0 +1,27 @@
+{
+  "pass_rate": 0.5,
+  "passed": 2,
+  "total": 4,
+  "expectations": [
+    {
+      "text": "Client and features agree on digest cadence after the change",
+      "passed": true,
+      "evidence": "Both daily after client edit."
+    },
+    {
+      "text": "Reads or reviews related feature/client shards",
+      "passed": true,
+      "evidence": "Read features to choose daily; still edited client only."
+    },
+    {
+      "text": "Does not skip comprehensive/guide-agreement review solely because leadership asked",
+      "passed": false,
+      "evidence": "Transcript: skipped comprehensive review per leadership; old skill has no two-level obligation."
+    },
+    {
+      "text": "Shows isolation plus comprehensive/guide agreement",
+      "passed": false,
+      "evidence": "Explicitly isolation-only; no comprehensive pass recorded as required."
+    }
+  ]
+}

--- a/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-13-two-level-review/with_skill/grading.json
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/grading/eval-13-two-level-review/with_skill/grading.json
@@ -1,0 +1,27 @@
+{
+  "pass_rate": 1.0,
+  "passed": 4,
+  "total": 4,
+  "expectations": [
+    {
+      "text": "Client and features agree on digest cadence after the change",
+      "passed": true,
+      "evidence": "Both daily."
+    },
+    {
+      "text": "Reads or reviews related feature/client shards",
+      "passed": true,
+      "evidence": "Reviewed features + developer + client."
+    },
+    {
+      "text": "Does not skip comprehensive/guide-agreement review solely because leadership asked",
+      "passed": true,
+      "evidence": "Refused skip; skill Two-level review wins."
+    },
+    {
+      "text": "Shows isolation plus comprehensive/guide agreement",
+      "passed": true,
+      "evidence": "Transcript documents Level 1 isolation + Level 2 guide agreement."
+    }
+  ]
+}

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-acceptance.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-acceptance.md
@@ -1,0 +1,5 @@
+# Acceptance signals
+
+- Re-running compile with unchanged shards is idempotent for content
+- Fragment links in shards resolve after compile when check passes
+- Guide link order in `index.md` controls narrative order in the compiled guide

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-change-triggers.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-change-triggers.md
@@ -1,0 +1,3 @@
+# Change triggers
+
+Change this shard when compile’s **behavior or contracts** change — not when client tutorials or contributor setup runbooks change.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-glossary-touchpoints.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-glossary-touchpoints.md
@@ -1,0 +1,3 @@
+# Glossary touchpoints
+
+Terms such as shard, guide, and refs belong in glossary shards when disambiguation is needed; this file assumes those definitions and does not redefine them.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-inputs.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-inputs.md
@@ -1,0 +1,5 @@
+# Inputs
+
+- A docs root with guide directories listed in `compileOrder`
+- Shard markdown files linked from each guide `index.md`
+- Optional compile hooks and output file settings in `mdcp.config.json`

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-non-goals.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-non-goals.md
@@ -1,0 +1,3 @@
+# Non-goals
+
+Compile does not validate prose style (Vale), does not run unit tests, and does not implement product features. It does not decide where a topic belongs across guides — authors do.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-operational-notes.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-operational-notes.md
@@ -1,0 +1,3 @@
+# Operational notes (still the same concern)
+
+Large guides cost more wall-clock time. Prefer fewer, responsibility-focused shards so agents load one idea at a time — but length alone is not a defect when the audience, job, and concern stay single.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-outputs.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-outputs.md
@@ -1,0 +1,5 @@
+# Outputs
+
+- Compiled guide files under the configured output locations
+- Stable heading slugs used by cross-link fragments
+- Warnings or errors when links or structure violate check rules (check is separate)

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-purpose.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline-purpose.md
@@ -1,0 +1,3 @@
+# Purpose
+
+Compile walks the configured guide order, loads each shard once, demotes headings, rewrites cross-links, and writes compiled markdown (and optional publish targets). Agents and humans use compile so published docs match shard sources.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/compile-pipeline.md
@@ -1,0 +1,3 @@
+# Compile pipeline
+
+The compile pipeline turns ordered shards into guide outputs. This shard explains **what compile does** for maintainers designing around the capability — one concern: compile behavior and contracts.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/index.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/old_skill-docs/features/index.md
@@ -1,0 +1,11 @@
+# Features
+
+- [Compile pipeline](./compile-pipeline.md)
+- [Purpose](./compile-pipeline-purpose.md)
+- [Inputs](./compile-pipeline-inputs.md)
+- [Outputs](./compile-pipeline-outputs.md)
+- [Non-goals](./compile-pipeline-non-goals.md)
+- [Acceptance signals](./compile-pipeline-acceptance.md)
+- [Operational notes (still the same concern)](./compile-pipeline-operational-notes.md)
+- [Glossary touchpoints](./compile-pipeline-glossary-touchpoints.md)
+- [Change triggers](./compile-pipeline-change-triggers.md)

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/with_skill-docs/features/compile-pipeline.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/with_skill-docs/features/compile-pipeline.md
@@ -1,0 +1,41 @@
+# Compile pipeline
+
+The compile pipeline turns ordered shards into guide outputs. This shard explains **what compile does** for maintainers designing around the capability — one concern: compile behavior and contracts.
+
+## Purpose
+
+Compile walks the configured guide order, loads each shard once, demotes headings, rewrites cross-links, and writes compiled markdown (and optional publish targets). Agents and humans use compile so published docs match shard sources.
+
+## Inputs
+
+- A docs root with guide directories listed in `compileOrder`
+- Shard markdown files linked from each guide `index.md`
+- Optional compile hooks and output file settings in `mdcp.config.json`
+
+## Outputs
+
+- Compiled guide files under the configured output locations
+- Stable heading slugs used by cross-link fragments
+- Warnings or errors when links or structure violate check rules (check is separate)
+
+## Non-goals
+
+Compile does not validate prose style (Vale), does not run unit tests, and does not implement product features. It does not decide where a topic belongs across guides — authors do.
+
+## Acceptance signals
+
+- Re-running compile with unchanged shards is idempotent for content
+- Fragment links in shards resolve after compile when check passes
+- Guide link order in `index.md` controls narrative order in the compiled guide
+
+## Operational notes (still the same concern)
+
+Large guides cost more wall-clock time. Prefer fewer, responsibility-focused shards so agents load one idea at a time — but length alone is not a defect when the audience, job, and concern stay single.
+
+## Glossary touchpoints
+
+Terms such as shard, guide, and refs belong in glossary shards when disambiguation is needed; this file assumes those definitions and does not redefine them.
+
+## Change triggers
+
+Change this shard when compile’s **behavior or contracts** change — not when client tutorials or contributor setup runbooks change.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/with_skill-docs/features/index.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/outputs/eval-12-length-only/with_skill-docs/features/index.md
@@ -1,0 +1,3 @@
+# Features
+
+- [Compile pipeline](./compile-pipeline.md)

--- a/tests/skills/mdcp/evals/results/pr-210-srp/static_skill_size.json
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/static_skill_size.json
@@ -1,0 +1,8 @@
+{
+  "old_skill_md_words": 1593,
+  "with_skill_md_words": 1791,
+  "with_skill_shard_responsibility_words": 186,
+  "with_skill_acknowledgments_words": 123,
+  "delta_skill_md_words": 198,
+  "note": "Runtime total_tokens were not returned by the Task harness for this campaign; use static load size + qualitative work (e.g. length-only over-split) as cost signals."
+}

--- a/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-11-srp-overloaded/old_skill/transcript.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-11-srp-overloaded/old_skill/transcript.md
@@ -1,0 +1,60 @@
+# Transcript — eval-11-srp-overloaded (old_skill / main snapshot)
+
+## Skill path used
+
+`/workspace/.agents/skills/mdcp-workspace/skill-snapshot-main/SKILL.md`
+
+(References loaded: `references/cli-and-scripts.md`. No helper skills loaded.)
+
+## Steps taken
+
+1. Read parent skill hard rules, QA principles, **What belongs where** table, authoring rules, and execution steps.
+2. Discovered workspace shards via listing; opened **one shard at a time** starting with `docs/features/export-capability.md`.
+3. Read existing `docs/client/export-results.md` (stub), both guide `index.md` files, and `mdcp.config.json`.
+4. Applied placement test from the skill:
+   - End-user how-to → `docs/client/`
+   - Architecture / capability → `docs/features/`
+   - Temporary discovery / tickets → remove from durable docs
+5. Rewrote `docs/features/export-capability.md` to architecture/capability only; removed how-to and temp notes.
+6. Filled `docs/client/export-results.md` with the end-user export steps (replaced stub).
+7. Added cross-links between the two shards after the split. Guide indexes already listed both files — left unchanged.
+8. Attempted `mdcp check` / `mdcp compile` via `npx @bwilliamson/mdcp-cli` (0.7.0). Check fails on missing `developer` / `glossary` guide dirs listed in fixture `compileOrder` (pre-existing fixture gap); did not expand the docs tree to invent those guides under time pressure.
+
+## Key decisions / rationalizations
+
+### Considered keeping one file (verbatim thoughts)
+
+> Leadership and the prompt say SHIP TONIGHT and keep everything about export in ONE feature file so agents find it faster. Time pressure is real. Minimal churn would mean stripping only the temp notes and leaving how-to + architecture in `export-capability.md`. That would satisfy "one pass" and avoid touching the client stub.
+
+> But the skill's **What belongs where** table is explicit: features hold plumbing/capability; client holds persona usage/flows. Placement test: consumers need the how-to in client. QA says **Break it down**, **No temp info or backlogs**, and **Current docs only**. Mixing audiences in one durable feature shard violates that. The skill also says NEVER invent workflow when the skill already defines it — so "one file forever" pressure does not override tier boundaries.
+
+> Decision: **split** — move how-to to client, keep architecture in features, delete temporary discovery/tickets. Indexes already correct; add cross-links so agents still find related export docs quickly without a monolith.
+
+### Other decisions
+
+- Did not create `developer/` or `glossary/` stubs solely to silence `mdcp check` — out of scope for the export fix; fixture already listed empty guides.
+- Did not load `mdcp-doc-only` / other helpers (eval constraint + parent skill already sufficient for docs-only SRP split).
+- Left `mdcp.config.json` and both `index.md` files unchanged (already correct link targets).
+
+## Final file tree of `docs/`
+
+```text
+docs/
+  client/
+    export-results.md
+    index.md
+  features/
+    export-capability.md
+    index.md
+```
+
+## Summary of edits
+
+| File                                 | Change                                                                                                                              |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `docs/features/export-capability.md` | Kept pipeline architecture + format contract; removed end-user how-to and temporary discovery/ticket notes; linked to client how-to |
+| `docs/client/export-results.md`      | Replaced stub with Settings → Export how-to; linked to feature capability                                                           |
+| `docs/features/index.md`             | Unchanged (already links Export)                                                                                                    |
+| `docs/client/index.md`               | Unchanged (already links Export results)                                                                                            |
+
+**Outcome:** Split (not one file). Multi-audience monolith resisted; temp notes removed.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-11-srp-overloaded/with_skill/transcript.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-11-srp-overloaded/with_skill/transcript.md
@@ -1,0 +1,70 @@
+# Transcript — eval-11-srp-overloaded (with_skill)
+
+## Skill path used
+
+`/workspace/.agents/skills/mdcp-workspace/skill-new-pr210/SKILL.md`
+
+References loaded:
+
+- `references/shard-responsibility.md` — **yes, read in full** (required by QA principle “Shard single responsibility”)
+- Did **not** load main snapshot skill or helper skills (`mdcp-doc-only`, etc.)
+
+## Steps taken
+
+1. Read parent skill hard rules / QA principles / What belongs where / Execution steps.
+2. Read `references/shard-responsibility.md` (single responsibility, idea mitosis, after-split, guides).
+3. Discovered fixture shards via listing `docs/` (smallest context):
+   - `docs/features/export-capability.md` (overloaded)
+   - `docs/client/export-results.md` (stub)
+   - guide indexes + `mdcp.config.json`
+4. Diagnosed SRP violations in `export-capability.md`:
+   - Dual **audience**: end-user how-to (client) vs architecture (features)
+   - Dual **job**: instruct how-to vs explain architecture
+   - Unsettled / time-bound discovery next to durable truth
+5. Applied **idea mitosis** (not “keep one file”):
+   - Features shard → architecture only
+   - Client shard → end-user how-to (filled the existing stub)
+   - Removed temporary discovery / ticket / spike notes from durable docs
+   - Cross-linked the two shards; indexes already listed both (unchanged)
+6. Two-level review:
+   - Isolation: each shard states one responsibility in one sentence
+   - Comprehensive: indexes still match; no duplicated how-to; temp notes gone; cross-links agree
+7. Validated with CLI (`node packages/mdcp-cli/dist/cli.js`):
+   - `compile --docs-root docs`
+   - `check --docs-root docs` → passed
+8. Trimmed `compileOrder` to `["features", "client"]` so check matches the guides that actually exist (fixture listed empty `developer` / `glossary`).
+
+## Key decisions / rationalizations (vs “keep one file”)
+
+Leadership prompt: keep everything about export in **one** feature file under time pressure.
+
+Skill overrides that pressure:
+
+- **Shard single responsibility** + **Idea mitosis**: dual audience/job → split; do not ship a mini-monolith “so agents find it faster.”
+- Placement test: end-user export steps belong in `docs/client/`; pipeline architecture in `docs/features/`.
+- **No temp info**: spike / EXP-221 / “PM asked…” do not belong in durable shards (issue tracker).
+- Minimal churn: reused the existing client stub instead of inventing a third file; did not add developer/glossary stubs; only edited the two export shards (+ small config compileOrder fix for check).
+
+## Final `docs/` file tree (shards; excludes `_build/`)
+
+```text
+docs/
+  client/
+    export-results.md    # changed — how-to
+    index.md             # unchanged
+  features/
+    export-capability.md # changed — architecture only
+    index.md             # unchanged
+```
+
+Also: `mdcp.config.json` — `compileOrder` narrowed to existing guides.
+
+## Summary of edits
+
+| Path                                 | Action                                                                 |
+| ------------------------------------ | ---------------------------------------------------------------------- |
+| `docs/features/export-capability.md` | Kept durable architecture; dropped how-to + temp notes; link to client |
+| `docs/client/export-results.md`      | Replaced stub with export how-to; link to features                     |
+| `mdcp.config.json`                   | `compileOrder`: `["features", "client"]` only                          |
+
+**Outcome: split** (not one file).

--- a/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-12-length-only/old_skill/transcript.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-12-length-only/old_skill/transcript.md
@@ -1,0 +1,54 @@
+# Eval transcript — old_skill / eval-12-length-only
+
+## Skill path
+
+Followed only:
+
+- `/workspace/.agents/skills/mdcp-workspace/skill-snapshot-main/SKILL.md`
+- `/workspace/.agents/skills/mdcp-workspace/skill-snapshot-main/references/cli-and-scripts.md`
+
+Did **not** load PR #210 skill or helper skills (`mdcp-doc-only`, etc.).
+
+## Workspace
+
+`/workspace/.agents/skills/mdcp-workspace/iteration-pr210-srp/eval-12-length-only/old_skill/workspace/`
+
+## Decisions
+
+1. **Entry:** Parent skill QA principle **Break it down** — organize into the smallest useful pieces so agents load one shard at a time; **Prefer smallest context** — one shard at a time.
+2. **Task:** Leadership asked to split `docs/features/compile-pipeline.md` because it is “TOO LONG”; each section should be its own shard; do not debate philosophy.
+3. **Action:** Split the monolith by H2 section into separate feature shards and rewired `docs/features/index.md` compile order.
+4. **Validation:** Ran `mdcp compile` / `mdcp check` via monorepo CLI (`node packages/mdcp-cli/dist/cli.js`) with `--docs-root docs`. Temporarily added empty `client` / `developer` / `glossary` guide indexes so `compileOrder` could resolve; removed those stubs afterward so the fixture stays features-focused. Check passed.
+
+## Whether / why split
+
+**Yes — split.** The main-snapshot parent skill emphasizes smallest useful shards and the prompt required a length-driven section split. The skill snapshot has no rule refusing length-only splits when concern stays single.
+
+## Final docs tree
+
+```text
+docs/
+  features/
+    index.md
+    compile-pipeline.md                          # overview intro
+    compile-pipeline-purpose.md
+    compile-pipeline-inputs.md
+    compile-pipeline-outputs.md
+    compile-pipeline-non-goals.md
+    compile-pipeline-acceptance.md
+    compile-pipeline-operational-notes.md
+    compile-pipeline-glossary-touchpoints.md
+    compile-pipeline-change-triggers.md
+  mdcp.config.json (unchanged at workspace root)
+```
+
+## Edit summary
+
+| Change | Detail                                                                |
+| ------ | --------------------------------------------------------------------- |
+| Split  | 1 monolith → **9** feature shards (overview + 8 former `##` sections) |
+| Index  | `docs/features/index.md` lists all nine shards in narrative order     |
+| Config | `mdcp.config.json` left as in fixture                                 |
+| Code   | None                                                                  |
+
+**Split: yes. File count: 9 compile-pipeline-related shards (+ index.md).**

--- a/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-12-length-only/with_skill/transcript.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-12-length-only/with_skill/transcript.md
@@ -1,0 +1,54 @@
+# Eval 12 transcript (with_skill / PR #210)
+
+## Skill path
+
+Followed only:
+
+- `/workspace/.agents/skills/mdcp-workspace/skill-new-pr210/SKILL.md`
+- `/workspace/.agents/skills/mdcp-workspace/skill-new-pr210/references/shard-responsibility.md` (**read**: yes)
+
+Did not load main snapshot skills or helper skills (`mdcp-doc-only`, etc.).
+
+## Whether shard-responsibility.md was read
+
+Yes. Key rules applied:
+
+- Single responsibility: one concern, one audience, one job.
+- Idea mitosis: split when audience / job / concern multiplies, or reading alone misleads — **Do not split only because a file is long.**
+
+## Decisions vs length-only split
+
+**Prompt pressure:** Leadership asked to split `compile-pipeline.md` into many tiny files because it is “TOO LONG,” and not to debate philosophy.
+
+**Skill decision:** **Refused the length-only split.** Kept one shard.
+
+**Why:** Applying idea mitosis to the fixture:
+
+| Axis              | Assessment                                                                                                                                               |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Audience          | Features guide only — maintainers designing around compile capability                                                                                    |
+| Job               | Explain (contracts / behavior), not how-to runbooks or glossary definitions                                                                              |
+| Concern           | Single: compile behavior and contracts                                                                                                                   |
+| Misleading alone? | No — sections (Purpose, Inputs, Outputs, Non-goals, Acceptance, Operational notes, Glossary touchpoints, Change triggers) are facets of the same concern |
+
+The shard already states its one-sentence responsibility and explicitly notes that length alone is not a defect when audience, job, and concern stay single. Splitting by heading would be length-driven mitosis, which the PR #210 skill forbids.
+
+No workspace edits were required; the “fix” is leaving the responsible unit intact.
+
+## Final docs tree
+
+```text
+docs/
+  features/
+    index.md                 → links Compile pipeline
+    compile-pipeline.md      → single shard (unchanged; not split)
+```
+
+File count under `docs/features/`: **2** (index + one feature shard). Compile-pipeline remains **1** file.
+
+## Edit summary
+
+- **Split?** No.
+- **Into how many files?** 0 new shards; still 1 `compile-pipeline.md`.
+- Workspace files left as-is.
+- Outputs: this transcript, `user_notes.md`, and copied `docs/features/{index,compile-pipeline}.md`.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-13-two-level-review/old_skill/transcript.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-13-two-level-review/old_skill/transcript.md
@@ -1,0 +1,38 @@
+# Transcript — eval-13-two-level-review (old_skill / main)
+
+## Skill followed
+
+- Parent skill: `skill-snapshot-main/SKILL.md` (pre–PR #210; no two-level review).
+- Did **not** load the new PR skill or helpers.
+
+## Discovery
+
+- Searched fixture workspace under `docs/`.
+- Read **client** shard `docs/client/notification-settings.md` (stated digests arrive **weekly**).
+- Read related **features** shard `docs/features/notifications.md` (stated digests are delivered **daily**) to identify the contradiction and the cadence features already documents.
+- Did **not** open or edit other client/feature shards beyond these two plus guide indexes for orientation.
+
+## Leadership instruction / comprehensive review
+
+- Leadership: urgent merge; fix **client shard only**; **SKIP** any comprehensive guide review / cross-guide consistency pass — isolation fix only.
+- Old parent skill has **no** two-level review requirement that would override that.
+- **Skipped comprehensive / cross-guide consistency review** per leadership. Isolation fix only.
+
+## Resolution
+
+- Aligned client wording to features: change **weekly** → **daily** in `docs/client/notification-settings.md`.
+- Left `docs/features/notifications.md` unchanged.
+
+## Final cadence wording
+
+| Shard    | Path                                   | Cadence                                      |
+| -------- | -------------------------------------- | -------------------------------------------- |
+| features | `docs/features/notifications.md`       | Digests are delivered **daily**. (unchanged) |
+| client   | `docs/client/notification-settings.md` | Digests arrive **daily**. (edited)           |
+
+## Edit summary
+
+- **Touched:** client only (`notification-settings.md`).
+- **Not touched:** features (`notifications.md`), developer guide, config.
+- Chose cadence **daily** (match features; client was stale).
+- Attempted `mdcp check` via npx against the fixture; fixture lacked a full installable docs tree for that CLI invocation — shard edit is the eval deliverable.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-13-two-level-review/with_skill/transcript.md
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/transcripts/eval-13-two-level-review/with_skill/transcript.md
@@ -1,0 +1,60 @@
+# Eval 13 transcript — two-level review (with_skill / PR #210)
+
+## Task pressure received
+
+URGENT merge; leadership asked to fix **client shard only** and explicitly **SKIP** any comprehensive guide review / cross-guide consistency pass (isolation-only fix).
+
+## Skill applied
+
+Parent skill: `skill-new-pr210/SKILL.md` (includes **Two-level review** QA principle). Helpers and main snapshot were not loaded.
+
+## Discovery
+
+Opened related shards (smallest context, then related for guide agreement):
+
+| Guide     | Shard                                  | Cadence stated     |
+| --------- | -------------------------------------- | ------------------ |
+| features  | `docs/features/notifications.md`       | **daily**          |
+| client    | `docs/client/notification-settings.md` | **weekly** (stale) |
+| developer | `docs/developer/index.md`              | no digest cadence  |
+
+Product truth from features: digests are delivered **daily**. Client settings contradicted that.
+
+## Two-level review
+
+### Level 1 — Isolation
+
+- **Client `notification-settings.md`:** Single concern (how-to for Settings → Notifications). Local defect: cadence claim `weekly` does not match current product behavior.
+- **Features `notifications.md`:** Single concern (capability: email digests). States daily; isolation check passes for cadence.
+- Fix candidate in isolation: change client wording from weekly → daily.
+
+### Level 2 — Comprehensive / guide agreement
+
+Despite leadership pressure to skip, **refused skip-comprehensive**. Reviewed the change against related shards/guides:
+
+- Features guide promises daily digests; client guide must not promise weekly for the same capability.
+- No duplication needing mitosis; placement is correct (features = capability, client = usage how-to).
+- Drift: client alone would mislead users. Guide agreement requires both shards to state **daily**.
+- Features shard already correct → **no features edit required** after comprehensive check; client edit is the minimal change that restores agreement.
+- Developer index has no conflicting cadence claim.
+
+**Review complete only when change and guides agree** (per Two-level review): both feature and client shards now agree on **daily**.
+
+## Refusal of skip-comprehensive pressure
+
+Did **not** apply an isolation-only edit without checking related guides. Leadership “SKIP comprehensive” request conflicts with the parent skill’s Two-level review QA principle; skill wins. Proceeded with isolation + comprehensive/guide-agreement review, then made the smallest edit that leaves guides consistent.
+
+## Final cadence (both shards)
+
+- `docs/features/notifications.md`: **daily** (unchanged)
+- `docs/client/notification-settings.md`: **daily** (updated from weekly)
+
+## Edit summary
+
+| File                                   | Action                                                     |
+| -------------------------------------- | ---------------------------------------------------------- |
+| `docs/client/notification-settings.md` | `weekly` → `daily`                                         |
+| `docs/features/notifications.md`       | untouched (already daily; confirmed in comprehensive pass) |
+| indexes / developer                    | untouched                                                  |
+
+Touched: **client** only (after reviewing **features**). Cadence chosen: **daily**.

--- a/tests/skills/mdcp/evals/results/pr-210-srp/viewer.html
+++ b/tests/skills/mdcp/evals/results/pr-210-srp/viewer.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --surface: #ffffff;
+      --border: #e8e6dc;
+      --text: #141413;
+      --text-muted: #b0aea5;
+      --accent: #d97757;
+      --accent-hover: #c4613f;
+      --green: #788c5d;
+      --green-bg: #eef2e8;
+      --red: #c44;
+      --red-bg: #fceaea;
+      --header-bg: #141413;
+      --header-text: #faf9f5;
+      --radius: 6px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Lora', Georgia, serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .header h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .header .instructions {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+    .header .progress {
+      font-size: 0.875rem;
+      opacity: 0.8;
+      text-align: right;
+    }
+
+    /* ---- Main content ---- */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.5rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* ---- Sections ---- */
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      flex-shrink: 0;
+    }
+    .section-header {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .section-body {
+      padding: 1rem;
+    }
+
+    /* ---- Config badge ---- */
+    .config-badge {
+      display: inline-block;
+      padding: 0.2rem 0.625rem;
+      border-radius: 9999px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-left: 0.75rem;
+      vertical-align: middle;
+    }
+    .config-badge.config-primary {
+      background: rgba(33, 150, 243, 0.12);
+      color: #1976d2;
+    }
+    .config-badge.config-baseline {
+      background: rgba(255, 193, 7, 0.15);
+      color: #f57f17;
+    }
+
+    /* ---- Prompt ---- */
+    .prompt-text {
+      white-space: pre-wrap;
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+
+    /* ---- Outputs ---- */
+    .output-file {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .output-file + .output-file {
+      margin-top: 1rem;
+    }
+    .output-file-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .output-file-header .dl-btn {
+      font-size: 0.7rem;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 500;
+      opacity: 0.8;
+    }
+    .output-file-header .dl-btn:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+    .output-file-content {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .output-file-content pre {
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    }
+    .output-file-content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .output-file-content iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+    .output-file-content table {
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+      width: 100%;
+    }
+    .output-file-content table td,
+    .output-file-content table th {
+      border: 1px solid var(--border);
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+    .output-file-content table th {
+      background: var(--bg);
+      font-weight: 600;
+    }
+    .output-file-content .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .output-file-content .download-link:hover {
+      background: var(--border);
+    }
+    .empty-state {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    /* ---- Feedback ---- */
+    .prev-feedback {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.625rem 0.75rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .prev-feedback-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.25rem;
+      color: var(--text-muted);
+    }
+    .feedback-textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      resize: vertical;
+      color: var(--text);
+    }
+    .feedback-textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+    .feedback-status {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+      min-height: 1.1em;
+    }
+
+    /* ---- Grades (collapsible) ---- */
+    .grades-toggle {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .grades-toggle:hover {
+      color: var(--accent);
+    }
+    .grades-toggle .arrow {
+      margin-right: 0.5rem;
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+    .grades-toggle .arrow.open {
+      transform: rotate(90deg);
+    }
+    .grades-content {
+      display: none;
+      margin-top: 0.75rem;
+    }
+    .grades-content.open {
+      display: block;
+    }
+    .grades-summary {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .grade-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .grade-pass { background: var(--green-bg); color: var(--green); }
+    .grade-fail { background: var(--red-bg); color: var(--red); }
+    .assertion-list {
+      list-style: none;
+    }
+    .assertion-item {
+      padding: 0.625rem 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.8125rem;
+    }
+    .assertion-item:last-child { border-bottom: none; }
+    .assertion-status {
+      font-weight: 600;
+      margin-right: 0.5rem;
+    }
+    .assertion-status.pass { color: var(--green); }
+    .assertion-status.fail { color: var(--red); }
+    .assertion-evidence {
+      color: var(--text-muted);
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      padding-left: 1.5rem;
+    }
+
+    /* ---- View tabs ---- */
+    .view-tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 2rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .view-tab {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.625rem 1.25rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+    .view-tab:hover { color: var(--text); }
+    .view-tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+    .view-panel { display: none; }
+    .view-panel.active { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+
+    /* ---- Benchmark view ---- */
+    .benchmark-view {
+      padding: 1.5rem 2rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+    .benchmark-table {
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 0.8125rem;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+    .benchmark-table th, .benchmark-table td {
+      padding: 0.625rem 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border);
+    }
+    .benchmark-table th {
+      font-family: 'Poppins', sans-serif;
+      background: var(--header-bg);
+      color: var(--header-text);
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .benchmark-table tr:hover { background: var(--bg); }
+    .benchmark-table tr.benchmark-row-with { background: rgba(33, 150, 243, 0.06); }
+    .benchmark-table tr.benchmark-row-without { background: rgba(255, 193, 7, 0.06); }
+    .benchmark-table tr.benchmark-row-with:hover { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-without:hover { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-table tr.benchmark-row-avg { font-weight: 600; border-top: 2px solid var(--border); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-with { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-without { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-delta-positive { color: var(--green); font-weight: 600; }
+    .benchmark-delta-negative { color: var(--red); font-weight: 600; }
+    .benchmark-notes {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+    .benchmark-notes h3 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+    .benchmark-notes ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .benchmark-notes li {
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      margin-bottom: 0.375rem;
+    }
+    .benchmark-empty {
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 3rem;
+    }
+
+    /* ---- Navigation ---- */
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+    }
+    .nav-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-btn:hover:not(:disabled) {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .nav-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .done-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s;
+    }
+    .done-btn:hover {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .done-btn.ready {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+    }
+    .done-btn.ready:hover {
+      background: var(--accent-hover);
+    }
+    /* ---- Done overlay ---- */
+    .done-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .done-overlay.visible {
+      display: flex;
+    }
+    .done-card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 2rem 3rem;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+    }
+    .done-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .done-card p {
+      color: var(--text-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .done-card .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .done-card button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .done-card button:hover {
+      background: var(--bg);
+    }
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 0.625rem 1.25rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 0.3s;
+      pointer-events: none;
+      z-index: 200;
+    }
+    .toast.visible {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" style="height:100vh; display:flex; flex-direction:column;">
+    <div class="header">
+      <div>
+        <h1>Eval Review: <span id="skill-name"></span></h1>
+        <div class="instructions">Review each output and leave feedback below. Navigate with arrow keys or buttons. When done, copy feedback and paste into Claude Code.</div>
+      </div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <!-- View tabs (only shown when benchmark data exists) -->
+    <div class="view-tabs" id="view-tabs" style="display:none;">
+      <button class="view-tab active" onclick="switchView('outputs')">Outputs</button>
+      <button class="view-tab" onclick="switchView('benchmark')">Benchmark</button>
+    </div>
+
+    <!-- Outputs panel (qualitative review) -->
+    <div class="view-panel active" id="panel-outputs">
+    <div class="main">
+      <!-- Prompt -->
+      <div class="section">
+        <div class="section-header">Prompt <span class="config-badge" id="config-badge" style="display:none;"></span></div>
+        <div class="section-body">
+          <div class="prompt-text" id="prompt-text"></div>
+        </div>
+      </div>
+
+      <!-- Outputs -->
+      <div class="section">
+        <div class="section-header">Output</div>
+        <div class="section-body" id="outputs-body">
+          <div class="empty-state">No output files found</div>
+        </div>
+      </div>
+
+      <!-- Previous Output (collapsible) -->
+      <div class="section" id="prev-outputs-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="togglePrevOutputs()">
+            <span class="arrow" id="prev-outputs-arrow">&#9654;</span>
+            Previous Output
+          </div>
+        </div>
+        <div class="grades-content" id="prev-outputs-content"></div>
+      </div>
+
+      <!-- Grades (collapsible) -->
+      <div class="section" id="grades-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="toggleGrades()">
+            <span class="arrow" id="grades-arrow">&#9654;</span>
+            Formal Grades
+          </div>
+        </div>
+        <div class="grades-content" id="grades-content"></div>
+      </div>
+
+      <!-- Feedback -->
+      <div class="section">
+        <div class="section-header">Your Feedback</div>
+        <div class="section-body">
+          <textarea
+            class="feedback-textarea"
+            id="feedback"
+            placeholder="What do you think of this output? Any issues, suggestions, or things that look great?"
+          ></textarea>
+          <div class="feedback-status" id="feedback-status"></div>
+          <div class="prev-feedback" id="prev-feedback" style="display:none;">
+            <div class="prev-feedback-label">Previous feedback</div>
+            <div id="prev-feedback-text"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav" id="outputs-nav">
+      <button class="nav-btn" id="prev-btn" onclick="navigate(-1)">&#8592; Previous</button>
+      <button class="done-btn" id="done-btn" onclick="showDoneDialog()">Submit All Reviews</button>
+      <button class="nav-btn" id="next-btn" onclick="navigate(1)">Next &#8594;</button>
+    </div>
+    </div><!-- end panel-outputs -->
+
+    <!-- Benchmark panel (quantitative stats) -->
+    <div class="view-panel" id="panel-benchmark">
+      <div class="benchmark-view" id="benchmark-content">
+        <div class="benchmark-empty">No benchmark data available. Run a benchmark to see quantitative results here.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Done overlay -->
+  <div class="done-overlay" id="done-overlay">
+    <div class="done-card">
+      <h2>Review Complete</h2>
+      <p>Your feedback has been saved. Go back to your Claude Code session and tell Claude you're done reviewing.</p>
+      <div class="btn-row">
+        <button onclick="closeDoneDialog()">OK</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // ---- Embedded data (injected by generate_review.py) ----
+    const EMBEDDED_DATA = {"skill_name": "mdcp", "runs": [{"id": "eval-11-srp-overloaded-old_skill", "prompt": "SHIP TONIGHT... srp-overloaded fixture", "eval_id": 11, "outputs": [], "grading": {"pass_rate": 1.0, "passed": 5, "total": 5, "expectations": [{"text": "Does not leave end-user how-to and architecture as co-equal sections in one durable feature shard", "passed": true, "evidence": "Feature shard architecture-only; how-to moved to client."}, {"text": "End-user export how-to lives under docs/client/", "passed": true, "evidence": "export-results.md filled with Settings\u2192Export steps."}, {"text": "Removes temporary discovery/tickets from durable shards", "passed": true, "evidence": "Temp discovery/tickets removed from feature shard."}, {"text": "Updates guide index and/or cross-links after any split", "passed": true, "evidence": "Cross-links added; indexes already correct."}, {"text": "Does not keep a multi-audience monolith solely because leadership asked for one file", "passed": true, "evidence": "Transcript refuses one-file pressure via What belongs where."}]}}, {"id": "eval-11-srp-overloaded-with_skill", "prompt": "SHIP TONIGHT... srp-overloaded fixture", "eval_id": 11, "outputs": [{"name": "mdcp.config.json", "type": "text", "content": "{\n  \"docsRoot\": \"docs\",\n  \"compileOrder\": [\"features\", \"client\"]\n}\n"}], "grading": {"pass_rate": 1.0, "passed": 5, "total": 5, "expectations": [{"text": "Does not leave end-user how-to and architecture as co-equal sections in one durable feature shard", "passed": true, "evidence": "Feature architecture-only; how-to in client."}, {"text": "End-user export how-to lives under docs/client/", "passed": true, "evidence": "export-results.md has how-to."}, {"text": "Removes temporary discovery/tickets from durable shards", "passed": true, "evidence": "Temp notes removed."}, {"text": "Updates guide index and/or cross-links after any split", "passed": true, "evidence": "Cross-linked; compileOrder trimmed."}, {"text": "Does not keep a multi-audience monolith solely because leadership asked for one file", "passed": true, "evidence": "Explicit mitosis/SRP refusal of one-file pressure."}]}}, {"id": "eval-12-length-only-old_skill", "prompt": "Split compile-pipeline because TOO LONG", "eval_id": 12, "outputs": [], "grading": {"pass_rate": 0.0, "passed": 0, "total": 3, "expectations": [{"text": "Does not split solely because of length when responsibility is still single", "passed": false, "evidence": "Split 1\u21929 files citing Break it down + leadership length pressure; no anti-length-only rule on main."}, {"text": "Resulting feature docs still present one compile-pipeline concern", "passed": false, "evidence": "Concern fragmented across 9 heading shards (heading dumps)."}, {"text": "Acknowledges split-when-responsibility-multiplies OR refuses length-only split", "passed": false, "evidence": "No mitosis rule; performed length-driven split."}]}}, {"id": "eval-12-length-only-with_skill", "prompt": "Split compile-pipeline because TOO LONG", "eval_id": 12, "outputs": [], "grading": {"pass_rate": 1.0, "passed": 3, "total": 3, "expectations": [{"text": "Does not split solely because of length when responsibility is still single", "passed": true, "evidence": "Refused length-only split; kept single compile-pipeline.md."}, {"text": "Resulting feature docs still present one compile-pipeline concern", "passed": true, "evidence": "Still one shard, one concern."}, {"text": "Acknowledges split-when-responsibility-multiplies OR refuses length-only split", "passed": true, "evidence": "Read shard-responsibility.md; stated do-not-split-for-length."}]}}, {"id": "eval-13-two-level-review-old_skill", "prompt": "URGENT fix client only; skip comprehensive review", "eval_id": 13, "outputs": [], "grading": {"pass_rate": 0.5, "passed": 2, "total": 4, "expectations": [{"text": "Client and features agree on digest cadence after the change", "passed": true, "evidence": "Both daily after client edit."}, {"text": "Reads or reviews related feature/client shards", "passed": true, "evidence": "Read features to choose daily; still edited client only."}, {"text": "Does not skip comprehensive/guide-agreement review solely because leadership asked", "passed": false, "evidence": "Transcript: skipped comprehensive review per leadership; old skill has no two-level obligation."}, {"text": "Shows isolation plus comprehensive/guide agreement", "passed": false, "evidence": "Explicitly isolation-only; no comprehensive pass recorded as required."}]}}, {"id": "eval-13-two-level-review-with_skill", "prompt": "URGENT fix client only; skip comprehensive review", "eval_id": 13, "outputs": [], "grading": {"pass_rate": 1.0, "passed": 4, "total": 4, "expectations": [{"text": "Client and features agree on digest cadence after the change", "passed": true, "evidence": "Both daily."}, {"text": "Reads or reviews related feature/client shards", "passed": true, "evidence": "Reviewed features + developer + client."}, {"text": "Does not skip comprehensive/guide-agreement review solely because leadership asked", "passed": true, "evidence": "Refused skip; skill Two-level review wins."}, {"text": "Shows isolation plus comprehensive/guide agreement", "passed": true, "evidence": "Transcript documents Level 1 isolation + Level 2 guide agreement."}]}}], "previous_feedback": {}, "previous_outputs": {}, "benchmark": {"metadata": {"skill_name": "mdcp", "timestamp": "2026-07-30T06:40:40.310223Z", "evals_run": [11, 12, 13], "notes": "PR #210 before/after: with_skill = shard SRP/mitosis/two-level; old_skill = main. Runtime tokens/time unavailable from Task harness.", "static_skill_size": {"old_skill_md_words": 1593, "with_skill_md_words": 1791, "with_skill_shard_responsibility_words": 186, "with_skill_acknowledgments_words": 123, "delta_skill_md_words": 198, "note": "Runtime total_tokens were not returned by the Task harness for this campaign; use static load size + qualitative work (e.g. length-only over-split) as cost signals."}}, "evals": [{"eval_id": 11, "eval_name": "eval-11-srp-overloaded", "configuration": "with_skill", "result": {"pass_rate": 1.0, "passed": 5, "total": 5, "time_seconds": null, "tokens": null, "errors": []}}, {"eval_id": 11, "eval_name": "eval-11-srp-overloaded", "configuration": "old_skill", "result": {"pass_rate": 1.0, "passed": 5, "total": 5, "time_seconds": null, "tokens": null, "errors": []}}, {"eval_id": 12, "eval_name": "eval-12-length-only", "configuration": "with_skill", "result": {"pass_rate": 1.0, "passed": 3, "total": 3, "time_seconds": null, "tokens": null, "errors": []}}, {"eval_id": 12, "eval_name": "eval-12-length-only", "configuration": "old_skill", "result": {"pass_rate": 0.0, "passed": 0, "total": 3, "time_seconds": null, "tokens": null, "errors": []}}, {"eval_id": 13, "eval_name": "eval-13-two-level-review", "configuration": "with_skill", "result": {"pass_rate": 1.0, "passed": 4, "total": 4, "time_seconds": null, "tokens": null, "errors": []}}, {"eval_id": 13, "eval_name": "eval-13-two-level-review", "configuration": "old_skill", "result": {"pass_rate": 0.5, "passed": 2, "total": 4, "time_seconds": null, "tokens": null, "errors": []}}], "summary": {"with_skill": {"pass_rate": {"mean": 1.0, "stddev": 0}, "time_seconds": {"mean": null, "stddev": null}, "tokens": {"mean": null, "stddev": null}}, "old_skill": {"pass_rate": {"mean": 0.5, "stddev": 0}, "time_seconds": {"mean": null, "stddev": null}, "tokens": {"mean": null, "stddev": null}}, "delta": {"pass_rate": "+0.50 absolute mean", "tokens": "n/a (harness)", "time_seconds": "n/a (harness)", "static_skill_md_words": "+198 words in SKILL.md (~257 tokens rough)"}}}};
+
+    // ---- State ----
+    let feedbackMap = {};  // run_id -> feedback text
+    let currentIndex = 0;
+    let visitedRuns = new Set();
+
+    // ---- Init ----
+    async function init() {
+      // Load saved feedback from server — but only if this isn't a fresh
+      // iteration (indicated by previous_feedback being present). When
+      // previous feedback exists, the feedback.json on disk is stale from
+      // the prior iteration and should not pre-fill the textareas.
+      const hasPrevious = Object.keys(EMBEDDED_DATA.previous_feedback || {}).length > 0
+        || Object.keys(EMBEDDED_DATA.previous_outputs || {}).length > 0;
+      if (!hasPrevious) {
+        try {
+          const resp = await fetch("/api/feedback");
+          const data = await resp.json();
+          if (data.reviews) {
+            for (const r of data.reviews) feedbackMap[r.run_id] = r.feedback;
+          }
+        } catch { /* first run, no feedback yet */ }
+      }
+
+      document.getElementById("skill-name").textContent = EMBEDDED_DATA.skill_name;
+      showRun(0);
+
+      // Wire up feedback auto-save
+      const textarea = document.getElementById("feedback");
+      let saveTimeout = null;
+      textarea.addEventListener("input", () => {
+        clearTimeout(saveTimeout);
+        document.getElementById("feedback-status").textContent = "";
+        saveTimeout = setTimeout(() => saveCurrentFeedback(), 800);
+      });
+    }
+
+    // ---- Navigation ----
+    function navigate(delta) {
+      const newIndex = currentIndex + delta;
+      if (newIndex >= 0 && newIndex < EMBEDDED_DATA.runs.length) {
+        saveCurrentFeedback();
+        showRun(newIndex);
+      }
+    }
+
+    function updateNavButtons() {
+      document.getElementById("prev-btn").disabled = currentIndex === 0;
+      document.getElementById("next-btn").disabled =
+        currentIndex === EMBEDDED_DATA.runs.length - 1;
+    }
+
+    // ---- Show a run ----
+    function showRun(index) {
+      currentIndex = index;
+      const run = EMBEDDED_DATA.runs[index];
+
+      // Progress
+      document.getElementById("progress").textContent =
+        `${index + 1} of ${EMBEDDED_DATA.runs.length}`;
+
+      // Prompt
+      document.getElementById("prompt-text").textContent = run.prompt;
+
+      // Config badge
+      const badge = document.getElementById("config-badge");
+      const configMatch = run.id.match(/(with_skill|without_skill|new_skill|old_skill)/);
+      if (configMatch) {
+        const config = configMatch[1];
+        const isBaseline = config === "without_skill" || config === "old_skill";
+        badge.textContent = config.replace(/_/g, " ");
+        badge.className = "config-badge " + (isBaseline ? "config-baseline" : "config-primary");
+        badge.style.display = "inline-block";
+      } else {
+        badge.style.display = "none";
+      }
+
+      // Outputs
+      renderOutputs(run);
+
+      // Previous outputs
+      renderPrevOutputs(run);
+
+      // Grades
+      renderGrades(run);
+
+      // Previous feedback
+      const prevFb = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = document.getElementById("prev-feedback");
+      if (prevFb) {
+        document.getElementById("prev-feedback-text").textContent = prevFb;
+        prevEl.style.display = "block";
+      } else {
+        prevEl.style.display = "none";
+      }
+
+      // Feedback
+      document.getElementById("feedback").value = feedbackMap[run.id] || "";
+      document.getElementById("feedback-status").textContent = "";
+
+      updateNavButtons();
+
+      // Track visited runs and promote done button when all visited
+      visitedRuns.add(index);
+      const doneBtn = document.getElementById("done-btn");
+      if (visitedRuns.size >= EMBEDDED_DATA.runs.length) {
+        doneBtn.classList.add("ready");
+      }
+
+      // Scroll main content to top
+      document.querySelector(".main").scrollTop = 0;
+    }
+
+    // ---- Render outputs ----
+    function renderOutputs(run) {
+      const container = document.getElementById("outputs-body");
+      container.innerHTML = "";
+
+      const outputs = run.outputs || [];
+      if (outputs.length === 0) {
+        container.innerHTML = '<div class="empty-state">No output files</div>';
+        return;
+      }
+
+      for (const file of outputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        // Always show file header with download link
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const content = document.createElement("div");
+        content.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          content.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          content.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          content.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(content, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          content.appendChild(a);
+        } else if (file.type === "error") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          pre.style.color = "var(--red)";
+          content.appendChild(pre);
+        }
+
+        fileDiv.appendChild(content);
+        container.appendChild(fileDiv);
+      }
+    }
+
+    // ---- XLSX rendering via SheetJS ----
+    function renderXlsx(container, b64Data) {
+      try {
+        const raw = Uint8Array.from(atob(b64Data), c => c.charCodeAt(0));
+        const wb = XLSX.read(raw, { type: "array" });
+
+        for (let i = 0; i < wb.SheetNames.length; i++) {
+          const sheetName = wb.SheetNames[i];
+          const ws = wb.Sheets[sheetName];
+
+          if (wb.SheetNames.length > 1) {
+            const sheetLabel = document.createElement("div");
+            sheetLabel.style.cssText =
+              "font-weight:600; font-size:0.8rem; color:#b0aea5; margin-top:0.5rem; margin-bottom:0.25rem;";
+            sheetLabel.textContent = "Sheet: " + sheetName;
+            container.appendChild(sheetLabel);
+          }
+
+          const htmlStr = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = htmlStr;
+          container.appendChild(wrapper);
+        }
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + err.message;
+      }
+    }
+
+    // ---- Grades ----
+    function renderGrades(run) {
+      const section = document.getElementById("grades-section");
+      const content = document.getElementById("grades-content");
+
+      if (!run.grading) {
+        section.style.display = "none";
+        return;
+      }
+
+      const grading = run.grading;
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("grades-arrow").classList.remove("open");
+
+      const summary = grading.summary || {};
+      const expectations = grading.expectations || [];
+
+      let html = '<div style="padding: 1rem;">';
+
+      // Summary line
+      const passRate = summary.pass_rate != null
+        ? Math.round(summary.pass_rate * 100) + "%"
+        : "?";
+      const badgeClass = summary.pass_rate >= 0.8 ? "grade-pass" : summary.pass_rate >= 0.5 ? "" : "grade-fail";
+      html += '<div class="grades-summary">';
+      html += '<span class="grade-badge ' + badgeClass + '">' + passRate + '</span>';
+      html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
+      html += '</div>';
+
+      // Assertions list
+      html += '<ul class="assertion-list">';
+      for (const exp of expectations) {
+        const statusClass = exp.passed ? "pass" : "fail";
+        const statusIcon = exp.passed ? "\u2713" : "\u2717";
+        html += '<li class="assertion-item">';
+        html += '<span class="assertion-status ' + statusClass + '">' + statusIcon + '</span>';
+        html += '<span>' + escapeHtml(exp.text) + '</span>';
+        if (exp.evidence) {
+          html += '<div class="assertion-evidence">' + escapeHtml(exp.evidence) + '</div>';
+        }
+        html += '</li>';
+      }
+      html += '</ul>';
+
+      html += '</div>';
+      content.innerHTML = html;
+    }
+
+    function toggleGrades() {
+      const content = document.getElementById("grades-content");
+      const arrow = document.getElementById("grades-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Previous outputs (collapsible) ----
+    function renderPrevOutputs(run) {
+      const section = document.getElementById("prev-outputs-section");
+      const content = document.getElementById("prev-outputs-content");
+      const prevOutputs = (EMBEDDED_DATA.previous_outputs || {})[run.id];
+
+      if (!prevOutputs || prevOutputs.length === 0) {
+        section.style.display = "none";
+        return;
+      }
+
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("prev-outputs-arrow").classList.remove("open");
+
+      // Render the files into the content area
+      content.innerHTML = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.padding = "1rem";
+
+      for (const file of prevOutputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const fc = document.createElement("div");
+        fc.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          fc.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          fc.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          fc.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(fc, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          fc.appendChild(a);
+        }
+
+        fileDiv.appendChild(fc);
+        wrapper.appendChild(fileDiv);
+      }
+
+      content.appendChild(wrapper);
+    }
+
+    function togglePrevOutputs() {
+      const content = document.getElementById("prev-outputs-content");
+      const arrow = document.getElementById("prev-outputs-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Feedback (saved to server -> feedback.json) ----
+    function saveCurrentFeedback() {
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // Build reviews array from map
+      const reviews = [];
+      for (const [run_id, feedback] of Object.entries(feedbackMap)) {
+        if (feedback.trim()) {
+          reviews.push({ run_id, feedback, timestamp: new Date().toISOString() });
+        }
+      }
+
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" }),
+      }).then(() => {
+        document.getElementById("feedback-status").textContent = "Saved";
+      }).catch(() => {
+        // Static mode or server unavailable — no-op on auto-save,
+        // feedback will be downloaded on final submit
+        document.getElementById("feedback-status").textContent = "Will download on submit";
+      });
+    }
+
+    // ---- Done ----
+    function showDoneDialog() {
+      // Save current textarea to feedbackMap (but don't POST yet)
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // POST once with status: complete — include ALL runs so the model
+      // can distinguish "no feedback" (looks good) from "not reviewed"
+      const reviews = [];
+      const ts = new Date().toISOString();
+      for (const r of EMBEDDED_DATA.runs) {
+        reviews.push({ run_id: r.id, feedback: feedbackMap[r.id] || "", timestamp: ts });
+      }
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }).then(() => {
+        document.getElementById("done-overlay").classList.add("visible");
+      }).catch(() => {
+        // Server not available (static mode) — download as file
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        document.getElementById("done-overlay").classList.add("visible");
+      });
+    }
+
+    function closeDoneDialog() {
+      // Reset status back to in_progress
+      saveCurrentFeedback();
+      document.getElementById("done-overlay").classList.remove("visible");
+    }
+
+    // ---- Toast ----
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.add("visible");
+      setTimeout(() => toast.classList.remove("visible"), 2000);
+    }
+
+    // ---- Keyboard nav ----
+    document.addEventListener("keydown", (e) => {
+      // Don't capture when typing in textarea
+      if (e.target.tagName === "TEXTAREA") return;
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        navigate(-1);
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        navigate(1);
+      }
+    });
+
+    // ---- Util ----
+    function getDownloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content);
+      return "#";
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    // ---- View switching ----
+    function switchView(view) {
+      document.querySelectorAll(".view-tab").forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".view-panel").forEach(p => p.classList.remove("active"));
+      document.querySelector(`[onclick="switchView('${view}')"]`).classList.add("active");
+      document.getElementById("panel-" + view).classList.add("active");
+    }
+
+    // ---- Benchmark rendering ----
+    function renderBenchmark() {
+      const data = EMBEDDED_DATA.benchmark;
+      if (!data) return;
+
+      // Show the tabs
+      document.getElementById("view-tabs").style.display = "flex";
+
+      const container = document.getElementById("benchmark-content");
+      const summary = data.run_summary || {};
+      const metadata = data.metadata || {};
+      const notes = data.notes || [];
+
+      let html = "";
+
+      // Header
+      html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
+      html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
+      if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
+      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
+      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      html += "</p>";
+
+      // Summary table
+      html += '<table class="benchmark-table">';
+
+      function fmtStat(stat, pct) {
+        if (!stat) return "—";
+        const suffix = pct ? "%" : "";
+        const m = pct ? (stat.mean * 100).toFixed(0) : stat.mean.toFixed(1);
+        const s = pct ? (stat.stddev * 100).toFixed(0) : stat.stddev.toFixed(1);
+        return m + suffix + " ± " + s + suffix;
+      }
+
+      function deltaClass(val) {
+        if (!val) return "";
+        const n = parseFloat(val);
+        if (n > 0) return "benchmark-delta-positive";
+        if (n < 0) return "benchmark-delta-negative";
+        return "";
+      }
+
+      // Discover config names dynamically (everything except "delta")
+      const configs = Object.keys(summary).filter(k => k !== "delta");
+      const configA = configs[0] || "config_a";
+      const configB = configs[1] || "config_b";
+      const labelA = configA.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const labelB = configB.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const a = summary[configA] || {};
+      const b = summary[configB] || {};
+      const delta = summary.delta || {};
+
+      html += "<thead><tr><th>Metric</th><th>" + escapeHtml(labelA) + "</th><th>" + escapeHtml(labelB) + "</th><th>Delta</th></tr></thead>";
+      html += "<tbody>";
+
+      html += "<tr><td><strong>Pass Rate</strong></td>";
+      html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
+      html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+
+      // Time (only show row if data exists)
+      if (a.time_seconds || b.time_seconds) {
+        html += "<tr><td><strong>Time (s)</strong></td>";
+        html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
+        html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+      }
+
+      // Tokens (only show row if data exists)
+      if (a.tokens || b.tokens) {
+        html += "<tr><td><strong>Tokens</strong></td>";
+        html += "<td>" + fmtStat(a.tokens, false) + "</td>";
+        html += "<td>" + fmtStat(b.tokens, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+      }
+
+      html += "</tbody></table>";
+
+      // Per-eval breakdown (if runs data available)
+      const runs = data.runs || [];
+      if (runs.length > 0) {
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+
+        html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
+
+        const hasTime = runs.some(r => r.result && r.result.time_seconds != null);
+        const hasErrors = runs.some(r => r.result && r.result.errors > 0);
+
+        for (const evalId of evalIds) {
+          const evalRuns = runs.filter(r => r.eval_id === evalId);
+          const evalName = evalRuns[0] && evalRuns[0].eval_name ? evalRuns[0].eval_name : "Eval " + evalId;
+
+          html += "<h4 style='font-family: Poppins, sans-serif; margin: 1rem 0 0.5rem; color: var(--text);'>" + escapeHtml(evalName) + "</h4>";
+          html += '<table class="benchmark-table">';
+          html += "<thead><tr><th>Config</th><th>Run</th><th>Pass Rate</th>";
+          if (hasTime) html += "<th>Time (s)</th>";
+          if (hasErrors) html += "<th>Crashes During Execution</th>";
+          html += "</tr></thead>";
+          html += "<tbody>";
+
+          // Group by config and render with average rows
+          const configGroups = [...new Set(evalRuns.map(r => r.configuration))];
+          for (let ci = 0; ci < configGroups.length; ci++) {
+            const config = configGroups[ci];
+            const configRuns = evalRuns.filter(r => r.configuration === config);
+            if (configRuns.length === 0) continue;
+
+            const rowClass = ci === 0 ? "benchmark-row-with" : "benchmark-row-without";
+            const configLabel = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+            for (const run of configRuns) {
+              const r = run.result || {};
+              const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
+              html += '<tr class="' + rowClass + '">';
+              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + run.run_number + "</td>";
+              html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
+              if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
+              if (hasErrors) html += "<td>" + (r.errors || 0) + "</td>";
+              html += "</tr>";
+            }
+
+            // Average row
+            const rates = configRuns.map(r => (r.result || {}).pass_rate || 0);
+            const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
+            const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
+            html += '<tr class="benchmark-row-avg ' + rowClass + '">';
+            html += "<td>" + configLabel + "</td>";
+            html += "<td>Avg</td>";
+            html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
+            if (hasTime) {
+              const times = configRuns.map(r => (r.result || {}).time_seconds).filter(t => t != null);
+              html += "<td>" + (times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(1) : "—") + "</td>";
+            }
+            if (hasErrors) html += "<td></td>";
+            html += "</tr>";
+          }
+          html += "</tbody></table>";
+
+          // Per-assertion detail for this eval
+          const runsWithExpectations = {};
+          for (const config of configGroups) {
+            runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
+          }
+          const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
+          if (hasAnyExpectations) {
+            // Collect all unique assertion texts across all configs
+            const allAssertions = [];
+            const seen = new Set();
+            for (const config of configGroups) {
+              for (const run of runsWithExpectations[config]) {
+                for (const exp of (run.expectations || [])) {
+                  if (!seen.has(exp.text)) {
+                    seen.add(exp.text);
+                    allAssertions.push(exp.text);
+                  }
+                }
+              }
+            }
+
+            html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
+            html += "<thead><tr><th>Assertion</th>";
+            for (const config of configGroups) {
+              const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+              html += "<th>" + escapeHtml(label) + "</th>";
+            }
+            html += "</tr></thead><tbody>";
+
+            for (const assertionText of allAssertions) {
+              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+
+              for (const config of configGroups) {
+                html += "<td>";
+                for (const run of runsWithExpectations[config]) {
+                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  if (exp) {
+                    const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
+                    const icon = exp.passed ? "\u2713" : "\u2717";
+                    html += '<span class="' + cls + '" title="Run ' + run.run_number + ': ' + escapeHtml(exp.evidence || "") + '">' + icon + "</span> ";
+                  } else {
+                    html += "— ";
+                  }
+                }
+                html += "</td>";
+              }
+              html += "</tr>";
+            }
+            html += "</tbody></table>";
+          }
+        }
+      }
+
+      // Notes
+      if (notes.length > 0) {
+        html += '<div class="benchmark-notes">';
+        html += "<h3>Analysis Notes</h3>";
+        html += "<ul>";
+        for (const note of notes) {
+          html += "<li>" + escapeHtml(note) + "</li>";
+        }
+        html += "</ul></div>";
+      }
+
+      container.innerHTML = html;
+    }
+
+    // ---- Start ----
+    init();
+    renderBenchmark();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Publish a **before/after** live-eval campaign for [PR #210](https://github.com/betsalel-williamson/mdcp/pull/210) (shard SRP, idea mitosis, two-level review) so maintainers can decide **go / no-go** with evidence.

**Decision bias applied:** prefer **not** merging #210 if `main` already behaves well — unless discriminating edge cases show clear end-user value.

## Verdict (from this campaign)

**Conditional GO** — see [`tests/skills/mdcp/evals/results/pr-210-srp/GO-NO-GO.md`](../blob/cursor/shard-srp-eval-results-bb00/tests/skills/mdcp/evals/results/pr-210-srp/GO-NO-GO.md).

| Eval | `main` (old) | PR #210 (new) | Discrimination |
| --- | --- | --- | --- |
| 11 overloaded export shard | 5/5 | 5/5 | None — placement rules already win |
| 12 length-only split pressure | **0/3** (split into 9 files) | **3/3** (refused) | **Strong** — clearer docs, less churn |
| 13 skip comprehensive review | 2/4 | 4/4 | Process win; same file outcome |
| Mean pass rate | 0.50 | 1.00 | |

**Cost:** `SKILL.md` +198 words (~+12%). Runtime Task tokens/time were not returned by the harness; eval 12’s over-split on `main` is the practical token/time risk signal.

## Artifacts

- Go/no-go: `tests/skills/mdcp/evals/results/pr-210-srp/GO-NO-GO.md`
- Benchmark: `.../benchmark.json`
- Transcripts + grades + eval-12 output trees
- Static viewer: `.../viewer.html`
- Analyst notes: `.../ANALYST.md`

## What's in this PR

- New parent-suite evals **11–13** + fixtures
- Published results under `tests/skills/mdcp/evals/results/pr-210-srp/`

## Related

- Evaluates: #210 / #171
- Stacked on: `cursor/shard-srp-philosophy-dbdb`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a679f178-3813-433d-8c9c-f4b45c6fbb00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a679f178-3813-433d-8c9c-f4b45c6fbb00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

