### PR TITLE
fix(ci): set git identity before release commit

### DIFF
--- a/scripts/release-main.mjs
+++ b/scripts/release-main.mjs
@@ -155,6 +155,9 @@ if (!dryRun) {
   console.log('> git remote set-url origin (token redacted)');
 }
 
+// Runners have no git identity; required before commit (local to this clone).
+run('git config user.name "github-actions[bot]"');
+run('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"');
 run('git add -A');
 run('git commit -m "chore: release"');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release on `main` failed at `git commit -m "chore: release"` because Actions runners have no `user.name` / `user.email`.

`scripts/release-main.mjs` now configures local git identity as `github-actions[bot]` before `git add` / commit.

## After merge

Re-approve the **`release`** environment on the next Release run (pending changesets should still be present if the failed run never committed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2679c8f3-fb60-4981-9bd3-7c90aee7b711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2679c8f3-fb60-4981-9bd3-7c90aee7b711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

