### PR TITLE
fix(ci): heal missing GitHub Releases after partial release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       contents: read
     outputs:
       has_changesets: ${{ steps.detect.outputs.has_changesets }}
+      has_missing_releases: ${{ steps.missing.outputs.has_missing_releases }}
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
@@ -51,7 +52,7 @@ jobs:
           mapfile -t files < <(find .changeset -maxdepth 1 -type f -name '*.md' ! -name 'README.md' ! -name '_*' | sort)
           if [ "${#files[@]}" -eq 0 ]; then
             echo "has_changesets=false" >> "$GITHUB_OUTPUT"
-            echo "No pending changesets — release job will no-op." | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "No pending changesets." | tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           echo "has_changesets=true" >> "$GITHUB_OUTPUT"
@@ -71,10 +72,17 @@ jobs:
           } | tee -a "$GITHUB_STEP_SUMMARY"
           pnpm changeset:reject-major
 
+      - name: Detect missing GitHub Releases
+        id: missing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/detect-missing-github-releases.mjs
+
   release:
     name: Version and publish
     needs: plan
-    if: needs.plan.outputs.has_changesets == 'true'
+    if: needs.plan.outputs.has_changesets == 'true' || needs.plan.outputs.has_missing_releases == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write # Release commit, tags, GitHub Releases (via RELEASE_GITHUB_TOKEN for push)

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -863,7 +863,9 @@ There is **no calendar cadence** and **no Version Packages PR**. Releases are **
 
 1. Contributors add a changeset with each PR that affects a published package or skill.
 2. Merging that PR to `main` runs the [release workflow](.github/workflows/release.yml) (`pnpm release:main`).
