### PR TITLE
docs: Feedback-ready drafts for ontology density and token-cost issues

### DIFF
--- a/.github/ISSUE_DRAFTS/01-ontology-reuse-and-idea-density.md
+++ b/.github/ISSUE_DRAFTS/01-ontology-reuse-and-idea-density.md
@@ -1,0 +1,104 @@
+# Issue draft 1 — Ontology / idea density / OOP reuse
+
+Copy into **Feedback or question** (`.github/ISSUE_TEMPLATE/02-feedback.yml`).
+
+## Title
+
+```text
+[Feedback] Ontology condensation & idea density: define once without prose inheritance?
+```
+
+## Value-add priority (dropdown)
+
+`P1 — high near-term value`
+
+## Suggested labels (after create)
+
+`feedback`, `protocol`, `documentation`, `priority:P1`
+
+## Summary
+
+```markdown
+## Question
+
+From a CS / knowledge-modeling lens: how does MDCP _condense_ an ontology of product intent as a project grows? Stakeholders worry that without OOP-style inheritance (“Animal → Dog → Poodle” in docs), **idea density falls over time** and **near-duplicate variants rise** (documentation as a denormalized store).
+
+Concrete worry: a system modeling animals cannot describe qualities once and have other documents inherit those qualities succinctly — so as N → ∞, the corpus grows fluff and drift.
+
+## Position to validate (maintainer intuition)
+
+### Category error (docs ≠ domain model)
+
+Code inheritance answers: _what is this thing, and what properties reuse?_  
+Documentation jobs answer: _who needs what, for which action, at what fidelity?_
+
+MDCP captures **context and intent** so humans and agents can reason about how a system should function, audit the **as-built** system against high-level specs, and keep durable information out of chat. That is a separate concern from precise system modeling that **code** (types, schemas, tests) already does well.
+
+Forcing `extends` / prose inheritance into Markdown often produces the opposite pathology: mega-base docs no one can load alone, mixing explain / how-to / reference.
+
+### How MDCP condenses today (not a type system)
+
+- **Shard SRP + idea mitosis** — one settled idea × audience × job; split when a second responsibility appears
+- **Glossary** — one term per shard + disambiguation
+- **Guides** — ordered constellations; compile for humans/CI
+- **Composition** — links, shared insert libraries (`inlineInserts`), pointer shards into source
+- **Archetypes / extensions** — layout packs; SOLID applied to protocol layers, not class inheritance of shard bodies
+- **Explicit non-goal** — no preprocessor, templating, or parameterized partials in core ([preprocessor-templating](docs/features/design-constraints/preprocessor-templating.md))
+
+Closest OOP analogies: SRP on shards, open/closed via extensions. There is **no** concept-inheritance DSL for documentation ideas — by design.
+
+### Sidestep for product software (density without inheritance)
+
+Describe features at a **high level** (plan, constraints, acceptance). Put hard structure in tables, data, schemas, and code. Refactor information so the doc set is not a denormalized dump of implementation. Tight constraints documented in Markdown should **migrate into tests, harnesses, and QA layers** that enforce them. Flexible systems stay light; rigid / high-rigor systems need more shards and stricter intake — not a second type system in prose.
+
+### Real scaling risk (accept under a better name)
+
+Density collapse is a **governance + information architecture** failure, not the absence of `class Dog extends Animal` in Markdown:
+
+- uncontrolled mitosis / copy-paste variants
+- glossary forks instead of disambiguation
+- no intake bar: _necessary, unique, serves the purpose_ (Navy technical-manual rigor as existence proof — hierarchies, section flows, templates, oversight)
+
+Large corpora (hundreds → tens of thousands of pages) are in **scope of the content domain** ([scope and positioning](docs/features/protocol/01-scope-and-positioning.md)); dogfood is still early/small. Scaling needs resources and experimentation (archetypes, intake QA, check at large N) — not a mathematical proof that density must fall.
+
+### Positioning vs mature doc orgs
+
+Successful large systems (e.g. GCP-scale client docs) already practice MDCP-like principles: SRP topics, organized guides, accurate information, technical writers + engineers. They are **existence proofs of the practice**, not proof that MDCP is unnecessary for everyone.
+
+MDCP’s niche: teams and personalities that historically **ignored** documentation because it felt tedious — engineers focused on code and efficiency, less on client-side context and the surrounding product ecosystem (“inmates running the asylum”). The Skill + toolchain encode library discipline for that audience.
+
+## Decisions needed
+
+1. Is “define once → specialize at scale” a **protocol concern**, **extension pack**, **adopter playbook** (preprocess outside MDCP), or explicit **non-goal**?
+2. Confirm normative wording: OOP desire → MDCP primitives (composition, inserts, pointers, tests) vs reject prose inheritance in core.
+3. What belongs in `mdcp check` vs Skill/QA vs human two-level review for uniqueness / anti-duplication?
+4. How do rigid / high-detail systems (equipment manuals, hard specs) use the same protocol without stuffing implementation density into shards?
+
+## Related
+
+- #78 Extension taxonomy (`arch-*` / `format-*`)
+- #76 Modeling-framework compatibility matrix
+- #48 / #44 Protocol formalization
+- #157 Skill: doc-sync (inventory / coverage — related to scale, not inheritance)
+- #52 Compile-output diff (structural drift)
+- Sibling draft: token / cost measurement (file as separate Feedback issue)
+- Design constraint: preprocessor-templating (out of scope)
+
+## Acceptance (proposed)
+
+- [ ] Normative or design shard / ADR documenting today’s reuse surface, the category-error position, and chosen target model or non-goals
+- [ ] Explicit mapping: OOP inheritance desire → MDCP primitives (or “do this outside MDCP / in code & tests”)
+- [ ] Guidance for high-rigor corpora (intake uniqueness, hierarchies) without introducing Handlebars-style macros into core
+- [ ] Clarify relationship to #78, #76, and constraint→test migration for hard rules
+- [ ] Skill / QA updates only if workflow changes; `pnpm docs:check` green
+```
+
+## Additional context
+
+```markdown
+Stakeholder hypothesis: without idea inheritance, as projects grow to infinity, idea density decreases and duplication of variations increases.
+
+Maintainer working position (2026-07 exploration): category error between documentation context and OOP domain modeling; density is a governance problem; high-level feature contracts + tables/data + code/tests sidestep prose inheritance; MDCP targets under-documenting engineering cultures; large-scale rigor needs experimentation beyond current dogfood.
+
+File via Feedback template; Track suggestion: **1.0 Formalization**.
+```

