### PR TITLE
chore(mdcp-cli): drop unused commander dependency

### DIFF
--- a/.changeset/remove-unused-commander.md
+++ b/.changeset/remove-unused-commander.md
@@ -1,0 +1,5 @@
+---
+'@bwilliamson/mdcp-cli': patch
+---
+
+Drop unused `commander` dependency — the CLI already runs on CAC only.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -478,7 +478,7 @@ Tests live under `packages/mdcp-core/test/`. Integration tests invoke the built 
 
 ### mdcp-cli
 
-Thin Commander wrapper around `mdcp-core`. Source: [`packages/mdcp-cli/src/cli.ts`](packages/mdcp-cli/src/cli.ts).
+Thin [CAC](https://github.com/cacjs/cac) wrapper around `mdcp-core`. Source: [`packages/mdcp-cli/src/cli.ts`](packages/mdcp-cli/src/cli.ts).
 
 ```bash
 pnpm --filter @bwilliamson/mdcp-cli run build

--- a/docs/developer/packages-and-tests.md
+++ b/docs/developer/packages-and-tests.md
@@ -26,7 +26,7 @@ Tests live under `packages/mdcp-core/test/`. Integration tests invoke the built 
 
 ## mdcp-cli
 
-Thin Commander wrapper around `mdcp-core`. Source: [`packages/mdcp-cli/src/cli.ts`](../../packages/mdcp-cli/src/cli.ts).
+Thin [CAC](https://github.com/cacjs/cac) wrapper around `mdcp-core`. Source: [`packages/mdcp-cli/src/cli.ts`](../../packages/mdcp-cli/src/cli.ts).
 
 ```bash
 pnpm --filter @bwilliamson/mdcp-cli run build

--- a/packages/mdcp-cli/package.json
+++ b/packages/mdcp-cli/package.json
@@ -43,8 +43,7 @@
   },
   "dependencies": {
     "@bwilliamson/mdcp-core": "workspace:*",
-    "cac": "^7.0.0",
-    "commander": "^15.0.0"
+    "cac": "^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,9 +64,6 @@ importers:
       cac:
         specifier: ^7.0.0
         version: 7.0.0
-      commander:
-        specifier: ^15.0.0
-        version: 15.0.0
     devDependencies:
       '@types/node':
         specifier: ^26.1.1
@@ -2334,10 +2331,6 @@ packages:
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
-
-  commander@15.0.0:
-    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
-    engines: {node: '>=22.12.0'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -7536,8 +7529,6 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@12.1.0: {}
-
-  commander@15.0.0: {}
 
   commander@4.1.1: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove the leftover direct `commander` dependency from `@bwilliamson/mdcp-cli` now that the CLI is fully on CAC. Update the developer packages/tests shard (and compiled `DEVELOPERS.md`) so it no longer describes the CLI as a Commander wrapper.

## Protocol / skill versions

- **protocolVersion** (four-part): N/A
- **Parent skill** (`skills/mdcp` `metadata.version`): N/A
- **mdcp-cli**: patch (changeset) — dependency cleanup only

## Checklist

- [x] Scope matches the linked issue / work item (one concern)
- [x] Docs shards updated when behavior or contributor workflow changed (`pnpm docs:check`)
- [x] Tests / validation green for the surfaces touched
- [x] Changeset added when a published package’s user-facing behavior changes

## Test plan

- [x] `pnpm install` (lockfile drops direct `commander@15`)
- [x] `pnpm --filter @bwilliamson/mdcp-cli test`
- [x] `pnpm docs:check` with Vale
- [x] `pnpm run check` (full gate)

## Related

No tracker issue yet (cloud agent cannot open issues). Ready-to-paste intake below — please create the issue and add `Closes #N` to this PR.

### Ready-to-paste GitHub issue

**Title:** Drop unused `commander` dependency from mdcp-cli

**Body:**

```markdown
## Summary

After the CAC migration, `@bwilliamson/mdcp-cli` still listed `commander` as a direct dependency even though the CLI no longer imports it. Remove the leftover dependency and align contributor docs.

## Acceptance criteria

- [ ] `commander` is not a direct dependency of `packages/mdcp-cli/package.json`
- [ ] Lockfile no longer pins `commander@15` for mdcp-cli
- [ ] Developer docs describe the CLI as a CAC wrapper (not Commander)
- [ ] Patch changeset for `@bwilliamson/mdcp-cli`
- [ ] `pnpm run check` passes

## Labels / project

- Type: `enhancement` (or `dependencies` if preferred)
- Component: `cli`
- Priority: `priority:P3`
- Track: Maintenance
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c207994-a081-45be-8dec-5eb6b7e1fb3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c207994-a081-45be-8dec-5eb6b7e1fb3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

