### PR TITLE
docs(adr): decline hard-gated branch-before-edit skill rule

### DIFF
--- a/docs/features/adr/0004-decline-branch-before-edit-hard-gate.md
+++ b/docs/features/adr/0004-decline-branch-before-edit-hard-gate.md
@@ -1,0 +1,37 @@
+# ADR 0004: Decline a hard-gated branch-before-edit skill rule
+
+- **Status:** Accepted
+- **Date:** 2026-07-31
+- **Related:** GitHub issue #150; closed draft PRs #224 (skill hard gate) and #225 (eval campaign)
+
+## Context
+
+Issue #150 reported that agents sometimes edit tracked files on `main` instead of creating a short-lived feature branch first. Delivery conventions already said “branch before work” in [Agent work-item tracking](../../developer/agent-work-item-tracking.md) and helper Step 2 prose, but that guidance was soft.
+
+We explored hardening the same pattern used for [Atomic commit groups](../../glossary/atomic-commit-groups.md): MUST/NEVER skill language, plan fields before “go”, live-eval assertions, and (after pressure tests) extra rules for approved stay-on-main plans and explicit user overrides.
+
+### What we tried
+
+1. **Hard gate in parent QA and day-to-day helpers** — name the feature branch in the plan; NEVER edit on `main`/`master` (PR #224).
+2. **Eval campaign** (PR #225) — `without_skill` vs soft `old_skill` vs hard `new_skill` under stay-on-main pressure.
+3. **Follow-on complexity** — when soft vs hard did not diverge on fresh tasks, we added rules for “approved plan + go”, then an “explicit informed override” so humans could still insist on `main`.
+
+### What the evals showed
+
+- **Clear win vs no skill:** without MDCP guidance, agents stayed on `main` under leadership pressure.
+- **Little measured lift vs soft Step 2:** when the existing helper skill was loaded, soft “create a feature branch before editing” already produced branching in most fresh-task runs.
+- **Escalating process to chase edge cases:** the multi-turn “approved stay-on-main plan → go” hole needed more MUST language; that then needed a user-override escape hatch so the skill would not fight an informed human. The resulting rule set was hard to explain and easy to misread as paternalism or busywork.
+
+## Decision
+
+We will **not** ship a hard-gated branch-before-edit skill regime (MUST/NEVER plan fields, approved-plan refusal, explicit-override exceptions, and companion eval campaigns as a product obligation).
+
+Keep the **existing soft delivery guidance**: branch from updated `main` before work, one `WORK_ITEM` per branch, short-lived feature branches and PR review — as documented for contributors and helpers today. Do not grow parent QA and helper Process with a second Atomic-commit-groups-sized hard gate for branching.
+
+## Consequences
+
+- Soft “branch before work” remains the as-built expectation in developer tracking and day-to-day helpers; agents should still prefer short-lived branches.
+- Parent skill QA does **not** gain a Branch-before-edit MUST/NEVER bullet or override exception matrix from #224.
+- Live skill eval suites do **not** gain committed campaign trees or plan-only branch assertions from #225 as required product surface.
+- Issue #150 is treated as **not planned** for that hard-gate approach — soft guidance plus normal PR review remain the control.
+- If a future, smaller change proves a clear adopter benefit (for example a single plan-field checklist item with discriminating evals and no override maze), it needs a new ADR or issue — this ADR rejects the complex package we evaluated, not every possible reminder.

--- a/docs/features/adr/index.md
+++ b/docs/features/adr/index.md
@@ -9,3 +9,4 @@ Delivery backlog and roadmap tracks stay in GitHub issues / the project board �
 - [ADR 0001 — Remove `mdcp export` profiles](./0001-remove-export-profiles.md)
 - [ADR 0002 — Remove `mdcp refs lookup`](./0002-remove-refs-lookup.md)
 - [ADR 0003 — Do not adopt OKF](./0003-do-not-adopt-okf.md)
+- [ADR 0004 — Decline a hard-gated branch-before-edit skill rule](./0004-decline-branch-before-edit-hard-gate.md)

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -22,6 +22,7 @@ Product documentation for **what mdcp is designed to do** — the problems it so
   - [ADR 0001 — Remove `mdcp export` profiles](./adr/0001-remove-export-profiles.md)
   - [ADR 0002 — Remove `mdcp refs lookup`](./adr/0002-remove-refs-lookup.md)
   - [ADR 0003 — Do not adopt OKF](./adr/0003-do-not-adopt-okf.md)
+  - [ADR 0004 — Decline a hard-gated branch-before-edit skill rule](./adr/0004-decline-branch-before-edit-hard-gate.md)
 - [Design constraints](./design-constraints/index.md)
   - [Protocol](./protocol/00-vision-and-roadmap.md)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **ADR 0004** recording that we explored a hard-gated branch-before-edit skill rule for issue #150, then declined it: the approach grew too complex (MUST/NEVER, approved-plan refusal, user-override escape hatches, eval campaigns) without a clear value add over existing soft “branch before work” guidance.

Closes the process experiment tracked by draft PRs [#224](https://github.com/betsalel-williamson/mdcp/pull/224) and [#225](https://github.com/betsalel-williamson/mdcp/pull/225) (both closed). Soft delivery conventions in agent work-item tracking and helper Step 2 remain as-built.

## Protocol / skill versions

N/A — ADR / durable docs only; no skill or CLI contract change.

## Checklist

- [x] Scope matches the work item (one concern: record the reject decision)
- [x] Docs shards updated (`pnpm docs:check`)
- [x] Tests / validation green for surfaces touched
- [x] Changeset N/A (no published package behavior change)

## Test plan

- `pnpm docs:check`

## Related

Closes #150 (not planned for the hard-gate approach — see ADR 0004)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-490b595d-2818-4ed8-a5f4-e9b8dc50df61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-490b595d-2818-4ed8-a5f4-e9b8dc50df61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