--- a/.github/ISSUE_DRAFTS/02-token-use-measurement-and-cost.md
+++ b/.github/ISSUE_DRAFTS/02-token-use-measurement-and-cost.md
@@ -1,0 +1,98 @@
+# Issue draft 2 — Token use, cost, and verification economics
+
+Copy into **Feedback or question** (`.github/ISSUE_TEMPLATE/02-feedback.yml`).
+
+## Title
+
+```text
+[Feedback] Measure token / context cost: more or less to ship a feature, and at what scale?
+```
+
+## Value-add priority (dropdown)
+
+`P1 — high near-term value`
+
+## Suggested labels (after create)
+
+`feedback`, `documentation`, `protocol`, `priority:P1`
+
+## Summary
+
+```markdown
+## Question
+
+How are we measuring token (or context) use today? Bottom line for adopters: will developing a feature with MDCP use **more** or **less** tokens / inference cost on average than a traditional monolith-docs workflow — and **at what scale** does that tip?
+
+Downstream product pressure: as generation gets cheaper and humans focus more on **cost constraints**, teams will prefer translating ideas into working product with **minimized cost** and flexible timing — often a **cheap system running overnight** over an expensive system that blows the weekly budget and leaves no room for more work.
+
+## What exists today
+
+Token/context efficiency is mostly a **usage-model claim**, not a measurement product:
+
+- Agents are steered to host search → **one shard** ([usage-model](docs/features/protocol/usage-model.md)); MDCP does not enforce that
+- Evidence policy forbids unmeasured “token %” on landing (Tier C) ([benefit-claims-and-evidence](docs/features/protocol/benefit-claims-and-evidence.md))
+- Dogfood metric is **characters**, not tokenizer tokens: `pnpm bench:context-size` → [context-size-dogfood.csv](docs/features/protocol/context-size-dogfood.csv) — median feature shard ≈ **4.4%** of features monolith (2026-06-25)
+- Token-strip `export --llm` was **removed** (ADR 0001); CSV still has stale LLM-export columns
+- #160 (review-bench): token counts alone are the wrong headline; people-time / HIL may matter more; cost as **guardrail**, not pitch
+- Compile benches (#64/#67) measure CLI latency/scale, not LLM tokens or $
+
+## MDCP’s job in the cost picture
+
+MDCP holds durable **context and intent** so humans and AI can reason about the system and audit as-built behavior against high-level specs. Tight constraints in Markdown should migrate to **tests / harnesses / QA in code** — enforceable without burning inference on every check.
+
+Prefer **static analysis over inference** for routine gates (cheap, repeatable, overnight-friendly):
+
+| Layer                    | Mechanism today                                        | Cost profile                     |
+| ------------------------ | ------------------------------------------------------ | -------------------------------- |
+| Structural doc integrity | `mdcp check` (orphans, refs, links, coverage, compile) | Deterministic CI                 |
+| Evidence pointers        | `codeEvidence`, pointer shards                         | Compile-time; not semantic proof |
+| Hard constraints         | Shards → tests / schemas / harnesses                   | Enforced in code                 |
+| Semantic promise drift   | Two-level review, helpers, humans/agents               | Expensive if inference-default   |
+
+**Honest gap (already stated):** we are **not sure** how to solve efficient **semantic** doc↔code drift verification (does prose still match behavior?). FAQ: MDCP does not magically force code↔docs compliance. Related open work: #157 (doc-sync inventory), #52 (compile/monolith diff), #160 (review evidence). Do not conflate that unsolved problem with “measure per-turn shard vs monolith chars.”
+
+## Gaps for this issue
+
+- No real **token** measurement (model tokenizer)
+- No A/B vs traditional README / full monolith / dump-style corpora with agent traces
+- No accounting for Skill pack overhead
+- Savings are **conditional** on one-shard discipline
+- Unclear unit: per-turn context, end-to-end feature development, or verification-loop $
+- No written **static-first verification bar** for cost (when to allow overnight batch inference vs forbid PR-tax LLM audits)
+
+## Decisions needed
+
+1. Headline metric for adopters: chars vs tokens vs $ vs HIL review time?
+2. Baseline corpora and scale axes (N shards, feature size, brownfield vs greenfield, concurrent agents)
+3. Claim tier: what can move Tier C → Tier B (or adoption story) without overselling
+4. Cost policy: default verification stack = static + tests; inference scarce / batchable
+5. Explicit non-overlap with #64/#67 (compile latency) and coordination with #160 / #157 / #52
+
+## Related
+
+- #160 Review-bench MVP (HIL; tokens as guardrail)
+- #157 Skill: doc-sync (coverage inventory — static-leaning direction)
+- #52 Diff checking on compiled output
+- #45 Usage model
+- #59 / #60 MCP / hosted delivery
+- Sibling draft: ontology / idea density (file as separate Feedback issue)
+- ADR 0001 — removed token-strip export
+
+## Acceptance (proposed)
+
+- [ ] Written measurement method (tokenizer or chars, corpora, session definition, scale points)
+- [ ] Regenerable script (extend/replace `bench:context-size`) + committed results; refresh stale LLM-export CSV columns post–ADR 0001
+- [ ] Bottom-line guidance: when MDCP is expected to use fewer / more tokens or $, at what scale — with Benefit Claims tier wording
+- [ ] Short design note on **static-first vs inference** for verification cost (link #52 / #157 / #160; do not claim semantic drift is solved)
+- [ ] No Tier C “token %” on README until measured
+```
+
+## Additional context
+
+```markdown
+Practical stakeholder question: will this use more or less tokens to develop a feature, on average, and at what scale?
+
+Maintainer working position (2026-07 exploration): prefer cheap overnight / static gates over budget-blowing inference; MDCP maximizes durable context for reasoning and audit; hard guarantees migrate to code QA; semantic doc↔code drift remains an open systems problem — attack with static inventories and tests first, inference as a scarce resource.
+
+File via Feedback template; Track suggestion: **Maintenance** (adoption evidence / measurement); attach Performance track only if dedicated bench engine work dominates.
+```