-3. After the **Release plan** job posts pending changesets to the run summary, approve the **`release` environment**. CI then **sequentially**: applies changesets → syncs skill `metadata.version` → builds (so husky can run) → commits `chore: release` → **pushes to `main`** → publishes public packages to npm → creates GitHub Releases (including skill carriers) → pushes tags.
+3. After the **Release plan** job posts pending changesets (and any **missing GitHub Releases**) to the run summary, approve the **`release` environment**. CI then **sequentially**: applies changesets → syncs skill `metadata.version` → builds (so husky can run) → commits `chore: release` → **pushes to `main`** → publishes public packages to npm → **pushes tags** → creates GitHub Releases (including skill carriers).
+
+If a prior run versioned/published but failed before Releases finished, the next Release plan detects **missing** `name@version` Releases and the release job **heals** them without bumping versions again (`gh release create … --target`).
 
 **Agent Skills** live under `skills/` as the install surface (`npx skills add`). Version carriers and CHANGELOGs live under **`packages/skill-<id>/`** only — never under `skills/` (those files would pollute agent context on install). `pnpm release:main` syncs the carrier version into `skills/<id>/SKILL.md` `metadata.version`. Feature PRs must add a changeset targeting `@bwilliamson/skill-<id>` and must **not** hand-bump `metadata.version`. See [Agent Skill](#agent-skill-development).
 
@@ -963,9 +965,9 @@ Before approving the **`release` environment**, open the **Release plan** job su
 ### Routine releases (one step)
 
 1. Merge feature PRs that include changesets to `main`.
-2. Open the Release workflow run → read the **Release plan** job summary (pending changesets).
+2. Open the Release workflow run → read the **Release plan** job summary (pending changesets and/or missing GitHub Releases).
 3. Approve the **`release` environment** deployment.
-4. CI runs **`pnpm release:main`**: version → sync skill frontmatter → build → commit → **push to `main`** → `changeset publish` → GitHub Releases (npm packages **and** skill carriers) → push tags.
+4. CI runs **`pnpm release:main`**: with pending changesets — version → sync skill frontmatter → build → commit → **push to `main`** → `changeset publish` → **push tags** → GitHub Releases (npm packages **and** skill carriers). With no changesets but missing Releases — create those Releases idempotently (`--target`).
 
 There is no separate Version Packages PR.
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -865,7 +865,7 @@ There is **no calendar cadence** and **no Version Packages PR**. Releases are **
 2. Merging that PR to `main` runs the [release workflow](.github/workflows/release.yml) (`pnpm release:main`).
 3. After the **Release plan** job posts pending changesets (and any **missing GitHub Releases**) to the run summary, approve the **`release` environment**. CI then **sequentially**: applies changesets → syncs skill `metadata.version` → builds (so husky can run) → commits `chore: release` → **pushes to `main`** → publishes public packages to npm → **pushes tags** → creates GitHub Releases (including skill carriers).
 
-If a prior run versioned/published but failed before Releases finished, the next Release plan detects **missing** `name@version` Releases and the release job **heals** them without bumping versions again (`gh release create … --target`).
+If a prior run versioned/published but failed before tags/Releases finished, the next Release plan detects **missing** `name@version` git tags and/or GitHub Releases and the release job **heals** them without bumping versions again (tag + `gh release create … --target` at the commit that last changed that package’s `package.json`).
 
 **Agent Skills** live under `skills/` as the install surface (`npx skills add`). Version carriers and CHANGELOGs live under **`packages/skill-<id>/`** only — never under `skills/` (those files would pollute agent context on install). `pnpm release:main` syncs the carrier version into `skills/<id>/SKILL.md` `metadata.version`. Feature PRs must add a changeset targeting `@bwilliamson/skill-<id>` and must **not** hand-bump `metadata.version`. See [Agent Skill](#agent-skill-development).
 
@@ -967,7 +967,7 @@ Before approving the **`release` environment**, open the **Release plan** job su
 1. Merge feature PRs that include changesets to `main`.
 2. Open the Release workflow run → read the **Release plan** job summary (pending changesets and/or missing GitHub Releases).
 3. Approve the **`release` environment** deployment.
-4. CI runs **`pnpm release:main`**: with pending changesets — version → sync skill frontmatter → build → commit → **push to `main`** → `changeset publish` → **push tags** → GitHub Releases (npm packages **and** skill carriers). With no changesets but missing Releases — create those Releases idempotently (`--target`).
+4. CI runs **`pnpm release:main`**: with pending changesets — version → sync skill frontmatter → build → commit → **push to `main`** → `changeset publish` → **push tags** → GitHub Releases (npm packages **and** skill carriers). With no changesets but missing tags/Releases — create those git tags and Releases idempotently at each package’s version-bump commit (`--target`).
 
 There is no separate Version Packages PR.
 

--- a/docs/developer/publishing.md
+++ b/docs/developer/publishing.md
@@ -37,9 +37,9 @@ Before approving the **`release` environment**, open the **Release plan** job su
 ## Routine releases (one step)
 
 1. Merge feature PRs that include changesets to `main`.
-2. Open the Release workflow run → read the **Release plan** job summary (pending changesets).
+2. Open the Release workflow run → read the **Release plan** job summary (pending changesets and/or missing GitHub Releases).
 3. Approve the **`release` environment** deployment.
-4. CI runs **`pnpm release:main`**: version → sync skill frontmatter → build → commit → **push to `main`** → `changeset publish` → GitHub Releases (npm packages **and** skill carriers) → push tags.
+4. CI runs **`pnpm release:main`**: with pending changesets — version → sync skill frontmatter → build → commit → **push to `main`** → `changeset publish` → **push tags** → GitHub Releases (npm packages **and** skill carriers). With no changesets but missing Releases — create those Releases idempotently (`--target`).
 
 There is no separate Version Packages PR.
 

--- a/docs/developer/publishing.md
+++ b/docs/developer/publishing.md
@@ -39,7 +39,7 @@ Before approving the **`release` environment**, open the **Release plan** job su
 1. Merge feature PRs that include changesets to `main`.
 2. Open the Release workflow run → read the **Release plan** job summary (pending changesets and/or missing GitHub Releases).
 3. Approve the **`release` environment** deployment.
-4. CI runs **`pnpm release:main`**: with pending changesets — version → sync skill frontmatter → build → commit → **push to `main`** → `changeset publish` → **push tags** → GitHub Releases (npm packages **and** skill carriers). With no changesets but missing Releases — create those Releases idempotently (`--target`).
+4. CI runs **`pnpm release:main`**: with pending changesets — version → sync skill frontmatter → build → commit → **push to `main`** → `changeset publish` → **push tags** → GitHub Releases (npm packages **and** skill carriers). With no changesets but missing tags/Releases — create those git tags and Releases idempotently at each package’s version-bump commit (`--target`).
 
 There is no separate Version Packages PR.
 

--- a/docs/developer/versioning-and-releases.md
+++ b/docs/developer/versioning-and-releases.md
@@ -17,7 +17,9 @@ There is **no calendar cadence** and **no Version Packages PR**. Releases are **
 
 1. Contributors add a changeset with each PR that affects a published package or skill.
 2. Merging that PR to `main` runs the [release workflow](../../.github/workflows/release.yml) (`pnpm release:main`).
-3. After the **Release plan** job posts pending changesets to the run summary, approve the **`release` environment**. CI then **sequentially**: applies changesets → syncs skill `metadata.version` → builds (so husky can run) → commits `chore: release` → **pushes to `main`** → publishes public packages to npm → creates GitHub Releases (including skill carriers) → pushes tags.
+3. After the **Release plan** job posts pending changesets (and any **missing GitHub Releases**) to the run summary, approve the **`release` environment**. CI then **sequentially**: applies changesets → syncs skill `metadata.version` → builds (so husky can run) → commits `chore: release` → **pushes to `main`** → publishes public packages to npm → **pushes tags** → creates GitHub Releases (including skill carriers).
+
+If a prior run versioned/published but failed before Releases finished, the next Release plan detects **missing** `name@version` Releases and the release job **heals** them without bumping versions again (`gh release create … --target`).
 
 **Agent Skills** live under `skills/` as the install surface (`npx skills add`). Version carriers and CHANGELOGs live under **`packages/skill-<id>/`** only — never under `skills/` (those files would pollute agent context on install). `pnpm release:main` syncs the carrier version into `skills/<id>/SKILL.md` `metadata.version`. Feature PRs must add a changeset targeting `@bwilliamson/skill-<id>` and must **not** hand-bump `metadata.version`. See [Agent Skill](./agent-skill.md).
 

--- a/docs/developer/versioning-and-releases.md
+++ b/docs/developer/versioning-and-releases.md
@@ -19,7 +19,7 @@ There is **no calendar cadence** and **no Version Packages PR**. Releases are **
 2. Merging that PR to `main` runs the [release workflow](../../.github/workflows/release.yml) (`pnpm release:main`).
 3. After the **Release plan** job posts pending changesets (and any **missing GitHub Releases**) to the run summary, approve the **`release` environment**. CI then **sequentially**: applies changesets → syncs skill `metadata.version` → builds (so husky can run) → commits `chore: release` → **pushes to `main`** → publishes public packages to npm → **pushes tags** → creates GitHub Releases (including skill carriers).
 
-If a prior run versioned/published but failed before Releases finished, the next Release plan detects **missing** `name@version` Releases and the release job **heals** them without bumping versions again (`gh release create … --target`).
+If a prior run versioned/published but failed before tags/Releases finished, the next Release plan detects **missing** `name@version` git tags and/or GitHub Releases and the release job **heals** them without bumping versions again (tag + `gh release create … --target` at the commit that last changed that package’s `package.json`).
 
 **Agent Skills** live under `skills/` as the install surface (`npx skills add`). Version carriers and CHANGELOGs live under **`packages/skill-<id>/`** only — never under `skills/` (those files would pollute agent context on install). `pnpm release:main` syncs the carrier version into `skills/<id>/SKILL.md` `metadata.version`. Feature PRs must add a changeset targeting `@bwilliamson/skill-<id>` and must **not** hand-bump `metadata.version`. See [Agent Skill](./agent-skill.md).
 

--- a/scripts/detect-missing-github-releases.mjs
+++ b/scripts/detect-missing-github-releases.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Plan-job helper: detect workspace packages whose current version has no
+ * GitHub Release. Writes has_missing_releases to GITHUB_OUTPUT when set.
+ *
+ * Uses GH_TOKEN / GITHUB_TOKEN (contents:read is enough for public releases).
+ */
+import { execSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  packagesMissingGithubReleases,
+  readWorkspacePackages,
+  releaseTag,
+} from './lib/github-releases.mjs';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function listExistingReleaseTags() {
+  const raw = execSync('gh release list --limit 1000 --json tagName', {
+    cwd: root,
+    encoding: 'utf-8',
+  });
+  const rows = JSON.parse(raw);
+  return new Set(rows.map((r) => r.tagName));
+}
+
+const packages = [...readWorkspacePackages(root).values()];
+const existing = listExistingReleaseTags();
+const missing = packagesMissingGithubReleases(packages, existing);
+const hasMissing = missing.length > 0;
+
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `has_missing_releases=${hasMissing}\n`);
+}
+
+if (!hasMissing) {
+  console.log('All current package versions already have GitHub Releases.');
+  process.exit(0);
+}
+
+console.log(`Missing GitHub Releases (${missing.length}):`);
+for (const pkg of missing) {
+  console.log(`  ${releaseTag(pkg.name, pkg.version)}`);
+}
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  const lines = [
+    '## Missing GitHub Releases',
+    '',
+    'Current package versions on this commit have no GitHub Release yet.',
+    'Approving **release** will create them idempotently (no version bump).',
+    '',
+    ...missing.map((pkg) => `- \`${releaseTag(pkg.name, pkg.version)}\``),
+    '',
+  ];
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+}

