### PR TITLE
fix(mdcp-core): index transitive shards for same-output rewrite (#69)

### DIFF
--- a/.changeset/transitive-link-index-same-output.md
+++ b/.changeset/transitive-link-index-same-output.md
@@ -1,0 +1,5 @@
+---
+'@bwilliamson/mdcp-core': patch
+---
+
+Index every `linkedSectionFiles` path (including transitive `scopeRoot` shards outside `guideDir`) and prefer same-output `#anchor` rewrite for non-canonical co-compiled targets so `../` links under default `_build` outputs resolve correctly.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -680,11 +680,11 @@ When changing skill instructions:
 | `pnpm skill:validate` | Frontmatter fence lint + [skills-ref](https://agentskills.io/specification) validate on all skills under `skills/` |
 | `pnpm docs:check`     | Docs compile + lint gate after shard edits                                                                         |
 
-`pnpm skill:validate` runs in local `pnpm check`, PR CI, and during **`pnpm release:main`** after skill version sync (hard fail before the release commit / publish). It is not a [live skill eval](docs/glossary/live-skill-eval.md).
+`pnpm skill:validate` runs in local `pnpm check`, PR CI, and during **`pnpm release:main`** after skill version sync (hard fail before the release commit / publish). It is not a [live skill eval](#live-skill-eval).
 
 ### Live skill evals (optional, local)
 
-Qualitative with/without-skill grading is documented in [Live skill evals](#live-skill-evals) (suite inventory, layout contract, tooling). The glossary term is [live skill eval](docs/glossary/live-skill-eval.md). That loop is local-only — do **not** require Claude CLI or `skill-creator` in CI.
+Qualitative with/without-skill grading is documented in [Live skill evals](#live-skill-evals) (suite inventory, layout contract, tooling). The glossary term is [live skill eval](#live-skill-eval). That loop is local-only — do **not** require Claude CLI or `skill-creator` in CI.
 
 ### Acceptance criteria
 
@@ -1076,7 +1076,7 @@ Work is tracked under [#200](https://github.com/betsalel-williamson/mdcp/issues/
 
 ### Why this is necessary
 
-GitHub CodeQL’s `js/polynomial-redos` rule flagged several `mdcp-core` paths that parse headings and strip `` markers. The patterns used overlapping or unbounded quantifiers (`\s*` next to `{#…}`, `\s+` with a greedy remainder, non-greedy `.*?` between braces) on library-controlled strings. On adversarial input those matches can take time that grows badly with length — a [ReDoS](docs/glossary/redos.md) class of denial-of-service risk.
+GitHub CodeQL’s `js/polynomial-redos` rule flagged several `mdcp-core` paths that parse headings and strip `` markers. The patterns used overlapping or unbounded quantifiers (`\s*` next to `{#…}`, `\s+` with a greedy remainder, non-greedy `.*?` between braces) on library-controlled strings. On adversarial input those matches can take time that grows badly with length — a [ReDoS](#redos) class of denial-of-service risk.
 
 Even when everyday docs never hit the pathological case, the open alerts block a clean security dashboard, and the same regex shapes were copied across compile, refs, links, and xref lint. Fixing call sites one-by-one without a shared parse path invites the class to return.
 
@@ -1086,7 +1086,7 @@ Phase A introduces shared **linear** helpers for:
 
 - recognizing and demoting ATX headings
 - stripping Pandoc-style `` markers (including optional preceding whitespace when cleaning compiled output)
-- producing plain heading text for [heading slug](docs/glossary/heading-slug.md) generation
+- producing plain heading text for [heading slug](#heading-slug) generation
 
 Public package APIs keep their existing names; call sites delegate to the helpers. Duration-budget regression tests exercise the known CodeQL pump classes so a future regex reintroduction fails CI.
 
@@ -1110,7 +1110,7 @@ Phase B is a broader inventory of remaining regexes in `mdcp-core` (for example 
 
 Maintainer guide for tracking **GitHub Actions security posture** in this public OSS monorepo. Vulnerability **reporting** stays in [SECURITY.md](SECURITY.md); dependency and release triage stays in [Security-incident triage](#security-incident-triage). This shard is the audit trail for CI workflow and repository settings against the [OWASP GitHub Actions Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/GitHub_Actions_Security_Cheat_Sheet.html).
 
-Work is tracked under epic [#173 — Repository security posture](https://github.com/betsalel-williamson/mdcp/issues/173). The durable checklist lives in [#168 — OWASP GitHub Actions security checklist docs](https://github.com/betsalel-williamson/mdcp/issues/168); see [GitHub Actions security checklist](#github-actions-security-checklist) for row-by-row status. CodeQL findings on library regexes (heading / `` [ReDoS](docs/glossary/redos.md)) are tracked separately in [Safe markdown parsing](#safe-markdown-parsing-heading-and-anchor-helpers).
+Work is tracked under epic [#173 — Repository security posture](https://github.com/betsalel-williamson/mdcp/issues/173). The durable checklist lives in [#168 — OWASP GitHub Actions security checklist docs](https://github.com/betsalel-williamson/mdcp/issues/168); see [GitHub Actions security checklist](#github-actions-security-checklist) for row-by-row status. CodeQL findings on library regexes (heading / `` [ReDoS](#redos)) are tracked separately in [Safe markdown parsing](#safe-markdown-parsing-heading-and-anchor-helpers).
 
 ### Status vocabulary
 

--- a/docs/client-core/compile-hooks/cross-guide-links.md
+++ b/docs/client-core/compile-hooks/cross-guide-links.md
@@ -8,12 +8,12 @@ Multi-output consumer repos compile separate monoliths (for example `glossary.md
 
 At compile time, MDCP:
 
-1. Builds a **guide link index** from every guide in `compileOrder` — each manifest-listed shard maps to its compiled `{guideName, outputBasename, slug}` (slug from the demoted first heading, same rules as intra-guide rewrite), plus shards linked transitively from section bodies
+1. Builds a **guide link index** from every guide in `compileOrder` — each path in that guide's `linkedSectionFiles` (manifest plus transitive inline `.md` links) maps to its compiled `{guideName, outputBasename, slug}` (slug from the demoted first heading, same rules as intra-guide rewrite)
 2. Rewrites **cross-guide** `.md` links per shard (using the shard path for relative resolution) before sections are stitched
 3. Rewrites **publish-relative** `../` file links per shard when the guide has `compile.outputFile` — see [Publish-relative link rewriting](./publish-relative-links.md)
 4. Rewrites **same-guide** section links per shard (intra-guide pass with `sourceFile`), then again on the assembled body (intra-guide pass scoped to `guideDir`)
 
-Cross-guide handles indexed markdown between guides. Publish-relative rebases remaining file paths for outputs outside the shard tree (no manual path config). Intra-guide handles same-guide section targets. These are **assembly-time passes**, not compile hooks.
+Cross-guide handles indexed markdown between guides and co-compiled transitive targets. Publish-relative rebases remaining file paths for outputs outside the shard tree (no manual path config). Intra-guide handles same-guide section targets. These are **assembly-time passes**, not compile hooks.
 
 ## Cross-guide link matching
 
@@ -58,7 +58,27 @@ Links that must step **up and out** of the shard directory still require **`../`
 
 ### Transitive section discovery
 
-Manifest listing and the guide link index include shards reachable via transitive markdown `.md` links within the guide tree (`linkedSectionFiles`). To mention a path for readers **without** pulling it into the compile graph, use a backtick path (`` `topic/section-b.md` ``) instead of a markdown link — inline code is not scanned for transitive inclusion or link rewrite.
+For each compiling guide, `linkedSectionFiles` is the manifest closure plus every shard reachable by walking **inline** markdown `.md` links from those files within `guideDir` and `compile.scopeRoot` (when set). The **guide link index** indexes **every** path in that set — including shards outside `guideDir` (not only paths under `guideDir` or `glossary/`).
+
+**Ownership** when the same absolute path appears for more than one guide (first match wins):
+
+1. Manifest owner — the guide that lists the shard in its manifest
+2. Path under `guideDir` — the guide whose directory contains the shard
+3. Compiling guide — the guide whose transitive walk included the shard
+
+### What the walk follows
+
+| Authoring form                                                | Transitive inclusion                         |
+| ------------------------------------------------------------- | -------------------------------------------- |
+| Inline link `[label](path.md)` or `[label](path.md#fragment)` | **Yes** — followed into `linkedSectionFiles` |
+| Reference-style `[label][ref]` with `[ref]: path.md`          | **No** — not followed for inclusion          |
+| Backtick path `` `path.md` ``                                 | **No** — inline code is not scanned          |
+
+Authors who need a readable path **without** pulling the target into the compile graph can use a reference-style link or a backtick path. Reference-style and backticks skip transitive inclusion; backticks also skip link rewrite.
+
+### Default `_build` outputs and transitive targets
+
+With the default `outputDir` (`_build`), `./` and `../` links to transitively included shards outside `guideDir` rewrite through the guide link index and [same-output preference](#same-compiled-output-preference). Compiled `_build` output does **not** leave those co-compiled targets as raw `../file.md`.
 
 ## Cross-guide resolution
 
@@ -69,11 +89,21 @@ Path lookup order (relative to the **current shard** directory):
 3. `compile.scopeRoot` when set on the compiling guide
 4. `process.cwd()` and its parent
 
-When the resolved absolute path is in the guide link index:
+### Same compiled output preference
+
+When a `./` or `../` link resolves to a path present in the **assembling guide's** `slugByPath` map (the shard is co-compiled or transitively included in **this** output), cross-guide rewrite emits `#slug` or `#fragment` for that same document when:
+
+- the index has no entry, or
+- the index owner is the assembling guide, or
+- the index owner is another guide but ownership is **non-canonical** (transitive `scopeRoot` inclusion only — not a manifest listing and not under that owner's `guideDir`)
+
+Canonical ownership (manifest or path under `guideDir`) still wins for cross-output targets. Example: a glossary hub that transitively reaches a finding under `review/` keeps `architecture-review.md#find-004` even if the finding body was also pulled into the glossary compile graph. Multi-guide repos that only co-include a shared shard outside every `guideDir` keep in-document `#anchor` targets in each assembling output.
+
+When the resolved absolute path is in the guide link index (and same-output preference does not already apply):
 
 | Case                                             | Rewritten target                                                        |
 | ------------------------------------------------ | ----------------------------------------------------------------------- |
-| Same compiled output as the compiling guide      | `#slug` or `#fragment` when the link includes a fragment                |
+| Same compiled output as the assembling guide     | `#slug` or `#fragment` when the link includes a fragment                |
 | Different compiled output (`compile.outputFile`) | `{outputBasename}#slug` (for example `architecture-review.md#find-004`) |
 | Monolith output (no per-guide `outputFile`)      | `#slug`                                                                 |
 | Target guide in `ignoreGuides`                   | **unchanged** — keep source `.md` path (link to shard, not monolith)    |

--- a/docs/features/link-validation.md
+++ b/docs/features/link-validation.md
@@ -53,6 +53,8 @@ Publish-relative rewrite and publish-only lint are complementary: rewrite fixes 
 | Shard    | `lintLinks` / author time | Unresolved `.md` paths; same-shard `#fragment` vs demoted heading slugs            |
 | Compiled | After assemble            | `#fragment` vs `buildSlugRegistry`; relative file paths from output file directory |
 
+Compiled-phase checks run **after** cross-guide, publish-relative, and intra-guide rewrite. Co-compiled transitive targets (shards in `linkedSectionFiles` outside `guideDir`) are expected to rewrite to in-document `#slug` / `#fragment` via the guide link index and same-output preference — see [Cross-guide link rewriting](../client-core/compile-hooks/cross-guide-links.md#transitive-section-discovery). Validation treats remaining raw `../file.md` (or `./file.md`) to those co-compiled paths as broken when publish-only policy requires a compiled target.
+
 ## Check pipeline
 
 ```text
@@ -146,7 +148,8 @@ link: docs/client-cli/consumer-migration.md:42: dead anchor "#missing-slug" (slu
 - Shard dead same-doc `#fragment`
 - Compiled dead anchor after demotion
 - Compiled dead path after publish-relative link rewrite
-- Manifest-first guide link index — transitive guide does not overwrite manifest owner
+- Manifest-first guide link index — transitive guide does not overwrite manifest owner; index includes every `linkedSectionFiles` path for the compiling guide
+- Co-compiled transitive targets rewrite before compiled validation (same-output `#slug` / `#fragment`)
 - Cross-guide publish link rewrites to `guides.md#slug`, not same-doc `#slug`
 - `mdcp check` / `mdcp compile` exit **1** on broken links by default
 - `--warn-broken-links` exits **0** with `link-warn:` diagnostics

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -673,12 +673,12 @@ Multi-output consumer repos compile separate monoliths (for example `glossary.md
 
 At compile time, MDCP:
 
-1. Builds a **guide link index** from every guide in `compileOrder` — each manifest-listed shard maps to its compiled `{guideName, outputBasename, slug}` (slug from the demoted first heading, same rules as intra-guide rewrite), plus shards linked transitively from section bodies
+1. Builds a **guide link index** from every guide in `compileOrder` — each path in that guide's `linkedSectionFiles` (manifest plus transitive inline `.md` links) maps to its compiled `{guideName, outputBasename, slug}` (slug from the demoted first heading, same rules as intra-guide rewrite)
 2. Rewrites **cross-guide** `.md` links per shard (using the shard path for relative resolution) before sections are stitched
 3. Rewrites **publish-relative** `../` file links per shard when the guide has `compile.outputFile` — see [Publish-relative link rewriting](#publish-relative-link-rewriting)
 4. Rewrites **same-guide** section links per shard (intra-guide pass with `sourceFile`), then again on the assembled body (intra-guide pass scoped to `guideDir`)
 
-Cross-guide handles indexed markdown between guides. Publish-relative rebases remaining file paths for outputs outside the shard tree (no manual path config). Intra-guide handles same-guide section targets. These are **assembly-time passes**, not compile hooks.
+Cross-guide handles indexed markdown between guides and co-compiled transitive targets. Publish-relative rebases remaining file paths for outputs outside the shard tree (no manual path config). Intra-guide handles same-guide section targets. These are **assembly-time passes**, not compile hooks.
 
 ### Cross-guide link matching
 
@@ -723,7 +723,27 @@ Links that must step **up and out** of the shard directory still require **`../`
 
 #### Transitive section discovery
 
-Manifest listing and the guide link index include shards reachable via transitive markdown `.md` links within the guide tree (`linkedSectionFiles`). To mention a path for readers **without** pulling it into the compile graph, use a backtick path (`` `topic/section-b.md` ``) instead of a markdown link — inline code is not scanned for transitive inclusion or link rewrite.
+For each compiling guide, `linkedSectionFiles` is the manifest closure plus every shard reachable by walking **inline** markdown `.md` links from those files within `guideDir` and `compile.scopeRoot` (when set). The **guide link index** indexes **every** path in that set — including shards outside `guideDir` (not only paths under `guideDir` or `glossary/`).
+
+**Ownership** when the same absolute path appears for more than one guide (first match wins):
+
+1. Manifest owner — the guide that lists the shard in its manifest
+2. Path under `guideDir` — the guide whose directory contains the shard
+3. Compiling guide — the guide whose transitive walk included the shard
+
+#### What the walk follows
+
+| Authoring form                                                | Transitive inclusion                         |
+| ------------------------------------------------------------- | -------------------------------------------- |
+| Inline link `[label](path.md)` or `[label](path.md#fragment)` | **Yes** — followed into `linkedSectionFiles` |
+| Reference-style `[label][ref]` with `[ref]: path.md`          | **No** — not followed for inclusion          |
+| Backtick path `` `path.md` ``                                 | **No** — inline code is not scanned          |
+
+Authors who need a readable path **without** pulling the target into the compile graph can use a reference-style link or a backtick path. Reference-style and backticks skip transitive inclusion; backticks also skip link rewrite.
+
+#### Default `_build` outputs and transitive targets
+
+With the default `outputDir` (`_build`), `./` and `../` links to transitively included shards outside `guideDir` rewrite through the guide link index and [same-output preference](#same-compiled-output-preference). Compiled `_build` output does **not** leave those co-compiled targets as raw `../file.md`.
 
 ### Cross-guide resolution
 
@@ -734,11 +754,21 @@ Path lookup order (relative to the **current shard** directory):
 3. `compile.scopeRoot` when set on the compiling guide
 4. `process.cwd()` and its parent
 
-When the resolved absolute path is in the guide link index:
+#### Same compiled output preference
+
+When a `./` or `../` link resolves to a path present in the **assembling guide's** `slugByPath` map (the shard is co-compiled or transitively included in **this** output), cross-guide rewrite emits `#slug` or `#fragment` for that same document when:
+
+- the index has no entry, or
+- the index owner is the assembling guide, or
+- the index owner is another guide but ownership is **non-canonical** (transitive `scopeRoot` inclusion only — not a manifest listing and not under that owner's `guideDir`)
+
+Canonical ownership (manifest or path under `guideDir`) still wins for cross-output targets. Example: a glossary hub that transitively reaches a finding under `review/` keeps `architecture-review.md#find-004` even if the finding body was also pulled into the glossary compile graph. Multi-guide repos that only co-include a shared shard outside every `guideDir` keep in-document `#anchor` targets in each assembling output.
+
+When the resolved absolute path is in the guide link index (and same-output preference does not already apply):
 
 | Case                                             | Rewritten target                                                        |
 | ------------------------------------------------ | ----------------------------------------------------------------------- |
-| Same compiled output as the compiling guide      | `#slug` or `#fragment` when the link includes a fragment                |
+| Same compiled output as the assembling guide     | `#slug` or `#fragment` when the link includes a fragment                |
 | Different compiled output (`compile.outputFile`) | `{outputBasename}#slug` (for example `architecture-review.md#find-004`) |
 | Monolith output (no per-guide `outputFile`)      | `#slug`                                                                 |
 | Target guide in `ignoreGuides`                   | **unchanged** — keep source `.md` path (link to shard, not monolith)    |

--- a/packages/mdcp-core/src/compile/assemble.ts
+++ b/packages/mdcp-core/src/compile/assemble.ts
@@ -155,6 +155,7 @@ export function assembleGuide(guideDir: string, options: AssembleGuideOptions = 
         currentOutputBasename: options.outputBasename,
         currentOutputFile: options.outputFile,
         linkIndex: options.linkIndex,
+        slugByPath,
         ignoreGuides: options.ignoreGuides,
       });
     }

--- a/packages/mdcp-core/src/compile/guide-link-index.ts
+++ b/packages/mdcp-core/src/compile/guide-link-index.ts
@@ -15,6 +15,13 @@ export interface GuideLinkEntry {
   /** Absolute path to the guide's compiled output file. */
   outputFile: string;
   slug: string;
+  /**
+   * True when ownership comes from a manifest listing or a path under the owner's
+   * guideDir. False for shards only pulled in via transitive `scopeRoot` links —
+   * those may be co-compiled into multiple outputs and should prefer same-output
+   * `#anchor` rewrite when present in the assembling guide's slug map.
+   */
+  canonical: boolean;
 }
 
 /** Absolute shard path → compiled output target. */
@@ -25,18 +32,6 @@ export interface BuildGuideLinkIndexResult {
   shardCache: ShardCache;
   /** Memoized linkedSectionFiles per guide options key. */
   linkedFilesByGuide: Map<string, string[]>;
-}
-
-function isIndexableShardPath(
-  filePath: string,
-  guideDirs: Map<string, string>,
-  compileOrder: string[],
-  guidesRoot: string,
-): boolean {
-  const abs = resolve(filePath);
-  const glossaryDir = resolve(guidesRoot, 'glossary');
-  if (abs === glossaryDir || abs.startsWith(`${glossaryDir}/`)) return true;
-  return guideForShardPath(abs, guideDirs, compileOrder) !== undefined;
 }
 
 function resolveGuideDir(
@@ -174,29 +169,29 @@ export function buildGuideLinkIndex(
     );
 
     for (const filePath of files) {
-      if (!isIndexableShardPath(filePath, guideDirs, options.compileOrder, options.guidesRoot)) {
-        continue;
-      }
-      const slug = slugByPath.get(resolve(filePath));
+      // Index every path from linkedSectionFiles (manifest + transitive inline .md
+      // links under guideDir / scopeRoot), including shards outside guideDir.
+      const absPath = resolve(filePath);
+      const slug = slugByPath.get(absPath);
       if (!slug) continue;
 
       const owner = resolveShardOwner(
-        filePath,
+        absPath,
         name,
         manifestOwners,
         guideDirs,
         options.compileOrder,
       );
-      const existing = index.get(filePath);
+      const existing = index.get(absPath);
       if (
         existing &&
         ownerPriority(
-          filePath,
+          absPath,
           existing.guideName,
           manifestOwners,
           guideDirs,
           options.compileOrder,
-        ) >= ownerPriority(filePath, owner, manifestOwners, guideDirs, options.compileOrder)
+        ) >= ownerPriority(absPath, owner, manifestOwners, guideDirs, options.compileOrder)
       ) {
         continue;
       }
@@ -210,11 +205,13 @@ export function buildGuideLinkIndex(
         options.compileOrder.length,
         cwd,
       );
-      index.set(filePath, {
+      index.set(absPath, {
         guideName: owner,
         outputBasename: basename(outputFile),
         outputFile,
         slug,
+        canonical:
+          ownerPriority(absPath, owner, manifestOwners, guideDirs, options.compileOrder) >= 2,
       });
     }
   }

--- a/packages/mdcp-core/src/compile/publish-links.ts
+++ b/packages/mdcp-core/src/compile/publish-links.ts
@@ -194,6 +194,12 @@ export interface CrossGuideLinkRewriteOptions {
   /** Absolute path to the guide output being assembled. */
   currentOutputFile?: string;
   linkIndex: GuideLinkIndex;
+  /**
+   * Slugs for shards co-compiled into the current output. When a link resolves to a
+   * path in this map, rewrite to an in-document `#anchor` even if the shared index
+   * attributes the shard to another guide (multi-guide transitive co-inclusion).
+   */
+  slugByPath?: Map<string, string>;
   /** Guide names whose shards keep source `.md` paths instead of monolith `#slug` targets. */
   ignoreGuides?: string[];
   searchRoots?: string[];
@@ -216,6 +222,26 @@ function resolveIndexedMarkdownLink(
   if (!resolved) return null;
 
   const entry = options.linkIndex.get(resolved);
+  const sameOutputSlug = options.slugByPath?.get(resolved);
+  // Prefer in-document anchors for co-compiled shards unless another guide has
+  // canonical (manifest / guideDir) ownership — those keep cross-output targets.
+  const preferSameOutput =
+    sameOutputSlug !== undefined &&
+    (!entry || entry.guideName === options.currentGuideName || entry.canonical === false);
+  if (preferSameOutput) {
+    const anchor = fragment ? fragment.slice(1) : sameOutputSlug;
+    return {
+      entry: {
+        guideName: options.currentGuideName ?? '',
+        outputBasename: options.currentOutputBasename ?? '',
+        outputFile: options.currentOutputFile ?? '',
+        slug: sameOutputSlug,
+        canonical: false,
+      },
+      anchor,
+    };
+  }
+
   if (!entry) return null;
 
   const anchor = fragment ? fragment.slice(1) : entry.slug;

--- a/packages/mdcp-core/test/cross-guide-links.test.ts
+++ b/packages/mdcp-core/test/cross-guide-links.test.ts
@@ -160,6 +160,7 @@ describe('cross-guide link rewriting', () => {
         outputBasename: 'architecture-review.md',
         outputFile: join(work, 'architecture-review.md'),
         slug: 'find-004',
+        canonical: true,
       });
 
       const terms = join(work, 'glossary', 'terms.md');
@@ -168,6 +169,7 @@ describe('cross-guide link rewriting', () => {
         outputBasename: 'glossary.md',
         outputFile: join(work, 'glossary.md'),
         slug: 'terms',
+        canonical: true,
       });
     });
   });
@@ -255,12 +257,14 @@ describe('cross-guide link rewriting', () => {
           outputBasename: 'architecture-review.md',
           outputFile: join(work, 'architecture-review.md'),
           slug: 'find-004',
+          canonical: true,
         });
         expect(index.get(join(work, 'technical', 'deployment.md'))).toEqual({
           guideName: 'technical-guide',
           outputBasename: 'technical-guide.md',
           outputFile: join(work, 'technical-guide.md'),
           slug: 'deployment',
+          canonical: true,
         });
       });
     });
@@ -527,6 +531,115 @@ describe('cross-guide link rewriting', () => {
 
       expect(index.has(join(work, 'features', 'overview.md'))).toBe(true);
       expect(index.has(join(work, 'examples', 'other', 'README.md'))).toBe(false);
+    });
+  });
+
+  it('buildGuideLinkIndex includes transitive scopeRoot files outside guideDir', () => {
+    withTmpDir('mdcp-index-transitive-scope-', (work) => {
+      mkdirSync(join(work, 'guide', 'compiled'), { recursive: true });
+      mkdirSync(join(work, 'topics', 'security'), { recursive: true });
+
+      writeFileSync(join(work, 'guide', 'compiled', 'shards.md'), '- [Shard A](../shard-a.md)\n');
+      writeFileSync(
+        join(work, 'guide', 'shard-a.md'),
+        '# Shard A\n\n- [Onboarding](../onboarding.md#setup-prerequisites)\n',
+      );
+      writeFileSync(
+        join(work, 'onboarding.md'),
+        '# Onboarding\n\n## Setup prerequisites\n\n- [Security overview](./topics/security/index.md).\n',
+      );
+      writeFileSync(join(work, 'topics', 'security', 'index.md'), '# Security overview\n');
+
+      const opts: CompileOptionsInput = {
+        guidesRoot: work,
+        compileOrder: ['example-guide'],
+        docsRoot: work,
+        config: { outputDir: '_build', compileOrder: ['example-guide'] },
+        guides: [
+          {
+            name: 'example-guide',
+            path: 'guide/compiled',
+            compile: {
+              manifest: 'shards.md',
+              scopeRoot: '.',
+              outputFile: 'example-guide.md',
+            },
+          },
+        ],
+      };
+      const index = buildGuideLinkIndex(opts, work).index;
+
+      const onboarding = join(work, 'onboarding.md');
+      const security = join(work, 'topics', 'security', 'index.md');
+      expect(index.get(onboarding)).toEqual({
+        guideName: 'example-guide',
+        outputBasename: 'example-guide.md',
+        outputFile: join(work, '_build', 'example-guide.md'),
+        slug: 'onboarding',
+        canonical: false,
+      });
+      expect(index.get(security)).toEqual({
+        guideName: 'example-guide',
+        outputBasename: 'example-guide.md',
+        outputFile: join(work, '_build', 'example-guide.md'),
+        slug: 'security-overview',
+        canonical: false,
+      });
+    });
+  });
+
+  it('co-included shared shards rewrite to same-output anchors in each guide', () => {
+    withTmpDir('mdcp-co-include-shared-', (work) => {
+      for (const name of ['guide-a', 'guide-b'] as const) {
+        mkdirSync(join(work, name), { recursive: true });
+        writeFileSync(
+          join(work, name, 'index.md'),
+          `# ${name}\n\n## Sections\n\n- [Body](./body.md)\n`,
+        );
+        writeFileSync(join(work, name, 'body.md'), '## Body\n\nSee [Shared](../shared/note.md).\n');
+      }
+      mkdirSync(join(work, 'shared'), { recursive: true });
+      writeFileSync(join(work, 'shared', 'note.md'), '# Shared note\n\nBody.\n');
+
+      const opts: CompileOptionsInput = {
+        guidesRoot: work,
+        compileOrder: ['guide-a', 'guide-b'],
+        docsRoot: work,
+        config: { outputDir: '_build', compileOrder: ['guide-a', 'guide-b'] },
+        guides: [
+          {
+            name: 'guide-a',
+            path: 'guide-a',
+            compile: {
+              scopeRoot: '.',
+              outputFile: 'guide-a.md',
+              sectionsHeading: 'Sections',
+            },
+          },
+          {
+            name: 'guide-b',
+            path: 'guide-b',
+            compile: {
+              scopeRoot: '.',
+              outputFile: 'guide-b.md',
+              sectionsHeading: 'Sections',
+            },
+          },
+        ],
+      };
+
+      const shared = join(work, 'shared', 'note.md');
+      const index = buildGuideLinkIndex(opts, work).index;
+      expect(index.has(shared)).toBe(true);
+      expect(index.get(shared)?.slug).toBe('shared-note');
+      expect(['guide-a', 'guide-b']).toContain(index.get(shared)?.guideName);
+
+      const results = compileGuideResults(opts);
+      for (const result of results) {
+        expect(result.text).toContain('[Shared](#shared-note)');
+        expect(result.text).not.toMatch(/guide-[ab]\.md#shared-note/);
+        expect(result.text).not.toMatch(/\]\(\.\.\/shared\/note\.md\)/);
+      }
     });
   });
 });

--- a/packages/mdcp-core/test/publish-links.test.ts
+++ b/packages/mdcp-core/test/publish-links.test.ts
@@ -290,4 +290,49 @@ describe('publish link rewriting', () => {
       expect(guideText).not.toContain('assets/diagram.md)');
     });
   });
+
+  it('e2e #69: transitive out-of-guideDir shards rewrite under outputDir _build', () => {
+    withTmpDir('mdcp-issue-69-transitive-', (work) => {
+      mkdirSync(join(work, 'guide', 'compiled'), { recursive: true });
+      mkdirSync(join(work, 'topics', 'security'), { recursive: true });
+
+      writeFileSync(join(work, 'guide', 'compiled', 'shards.md'), '- [Shard A](../shard-a.md)\n');
+      writeFileSync(
+        join(work, 'guide', 'shard-a.md'),
+        '# Shard A\n\n- [Onboarding](../onboarding.md#setup-prerequisites)\n',
+      );
+      writeFileSync(
+        join(work, 'onboarding.md'),
+        '# Onboarding\n\n## Setup prerequisites\n\n- **Security docs**: [Security overview](./topics/security/index.md).\n',
+      );
+      writeFileSync(join(work, 'topics', 'security', 'index.md'), '# Security overview\n');
+
+      const results = compileGuideResults({
+        guidesRoot: work,
+        compileOrder: ['example-guide'],
+        docsRoot: work,
+        config: {
+          outputDir: '_build',
+          compileOrder: ['example-guide'],
+        },
+        guides: [
+          {
+            name: 'example-guide',
+            path: 'guide/compiled',
+            compile: {
+              manifest: 'shards.md',
+              scopeRoot: '.',
+              outputFile: 'example-guide.md',
+            },
+          },
+        ],
+      });
+
+      const text = results.find((r) => r.name === 'example-guide')!.text;
+      expect(text).toContain('[Onboarding](#setup-prerequisites)');
+      expect(text).toContain('[Security overview](#security-overview)');
+      expect(text).not.toMatch(/onboarding\.md\)/);
+      expect(text).not.toMatch(/topics\/security\/index\.md\)/);
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#69](https://github.com/betsalel-williamson/mdcp/issues/69): after #70, `./` shard-relative links in transitively included files rewrite correctly, but `../` links to those same out-of-`guideDir` shards still stayed raw under the default `outputDir: "_build"` because they were assembled but **not indexed**, and cross-guide rewrite could not resolve them.

## Changes

- Index **every** path from `linkedSectionFiles` (manifest + transitive inline `.md` under `guideDir` / `scopeRoot`), including shards outside `guideDir`.
- Add `canonical` ownership on guide link index entries (manifest or path-under-`guideDir` vs transitive-only).
- Cross-guide rewrite prefers same-output `#anchor` when the target is in the assembling guide’s `slugByPath` and ownership is missing, same-guide, or **non-canonical** — so multi-guide co-included shared files get in-document anchors, while canonical cross-guide targets (e.g. glossary → `architecture-review.md#find-004`) stay cross-output.
- Document transitive discovery, reference-style exclusion, and same-output preference in authoring shards.
- Regression tests for the #69 `_build` fixture, transitive index entries, and multi-guide co-inclusion.

## Out of scope

- `compile.followLinks` policy switch (issue suggestion A)
- Wiring `lintShardLinks` into default `mdcp check` (suggestion E)
- Fragment casing normalization (issue §5)

## Test plan

- [x] `pnpm --filter @bwilliamson/mdcp-core test -- test/cross-guide-links.test.ts test/publish-links.test.ts`
- [x] `mdcp check` (docs compile + lint + Vale)
- [x] Full `pnpm run check`

Closes #69

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94a866fa-e910-4b9e-95f9-d822efebbf20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94a866fa-e910-4b9e-95f9-d822efebbf20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

