### PR TITLE
docs(github): finish #87 acknowledgments + issue/PR templates residuals

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-extension-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/03-extension-proposal.yml
@@ -1,0 +1,138 @@
+name: Extension proposal
+description: Propose a shared archetype, formatting pack, pointer profile, or complementary skill
+title: '[Extension] '
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Propose an extension that stays out of protocol core — see [Extensions and archetypes](https://github.com/betsalel-williamson/mdcp/blob/main/docs/features/protocol/extensions-and-archetypes.md).
+
+        Local-only packs under `docs/extensions/` need no upstream issue. Use this form when you want shared guidance or an upstream complementary skill.
+
+        Maintainers apply a matching `priority:*` label from your selection below (and usually `protocol`), then finish [new issue intake](https://github.com/betsalel-williamson/mdcp/blob/main/docs/developer/agent-work-item-tracking.md#new-issue-intake-required).
+
+  - type: dropdown
+    id: extension-kind
+    attributes:
+      label: Extension kind
+      description: See kinds in Extensions and archetypes.
+      options:
+        - Archetype
+        - Formatting pack
+        - Pointer profile
+        - Other complementary skill
+    validations:
+      required: true
+
+  - type: input
+    id: proposed-id
+    attributes:
+      label: Proposed id / prefix
+      description: e.g. mdcp-arch-legal-ops, mdcp-format-mkdocs
+      placeholder: mdcp-arch-…
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Value-add priority
+      description: How much adopter or product value does this represent if we act on it?
+      options:
+        - P0 — user-facing blocker or broken core path (compile / check / refs)
+        - P1 — high near-term value
+        - P2 — important backlog
+        - P3 — nice-to-have / low urgency
+        - Defer — parked on an explicit gate
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem-audience
+    attributes:
+      label: Problem and audience
+      description: Project class and why the default Code Repository Archetype (or existing packs) falls short.
+    validations:
+      required: true
+
+  - type: textarea
+    id: when-to-use
+    attributes:
+      label: When to use
+      description: Trigger conditions for agents/humans choosing this extension.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-layout
+    attributes:
+      label: Proposed layout
+      description: Guide tiers, glossary seeds, or docs/extensions/ overlays you have in mind.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: check-compat
+    attributes:
+      label: Check compatibility
+      description: Optional extensions must not break core validation when disabled.
+      options:
+        - label: Does not break `mdcp check` when the extension is disabled
+          required: true
+        - label: Composes on top of conforming layouts (does not fork the parent skill for one-off advice)
+          required: true
+
+  - type: dropdown
+    id: delivery-intent
+    attributes:
+      label: Delivery intent
+      options:
+        - Upstream complementary skill
+        - Keep local docs/extensions/ (FYI / design discussion)
+        - Unsure
+    validations:
+      required: true
+
+  - type: input
+    id: protocol-version
+    attributes:
+      label: Target protocolVersion
+      description: Four-part protocol version this extension claims to support
+      placeholder: '0.5.0.0'
+    validations:
+      required: true
+
+  - type: input
+    id: parent-skill-version
+    attributes:
+      label: Parent skill version tested (optional)
+      description: From skills/mdcp SKILL.md metadata.version
+      placeholder: '0.7.2'
+    validations:
+      required: false
+
+  - type: input
+    id: mdcp-version
+    attributes:
+      label: mdcp-cli version (optional)
+      placeholder: '0.7.1'
+    validations:
+      required: false
+
+  - type: textarea
+    id: security-notes
+    attributes:
+      label: Security / trust notes (optional)
+      description: Third-party skill trust, permissions, or why this should stay local.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-sketch
+    attributes:
+      label: Acceptance sketch
+      description: What "done" looks like (naming, dogfood layout, check still green, catalog status).
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Protocol / skill versions
+
+<!-- Required when the change touches protocol shards, skills, schemas, or CLI contracts. Otherwise write N/A. -->
+
+- **protocolVersion** (four-part): <!-- e.g. 0.5.0.0 — schema default / label 0.5 -->
+- **Parent skill** (`skills/mdcp` `metadata.version`): <!-- e.g. 0.7.2 -->
+- **mdcp-cli** (if relevant): <!-- e.g. 0.7.1 -->
+
+## Checklist
+
+- [ ] Scope matches the linked issue / work item (one concern)
+- [ ] Docs shards updated when behavior or contributor workflow changed (`pnpm docs:check`)
+- [ ] Tests / validation green for the surfaces touched
+- [ ] Changeset added when a published package’s user-facing behavior changes
+
+## Test plan
+
+<!-- Commands you ran, or steps a reviewer should try. -->
+
+## Related
+
+Closes #

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -237,7 +237,7 @@ Use **one** mutually exclusive GitHub label so the board and `gh issue list` sta
 2. **Labels** — Maintainers or coding agents apply the matching `priority:*` label when triaging (GitHub forms cannot map a dropdown to a label automatically). Replace any previous `priority:*` label so only one remains.
 3. **What to work on next** — Prefer open issues labeled `priority:P0`, then `P1`. Skip `priority:defer` until the gate in the issue body is met.
 
-Issue templates live under `.github/ISSUE_TEMPLATE/`. Adoption stories do not require a priority dropdown (qualitative evidence, not a delivery backlog item).
+Issue templates live under `.github/ISSUE_TEMPLATE/` (bug report, feedback, adoption story, extension proposal). Adoption stories do not require a priority dropdown (qualitative evidence, not a delivery backlog item). Extension proposals use the priority dropdown and the `enhancement` type label; maintainers usually also apply `protocol`. Pull requests use `.github/PULL_REQUEST_TEMPLATE.md`, which asks for protocol/skill version when the change touches those surfaces.
 
 #### Other labels (apply on intake)
 

--- a/docs/developer/agent-work-item-tracking.md
+++ b/docs/developer/agent-work-item-tracking.md
@@ -69,7 +69,7 @@ Use **one** mutually exclusive GitHub label so the board and `gh issue list` sta
 2. **Labels** — Maintainers or coding agents apply the matching `priority:*` label when triaging (GitHub forms cannot map a dropdown to a label automatically). Replace any previous `priority:*` label so only one remains.
 3. **What to work on next** — Prefer open issues labeled `priority:P0`, then `P1`. Skip `priority:defer` until the gate in the issue body is met.
 
-Issue templates live under `.github/ISSUE_TEMPLATE/`. Adoption stories do not require a priority dropdown (qualitative evidence, not a delivery backlog item).
+Issue templates live under `.github/ISSUE_TEMPLATE/` (bug report, feedback, adoption story, extension proposal). Adoption stories do not require a priority dropdown (qualitative evidence, not a delivery backlog item). Extension proposals use the priority dropdown and the `enhancement` type label; maintainers usually also apply `protocol`. Pull requests use `.github/PULL_REQUEST_TEMPLATE.md`, which asks for protocol/skill version when the change touches those surfaces.
 
 ### Other labels (apply on intake)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the remaining work on [#87](https://github.com/betsalel-williamson/mdcp/issues/87): community **extension proposal** issue form and a **PR template** that asks for protocol/skill versions. Acknowledgments, bug report, and adoption-story templates were already on `main`.

## Changes

- Add `.github/ISSUE_TEMPLATE/03-extension-proposal.yml` (kind, id, priority, layout, check-compat, `protocolVersion`)
- Add `.github/PULL_REQUEST_TEMPLATE.md` with protocol / parent skill / CLI version fields
- Note both in `docs/developer/agent-work-item-tracking.md` (compiled into `DEVELOPERS.md`)

## Acceptance

- [x] Acknowledgments still visible on README (Denali Lumma)
- [x] Extension-proposal + existing issue templates under `.github/ISSUE_TEMPLATE/`
- [x] PR template present and references protocol version
- [x] Adoption-story retains skill-based bootstrap wording (no `mdcp init` regression)

## Test plan

- [x] YAML parse of new issue form
- [x] `pnpm docs:check` passed on the branch
- [ ] Confirm GitHub UI shows new issue type and PR template after merge

Closes #87

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02ba4caa-1a33-4d38-b310-fe118ccaf2a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02ba4caa-1a33-4d38-b310-fe118ccaf2a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