--- a/scripts/detect-missing-github-releases.mjs
+++ b/scripts/detect-missing-github-releases.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Plan-job helper: detect workspace packages whose current version has no
- * GitHub Release. Writes has_missing_releases to GITHUB_OUTPUT when set.
+ * Plan-job helper: detect workspace packages whose current version lacks a
+ * GitHub Release and/or git tag. Writes has_missing_releases to GITHUB_OUTPUT.
  *
  * Uses GH_TOKEN / GITHUB_TOKEN (contents:read is enough for public releases).
  */
@@ -10,7 +10,8 @@ import { appendFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  packagesMissingGithubReleases,
+  packagesNeedingReleaseHeal,
+  parseGitLsRemoteTags,
   readWorkspacePackages,
   releaseTag,
 } from './lib/github-releases.mjs';
@@ -26,33 +27,54 @@ function listExistingReleaseTags() {
   return new Set(rows.map((r) => r.tagName));
 }
 
+function listRemoteGitTags() {
+  const raw = execSync('git ls-remote --tags origin', {
+    cwd: root,
+    encoding: 'utf-8',
+  });
+  return parseGitLsRemoteTags(raw);
+}
+
 const packages = [...readWorkspacePackages(root).values()];
-const existing = listExistingReleaseTags();
-const missing = packagesMissingGithubReleases(packages, existing);
-const hasMissing = missing.length > 0;
+const needing = packagesNeedingReleaseHeal(
+  packages,
+  listExistingReleaseTags(),
+  listRemoteGitTags(),
+);
+const hasMissing = needing.length > 0;
 
 if (process.env.GITHUB_OUTPUT) {
   appendFileSync(process.env.GITHUB_OUTPUT, `has_missing_releases=${hasMissing}\n`);
 }
 
 if (!hasMissing) {
-  console.log('All current package versions already have GitHub Releases.');
+  console.log('All current package versions already have git tags and GitHub Releases.');
   process.exit(0);
 }
 