--- a/.github/ISSUE_DRAFTS/README.md
+++ b/.github/ISSUE_DRAFTS/README.md
@@ -1,0 +1,25 @@
+# Issue drafts (file manually, then delete)
+
+Temporary copy-paste packs for GitHub issues. **Do not** treat these as durable product docs — discovery stays on the [issue tracker](https://github.com/betsalel-williamson/mdcp/issues/); see [Agent work-item tracking](../../docs/developer/agent-work-item-tracking.md).
+
+## How to file
+
+Use the **Feedback or question** form (matches `.github/ISSUE_TEMPLATE/02-feedback.yml`):
+
+1. Open [Feedback or question](https://github.com/betsalel-williamson/mdcp/issues/new?template=02-feedback.yml).
+2. Set **Title** from the draft (keep the `[Feedback]` prefix the form suggests, or paste the draft title as-is).
+3. Set **Value-add priority** to the draft’s dropdown choice (**P1** for both).
+4. Paste **Summary** into the Summary field.
+5. Paste **Additional context** into Additional context (optional field).
+6. Submit, then apply the **Suggested labels** from the draft (forms only auto-apply `feedback`).
+7. Finish [new issue intake](../../docs/developer/agent-work-item-tracking.md#new-issue-intake-required): board (project #4), Status = Todo, Track, milestone if in-scope.
+
+| Draft                                   | Track (suggested)                                                                              |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `01-ontology-reuse-and-idea-density.md` | 1.0 Formalization                                                                              |
+| `02-token-use-measurement-and-cost.md`  | Maintenance (measurement / adoption evidence); link Performance only if bench work lands there |
+
+## After both issues exist
+
+1. Cross-link the two issue numbers in comments if useful.
+2. Delete this `ISSUE_DRAFTS/` directory in a follow-up commit (or leave until filing is done — coverage scan ignores `.github/**`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds temporary copy-paste packs under `.github/ISSUE_DRAFTS/` so a human can **manually open two P1 Feedback issues**, then delete the drafts. Content is shaped for `.github/ISSUE_TEMPLATE/02-feedback.yml` (title, priority dropdown, Summary, Additional context, post-create labels + intake).

These are **not** durable protocol shards (intentionally under `.github/`, which coverage scan ignores). Discovery belongs on the issue tracker after filing.

### Drafts

1. **`01-ontology-reuse-and-idea-density.md`** — OOP/inheritance hypothesis vs docs-as-context; idea density as governance; high-level + tables/tests sidestep; Navy/GCP existence proofs; MDCP niche for under-documenting eng cultures.
2. **`02-token-use-measurement-and-cost.md`** — measure tokens/cost at scale; prefer cheap overnight / static gates over budget-blowing inference; constraint→test migration; honest gap on semantic doc↔code drift (#157 / #52 / #160).

### How to file

See `.github/ISSUE_DRAFTS/README.md`:

1. [Feedback or question](https://github.com/betsalel-williamson/mdcp/issues/new?template=02-feedback.yml)
2. Paste title / set **P1** / paste Summary + Additional context
3. Apply suggested labels; finish [new issue intake](https://github.com/betsalel-williamson/mdcp/blob/main/docs/developer/agent-work-item-tracking.md#new-issue-intake-required)
4. Delete `ISSUE_DRAFTS/` once both issues exist

## Protocol / skill versions

- **protocolVersion**: N/A (no protocol/skill/schema/CLI contract change)
- **Parent skill**: N/A
- **mdcp-cli**: N/A

## Checklist

- [x] Scope = staging issue text for manual filing (one concern)
- [x] No durable `docs/` backlog shards
- [x] `.github/**` ignored by coverage scan
- [ ] Human files both issues and removes drafts

## Test plan

- [ ] Open Feedback form; paste draft 01; confirm fields map cleanly
- [ ] Same for draft 02
- [ ] After filing: delete `.github/ISSUE_DRAFTS/` in a follow-up commit

## Related

Manual follow-up issues (not yet numbered). Related existing: #78, #76, #157, #52, #160, #45, ADR 0001.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c515bbc4-c411-48ac-b9ce-5cd7975e61a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c515bbc4-c411-48ac-b9ce-5cd7975e61a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