-console.log(`Missing GitHub Releases (${missing.length}):`);
-for (const pkg of missing) {
-  console.log(`  ${releaseTag(pkg.name, pkg.version)}`);
+console.log(`Missing release artifacts (${needing.length}):`);
+for (const row of needing) {
+  const tag = releaseTag(row.pkg.name, row.pkg.version);
+  const parts = [];
+  if (row.missingTag) parts.push('tag');
+  if (row.missingRelease) parts.push('release');
+  console.log(`  ${tag} (missing ${parts.join(' + ')})`);
 }
 
 if (process.env.GITHUB_STEP_SUMMARY) {
   const lines = [
-    '## Missing GitHub Releases',
+    '## Missing release artifacts',
     '',
-    'Current package versions on this commit have no GitHub Release yet.',
-    'Approving **release** will create them idempotently (no version bump).',
+    'Current package versions lack a git tag and/or GitHub Release.',
+    'Approving **release** will create them idempotently at the package version commit (no version bump).',
     '',
-    ...missing.map((pkg) => `- \`${releaseTag(pkg.name, pkg.version)}\``),
+    ...needing.map((row) => {
+      const tag = releaseTag(row.pkg.name, row.pkg.version);
+      const parts = [];
+      if (row.missingTag) parts.push('tag');
+      if (row.missingRelease) parts.push('release');
+      return `- \`${tag}\` — missing ${parts.join(' + ')}`;
+    }),
     '',
   ];
   appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);

--- a/scripts/lib/github-releases.mjs
+++ b/scripts/lib/github-releases.mjs
@@ -1,0 +1,66 @@
+/**
+ * Helpers for per-package GitHub Releases (`name@version` tags).
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { changelogNotesForVersion } from './skill-packages.mjs';
+
+/** @typedef {{ name: string, version: string, dir: string, private: boolean }} WorkspacePackage */
+
+/**
+ * @param {string} root
+ * @returns {Map<string, WorkspacePackage>}
+ */
+export function readWorkspacePackages(root) {
+  const versions = new Map();
+  const packagesDir = join(root, 'packages');
+  if (!existsSync(packagesDir)) return versions;
+  for (const name of readdirSync(packagesDir)) {
+    const pkgPath = join(packagesDir, name, 'package.json');
+    if (!existsSync(pkgPath)) continue;
+    const json = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    if (json.name && json.version) {
+      versions.set(json.name, {
+        name: json.name,
+        version: json.version,
+        dir: name,
+        private: Boolean(json.private),
+      });
+    }
+  }
+  return versions;
+}
+
+/** @param {string} name @param {string} version */
+export function releaseTag(name, version) {
+  return `${name}@${version}`;
+}
+
+/**
+ * Packages whose current `name@version` is not in the set of existing release tags.
+ * @param {Iterable<WorkspacePackage>} packages
+ * @param {ReadonlySet<string>} existingReleaseTags
+ * @returns {WorkspacePackage[]}
+ */
+export function packagesMissingGithubReleases(packages, existingReleaseTags) {
+  const missing = [];
+  for (const pkg of packages) {
+    const tag = releaseTag(pkg.name, pkg.version);
+    if (!existingReleaseTags.has(tag)) {
+      missing.push(pkg);
+    }
+  }
+  return missing.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * @param {string} root
+ * @param {WorkspacePackage} pkg
+ */
+export function releaseNotesForPackage(root, pkg) {
+  const tag = releaseTag(pkg.name, pkg.version);
+  return (
+    changelogNotesForVersion(join(root, 'packages', pkg.dir, 'CHANGELOG.md'), pkg.version) ||
+    `Release ${tag}`
+  );
+}

--- a/scripts/lib/github-releases.mjs
+++ b/scripts/lib/github-releases.mjs
@@ -37,7 +37,43 @@ export function releaseTag(name, version) {
 }
 
 /**
- * Packages whose current `name@version` is not in the set of existing release tags.
+ * Parse `git ls-remote --tags` output into a set of tag names (peeled ^{} lines skipped).
+ * @param {string} lsRemoteOutput
+ * @returns {Set<string>}
+ */
+export function parseGitLsRemoteTags(lsRemoteOutput) {
+  const tags = new Set();
+  for (const line of lsRemoteOutput.split('\n')) {
+    const ref = line.split(/[\t ]+/).pop();
+    if (!ref || !ref.startsWith('refs/tags/')) continue;
+    if (ref.endsWith('^{}')) continue;
+    tags.add(ref.slice('refs/tags/'.length));
+  }
+  return tags;
+}
+
+/**
+ * Packages whose current `name@version` lacks a GitHub Release and/or a git tag.
+ * @param {Iterable<WorkspacePackage>} packages
+ * @param {ReadonlySet<string>} existingReleaseTags
+ * @param {ReadonlySet<string>} existingGitTags
+ * @returns {{ pkg: WorkspacePackage, missingRelease: boolean, missingTag: boolean }[]}
+ */
+export function packagesNeedingReleaseHeal(packages, existingReleaseTags, existingGitTags) {
+  const needing = [];
+  for (const pkg of packages) {
+    const tag = releaseTag(pkg.name, pkg.version);
+    const missingRelease = !existingReleaseTags.has(tag);
+    const missingTag = !existingGitTags.has(tag);
+    if (missingRelease || missingTag) {
+      needing.push({ pkg, missingRelease, missingTag });
+    }
+  }
+  return needing.sort((a, b) => a.pkg.name.localeCompare(b.pkg.name));
+}
+
+/**
+ * Packages whose current `name@version` is not in the set of existing GitHub Release tags.
  * @param {Iterable<WorkspacePackage>} packages
  * @param {ReadonlySet<string>} existingReleaseTags
  * @returns {WorkspacePackage[]}
@@ -63,4 +99,9 @@ export function releaseNotesForPackage(root, pkg) {
     changelogNotesForVersion(join(root, 'packages', pkg.dir, 'CHANGELOG.md'), pkg.version) ||
     `Release ${tag}`
   );
+}
+
+/** Path relative to repo root for a package's package.json. */
+export function packageJsonRelPath(pkg) {
+  return join('packages', pkg.dir, 'package.json');
 }

--- a/scripts/lib/github-releases.test.mjs
+++ b/scripts/lib/github-releases.test.mjs
@@ -1,27 +1,57 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { packagesMissingGithubReleases, releaseTag } from './github-releases.mjs';
+import {
+  packagesMissingGithubReleases,
+  packagesNeedingReleaseHeal,
+  parseGitLsRemoteTags,
+  releaseTag,
+} from './github-releases.mjs';
 
 describe('github-releases', () => {
   it('builds name@version tags', () => {
     assert.equal(releaseTag('@bwilliamson/skill-mdcp', '0.7.2'), '@bwilliamson/skill-mdcp@0.7.2');
   });
 
-  it('lists packages whose current version has no GitHub Release', () => {
+  it('parses git ls-remote --tags output', () => {
+    const tags = parseGitLsRemoteTags(`
+abc\trefs/tags/@bwilliamson/mdcp-cli@0.7.1
+def\trefs/tags/@bwilliamson/mdcp-cli@0.7.1^{}
+ghi refs/tags/v0.7.0
+`);
+    assert.deepEqual([...tags].sort(), ['@bwilliamson/mdcp-cli@0.7.1', 'v0.7.0']);
+  });
+
+  it('lists packages missing a GitHub Release and/or git tag', () => {
     const packages = [
       { name: '@bwilliamson/mdcp-cli', version: '0.7.1', dir: 'mdcp-cli', private: false },
       { name: '@bwilliamson/skill-mdcp', version: '0.7.2', dir: 'skill-mdcp', private: true },
       { name: '@bwilliamson/mdcp-presets', version: '0.7.0', dir: 'mdcp-presets', private: false },
     ];
-    const existing = new Set(['@bwilliamson/mdcp-cli@0.7.1']);
-    const missing = packagesMissingGithubReleases(packages, existing);
+    const releases = new Set(['@bwilliamson/mdcp-cli@0.7.1']);
+    const gitTags = new Set(['@bwilliamson/mdcp-cli@0.7.1', '@bwilliamson/mdcp-presets@0.7.0']);
+    const needing = packagesNeedingReleaseHeal(packages, releases, gitTags);
     assert.deepEqual(
-      missing.map((p) => releaseTag(p.name, p.version)),
-      ['@bwilliamson/mdcp-presets@0.7.0', '@bwilliamson/skill-mdcp@0.7.2'],
+      needing.map((row) => ({
+        tag: releaseTag(row.pkg.name, row.pkg.version),
+        missingRelease: row.missingRelease,
+        missingTag: row.missingTag,
+      })),
+      [
+        {
+          tag: '@bwilliamson/mdcp-presets@0.7.0',
+          missingRelease: true,
+          missingTag: false,
+        },
+        {
+          tag: '@bwilliamson/skill-mdcp@0.7.2',
+          missingRelease: true,
+          missingTag: true,
+        },
+      ],
     );
   });
 
-  it('returns empty when every current version already has a release', () => {
+  it('packagesMissingGithubReleases stays release-only', () => {
     const packages = [
       { name: '@bwilliamson/mdcp-cli', version: '0.7.1', dir: 'mdcp-cli', private: false },
     ];

--- a/scripts/lib/github-releases.test.mjs
+++ b/scripts/lib/github-releases.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { packagesMissingGithubReleases, releaseTag } from './github-releases.mjs';
+
+describe('github-releases', () => {
+  it('builds name@version tags', () => {
+    assert.equal(releaseTag('@bwilliamson/skill-mdcp', '0.7.2'), '@bwilliamson/skill-mdcp@0.7.2');
+  });
+
+  it('lists packages whose current version has no GitHub Release', () => {
+    const packages = [
+      { name: '@bwilliamson/mdcp-cli', version: '0.7.1', dir: 'mdcp-cli', private: false },
+      { name: '@bwilliamson/skill-mdcp', version: '0.7.2', dir: 'skill-mdcp', private: true },
+      { name: '@bwilliamson/mdcp-presets', version: '0.7.0', dir: 'mdcp-presets', private: false },
+    ];
+    const existing = new Set(['@bwilliamson/mdcp-cli@0.7.1']);
+    const missing = packagesMissingGithubReleases(packages, existing);
+    assert.deepEqual(
+      missing.map((p) => releaseTag(p.name, p.version)),
+      ['@bwilliamson/mdcp-presets@0.7.0', '@bwilliamson/skill-mdcp@0.7.2'],
+    );
+  });
+
+  it('returns empty when every current version already has a release', () => {
+    const packages = [
+      { name: '@bwilliamson/mdcp-cli', version: '0.7.1', dir: 'mdcp-cli', private: false },
+    ];
+    const existing = new Set(['@bwilliamson/mdcp-cli@0.7.1']);
+    assert.deepEqual(packagesMissingGithubReleases(packages, existing), []);
+  });
+});

--- a/scripts/release-main.mjs
+++ b/scripts/release-main.mjs
@@ -8,8 +8,10 @@
  * GitHub Releases so `gh release create` can resolve them; create also
  * passes `--target` so a fresh checkout can heal missing releases.
  *
- * With no pending changesets, ensures GitHub Releases exist for every
- * current workspace package version (idempotent heal after partial failure).
+ * With no pending changesets, ensures git tags + GitHub Releases exist for
+ * every current workspace package version (idempotent heal after partial
+ * failure). Tags point at the commit that last changed that package.json
+ * (the version bump commit), not necessarily HEAD.
  *
  * Requires RELEASE_GITHUB_TOKEN (fine-grained maintainer PAT).
  */
@@ -19,7 +21,9 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { findMajorBumps, pendingChangesetFiles } from './lib/changeset-bumps.mjs';
 import {
-  packagesMissingGithubReleases,
+  packageJsonRelPath,
+  packagesNeedingReleaseHeal,
+  parseGitLsRemoteTags,
   readWorkspacePackages,
   releaseNotesForPackage,
   releaseTag,
@@ -59,6 +63,56 @@ function listExistingReleaseTags() {
   return new Set(rows.map((r) => r.tagName));
 }
 
+function listRemoteGitTags() {
+  return parseGitLsRemoteTags(capture('git ls-remote --tags origin'));
+}
+
+/** Commit that last changed this package's package.json (version bump / release). */
+function resolvePackageVersionCommit(pkg) {
+  const rel = packageJsonRelPath(pkg).replace(/\\/g, '/');
+  const sha = capture(`git rev-list -1 HEAD -- "${rel}"`);
+  if (!sha) {
+    throw new Error(`No git history for ${rel}`);
+  }
+  return sha;
+}
+
+function ensureGitTag(tag, target) {
+  let localSha = '';
+  try {
+    localSha = capture(`git rev-list -1 "refs/tags/${tag}"`);
+  } catch {
+    // tag missing locally
+  }
+  if (localSha && localSha !== target) {
+    console.log(
+      `Tag ${tag} exists locally at ${localSha}, expected ${target} — leaving local tag; pushing if needed`,
+    );
+  } else if (!localSha) {
+    run(`git tag "${tag}" "${target}"`);
+  } else {
+    console.log(`Tag ${tag} already at ${target} locally`);
+  }
+
+  try {
+    const remote = capture(`git ls-remote --tags origin "refs/tags/${tag}"`);
+    const remoteSha = remote.split(/[\t ]+/)[0] || '';
+    if (remoteSha === target) {
+      console.log(`Tag ${tag} already on origin at ${target}`);
+      return;
+    }
+    if (remoteSha && remoteSha !== target) {
+      console.log(
+        `Tag ${tag} on origin at ${remoteSha}, expected ${target} — not moving a published tag`,
+      );
+      return;
+    }
+  } catch {
+    // treat as missing on remote
+  }
+  run(`git push origin "refs/tags/${tag}"`);
+}
+
 function createGithubRelease(tag, notes, target) {
   const tmp = join(root, '.tmp-release-notes.md');
   writeFileSync(tmp, `${notes}\n`);
@@ -69,7 +123,7 @@ function createGithubRelease(tag, notes, target) {
       console.log(`GitHub Release ${tag} already exists — updating notes`);
       run(`gh release edit "${tag}" --notes-file .tmp-release-notes.md`, { env });
     } catch {
-      // --target lets create work when the tag is not on the remote yet (heal / race).
+      // --target creates the tag on GitHub when missing; prefer matching the version commit.
       run(
         `gh release create "${tag}" --title "${tag}" --notes-file .tmp-release-notes.md --target "${target}"`,
         { env },
@@ -84,21 +138,35 @@ function createGithubRelease(tag, notes, target) {
   }
 }
 
-function ensureGithubReleases(packages) {
+/**
+ * Ensure git tags + GitHub Releases for the given packages at each package's
+ * version-bump commit (not necessarily HEAD).
+ * @param {import('./lib/github-releases.mjs').WorkspacePackage[]} packages
+ * @param {{ ensureTag?: boolean, ensureRelease?: boolean }} [opts]
+ */
+function ensureReleaseArtifacts(packages, opts = {}) {
+  const ensureTag = opts.ensureTag !== false;
+  const ensureRelease = opts.ensureRelease !== false;
   if (packages.length === 0) {
-    console.log('No GitHub Releases to create or update.');
+    console.log('No release artifacts to create or update.');
     return;
   }
-  const target = dryRun ? 'HEAD' : capture('git rev-parse HEAD');
-  console.log(`Ensuring GitHub Releases (${packages.length}) at target ${target}:`);
+  console.log(`Ensuring release artifacts (${packages.length}):`);
   for (const pkg of packages) {
     const tag = releaseTag(pkg.name, pkg.version);
+    const target = dryRun ? 'HEAD' : resolvePackageVersionCommit(pkg);
     const notes = releaseNotesForPackage(root, pkg);
     if (dryRun) {
-      console.log(`would ensure GitHub Release ${tag}`);
+      console.log(`would ensure tag+release ${tag} at ${target}`);
       continue;
     }
-    createGithubRelease(tag, notes, target);
+    console.log(`  ${tag} → ${target}`);
+    if (ensureTag) {
+      ensureGitTag(tag, target);
+    }
+    if (ensureRelease) {
+      createGithubRelease(tag, notes, target);
+    }
   }
 }
 
@@ -129,30 +197,37 @@ if (!ghToken && !dryRun) {
 }
 
 if (pending.length === 0) {
-  console.log('No pending changesets — checking for missing GitHub Releases.');
+  console.log('No pending changesets — checking for missing git tags / GitHub Releases.');
   if (dryRun) {
-    console.log('dry-run: would heal any missing GitHub Releases for current package versions.');
+    console.log('dry-run: would heal any missing tags/Releases for current package versions.');
     process.exit(0);
   }
   configureGitIdentityAndRemote(ghToken);
   const packages = [...readWorkspacePackages(root).values()];
-  const missing = packagesMissingGithubReleases(packages, listExistingReleaseTags());
-  if (missing.length === 0) {
+  const needing = packagesNeedingReleaseHeal(
+    packages,
+    listExistingReleaseTags(),
+    listRemoteGitTags(),
+  );
+  if (needing.length === 0) {
     console.log('Nothing to version, publish, or heal.');
     process.exit(0);
   }
   console.log(
-    `Healing missing GitHub Releases (${missing.length}): ${missing
-      .map((p) => releaseTag(p.name, p.version))
+    `Healing missing release artifacts (${needing.length}): ${needing
+      .map((row) => {
+        const tag = releaseTag(row.pkg.name, row.pkg.version);
+        const parts = [];
+        if (row.missingTag) parts.push('tag');
+        if (row.missingRelease) parts.push('release');
+        return `${tag}[${parts.join('+')}]`;
+      })
       .join(', ')}`,
   );
-  ensureGithubReleases(missing);
-  // Best-effort: push any local tags (e.g. left from a prior partial run on this runner).
-  try {
-    run('git push origin --tags');
-  } catch {
-    console.log('git push --tags skipped or failed (tags may already exist via --target).');
-  }
+  ensureReleaseArtifacts(
+    needing.map((row) => row.pkg),
+    { ensureTag: true, ensureRelease: true },
+  );
   console.log('Release heal complete.');
   process.exit(0);
 }
@@ -209,9 +284,9 @@ run('pnpm exec changeset publish');
 // Push tags before GitHub Releases so create can resolve them when present.
 run('git push origin --tags');
 
-ensureGithubReleases(bumped);
+// Ensure Releases (and any missing tags) at this release commit.
+ensureReleaseArtifacts(bumped);
 
-// Catch any tags created during release create (--target) or left local.
 run('git push origin --tags');
 
 console.log('Release complete.');

--- a/scripts/release-main.mjs
+++ b/scripts/release-main.mjs
@@ -1,24 +1,29 @@
 #!/usr/bin/env node
 /**
  * Single-step release on main: version → sync skills → build → commit →
- * push to main → publish npm + tags → GitHub Releases.
+ * push to main → publish npm → push tags → GitHub Releases.
  *
  * Push happens before npm publish so a failed push cannot leave registry
- * packages without the matching commit on main.
+ * packages without the matching commit on main. Tags are pushed before
+ * GitHub Releases so `gh release create` can resolve them; create also
+ * passes `--target` so a fresh checkout can heal missing releases.
  *
- * Requires RELEASE_GITHUB_TOKEN (fine-grained maintainer PAT). No-ops when
- * there are no pending changesets.
+ * With no pending changesets, ensures GitHub Releases exist for every
+ * current workspace package version (idempotent heal after partial failure).
+ *
+ * Requires RELEASE_GITHUB_TOKEN (fine-grained maintainer PAT).
  */
 import { execSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+import { writeFileSync, unlinkSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { findMajorBumps, pendingChangesetFiles } from './lib/changeset-bumps.mjs';
 import {
-  changelogNotesForVersion,
-  skillCarrierDirName,
-  skillIdFromPackageName,
-} from './lib/skill-packages.mjs';
+  packagesMissingGithubReleases,
+  readWorkspacePackages,
+  releaseNotesForPackage,
+  releaseTag,
+} from './lib/github-releases.mjs';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const dryRun = process.argv.includes('--dry-run');
@@ -39,44 +44,36 @@ function token() {
   return process.env.RELEASE_GITHUB_TOKEN || '';
 }
 
-function readWorkspaceVersions() {
-  const versions = new Map();
-  const packagesDir = join(root, 'packages');
-  for (const name of readdirSync(packagesDir)) {
-    const pkgPath = join(packagesDir, name, 'package.json');
-    if (!existsSync(pkgPath)) continue;
-    const json = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    if (json.name && json.version) {
-      versions.set(json.name, { version: json.version, dir: name, private: Boolean(json.private) });
-    }
-  }
-  return versions;
+function ghEnv() {
+  const t = token();
+  return {
+    ...process.env,
+    GH_TOKEN: t,
+    GITHUB_TOKEN: t,
+  };
 }
 
-function packageDirForName(name, dirHint) {
-  if (dirHint) return dirHint;
-  const id = skillIdFromPackageName(name);
-  if (id) return skillCarrierDirName(id);
-  return name.replace(/^@bwilliamson\//, '');
+function listExistingReleaseTags() {
+  const raw = capture('gh release list --limit 1000 --json tagName', { env: ghEnv() });
+  const rows = JSON.parse(raw);
+  return new Set(rows.map((r) => r.tagName));
 }
 
-function createGithubRelease(tag, notes) {
+function createGithubRelease(tag, notes, target) {
   const tmp = join(root, '.tmp-release-notes.md');
   writeFileSync(tmp, `${notes}\n`);
-  const env = {
-    ...process.env,
-    GH_TOKEN: token(),
-    GITHUB_TOKEN: token(),
-  };
+  const env = ghEnv();
   try {
     try {
       capture(`gh release view "${tag}"`, { env });
       console.log(`GitHub Release ${tag} already exists — updating notes`);
       run(`gh release edit "${tag}" --notes-file .tmp-release-notes.md`, { env });
     } catch {
-      run(`gh release create "${tag}" --title "${tag}" --notes-file .tmp-release-notes.md`, {
-        env,
-      });
+      // --target lets create work when the tag is not on the remote yet (heal / race).
+      run(
+        `gh release create "${tag}" --title "${tag}" --notes-file .tmp-release-notes.md --target "${target}"`,
+        { env },
+      );
     }
   } finally {
     try {
@@ -87,10 +84,76 @@ function createGithubRelease(tag, notes) {
   }
 }
 
+function ensureGithubReleases(packages) {
+  if (packages.length === 0) {
+    console.log('No GitHub Releases to create or update.');
+    return;
+  }
+  const target = dryRun ? 'HEAD' : capture('git rev-parse HEAD');
+  console.log(`Ensuring GitHub Releases (${packages.length}) at target ${target}:`);
+  for (const pkg of packages) {
+    const tag = releaseTag(pkg.name, pkg.version);
+    const notes = releaseNotesForPackage(root, pkg);
+    if (dryRun) {
+      console.log(`would ensure GitHub Release ${tag}`);
+      continue;
+    }
+    createGithubRelease(tag, notes, target);
+  }
+}
+
+function configureGitIdentityAndRemote(ghToken) {
+  if (dryRun) return;
+  const repo = capture('gh repo view --json nameWithOwner -q .nameWithOwner', {
+    env: { ...process.env, GH_TOKEN: ghToken, GITHUB_TOKEN: ghToken },
+  });
+  execSync(`git remote set-url origin https://x-access-token:${ghToken}@github.com/${repo}.git`, {
+    cwd: root,
+    stdio: 'ignore',
+  });
+  console.log('> git remote set-url origin (token redacted)');
+  // Runners have no git identity; required before commit (local to this clone).
+  run('git config user.name "github-actions[bot]"');
+  run('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"');
+}
+
 const changesetDir = join(root, '.changeset');
 const pending = pendingChangesetFiles(changesetDir);
+const ghToken = token();
+
+if (!ghToken && !dryRun) {
+  console.error(
+    'RELEASE_GITHUB_TOKEN is required (fine-grained PAT with Contents write on this repo).',
+  );
+  process.exit(1);
+}
+
 if (pending.length === 0) {
-  console.log('No pending changesets — nothing to version or publish.');
+  console.log('No pending changesets — checking for missing GitHub Releases.');
+  if (dryRun) {
+    console.log('dry-run: would heal any missing GitHub Releases for current package versions.');
+    process.exit(0);
+  }
+  configureGitIdentityAndRemote(ghToken);
+  const packages = [...readWorkspacePackages(root).values()];
+  const missing = packagesMissingGithubReleases(packages, listExistingReleaseTags());
+  if (missing.length === 0) {
+    console.log('Nothing to version, publish, or heal.');
+    process.exit(0);
+  }
+  console.log(
+    `Healing missing GitHub Releases (${missing.length}): ${missing
+      .map((p) => releaseTag(p.name, p.version))
+      .join(', ')}`,
+  );
+  ensureGithubReleases(missing);
+  // Best-effort: push any local tags (e.g. left from a prior partial run on this runner).
+  try {
+    run('git push origin --tags');
+  } catch {
+    console.log('git push --tags skipped or failed (tags may already exist via --target).');
+  }
+  console.log('Release heal complete.');
   process.exit(0);
 }
 
@@ -105,32 +168,19 @@ if (majors.length > 0) {
 
 console.log(`Pending changesets (${pending.length}): ${pending.join(', ')}`);
 
-const ghToken = token();
-if (!ghToken && !dryRun) {
-  console.error(
-    'RELEASE_GITHUB_TOKEN is required (fine-grained PAT with Contents write on this repo).',
-  );
-  process.exit(1);
-}
-
-const before = readWorkspaceVersions();
+const before = readWorkspacePackages(root);
 
 run('pnpm exec changeset version');
 run('node scripts/sync-skill-versions.mjs');
 run('pnpm skill:validate');
 run('pnpm build');
 
-const after = readWorkspaceVersions();
+const after = readWorkspacePackages(root);
 const bumped = [];
 for (const [name, next] of after) {
   const prev = before.get(name);
   if (!prev || prev.version !== next.version) {
-    bumped.push({
-      name,
-      version: next.version,
-      dir: next.dir,
-      private: next.private,
-    });
+    bumped.push(next);
   }
 }
 
@@ -141,23 +191,11 @@ if (bumped.length === 0) {
 
 console.log('Bumped:');
 for (const b of bumped) {
-  console.log(`  ${b.name}@${b.version}${b.private ? ' (skill carrier)' : ''}`);
+  console.log(`  ${releaseTag(b.name, b.version)}${b.private ? ' (skill carrier)' : ''}`);
 }
 
-if (!dryRun) {
-  const repo = capture('gh repo view --json nameWithOwner -q .nameWithOwner', {
-    env: { ...process.env, GH_TOKEN: ghToken, GITHUB_TOKEN: ghToken },
-  });
-  execSync(`git remote set-url origin https://x-access-token:${ghToken}@github.com/${repo}.git`, {
-    cwd: root,
-    stdio: 'ignore',
-  });
-  console.log('> git remote set-url origin (token redacted)');
-}
+configureGitIdentityAndRemote(ghToken);
 
-// Runners have no git identity; required before commit (local to this clone).
-run('git config user.name "github-actions[bot]"');
-run('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"');
 run('git add -A');
 run('git commit -m "chore: release"');
 
@@ -168,20 +206,12 @@ run('git push origin HEAD:main');
 run('pnpm audit --audit-level=high');
 run('pnpm exec changeset publish');
 
-for (const b of bumped) {
-  const tag = `${b.name}@${b.version}`;
-  const dir = packageDirForName(b.name, b.dir);
-  const notes =
-    changelogNotesForVersion(join(root, 'packages', dir, 'CHANGELOG.md'), b.version) ||
-    `Release ${tag}`;
-  if (dryRun) {
-    console.log(`would create GitHub Release ${tag}`);
-    continue;
-  }
-  createGithubRelease(tag, notes);
-}
+// Push tags before GitHub Releases so create can resolve them when present.
+run('git push origin --tags');
 
-// Ensure any tags created by changeset publish are on the remote.
+ensureGithubReleases(bumped);
+
+// Catch any tags created during release create (--target) or left local.
 run('git push origin --tags');
 
 console.log('Release complete.');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

You were right to expect idempotent heal — the previous run failed **after** the version commit (no changesets left), and the follow-up Release run **skipped** the publish job entirely. Tags from `changeset publish` were never pushed; GitHub Releases were never created.

### Fixes

1. **Push tags before** `gh release create`, and create with **`--target`**.
2. **Heal path:** with no pending changesets, ensure both **git tags** and **GitHub Releases** for every current `packages/*/package.json` `name@version`.
3. Tags are created at the commit that **last changed that package’s `package.json`** (e.g. `b1be591 chore: release` for skills `@0.7.2`), not at whatever HEAD the heal run is on.
4. **Plan job** detects missing tags and/or Releases and schedules the release job when needed.

### After merge

Approve **`release`** on the merge (or `workflow_dispatch`) → should create ~10 missing tags + Releases (skills `@0.7.2` + `mdcp-presets@0.7.0`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2679c8f3-fb60-4981-9bd3-7c90aee7b711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2679c8f3-fb60-4981-9bd3-7c90aee7b711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

