### PR TITLE
docs: fix pre-1.0 stability wording for independent versions

### DIFF
--- a/.changeset/fix-pre-1-0-stability-wording.md
+++ b/.changeset/fix-pre-1-0-stability-wording.md
@@ -1,0 +1,6 @@
+---
+'@bwilliamson/mdcp-cli': patch
+'@bwilliamson/mdcp-core': patch
+---
+
+Clarify pre-1.0 stability as per-package (independent versioning); stop gating docs on a single npm 1.0.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -875,7 +875,7 @@ If a prior run versioned/published but failed before tags/Releases finished, the
 
 ### Pre-1.0 policy (`0.x.y`)
 
-The project is **pre-1.0** (open alpha). Until **1.0.0**, there is **no API stability guarantee**. **Major bumps are disabled** (`pnpm changeset:reject-major`). Use **patch**, **minor** (including breaking-within-0.x), or **build** via `pnpm release:build`.
+Packages and Agent Skills are **pre-1.0** while on `0.x.y`. Until a given item reaches **1.0.0**, that item has **no API stability guarantee**. **Major bumps are disabled** (`pnpm changeset:reject-major`). Use **patch**, **minor** (including breaking-within-0.x), or **build** via `pnpm release:build`.
 
 | Bump      | When                                                                       |
 | --------- | -------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 ### Status
 
-**Pre-1.0:** There is **no API stability guarantee** until npm 1.0.
+**Pre-1.0:** Packages and Agent Skills version independently. Until a given package or skill reaches **1.0.0**, that item has **no API stability guarantee**.
 
 **Get involved:** [GitHub Issues](https://github.com/betsalel-williamson/mdcp/issues) for feedback and bugs; [adoption stories](https://github.com/betsalel-williamson/mdcp/issues/new?template=adoption-story.yml) for real-world use.
 

--- a/docs/client-cli/install-and-quick-start.md
+++ b/docs/client-cli/install-and-quick-start.md
@@ -25,7 +25,7 @@ npm install -g @bwilliamson/mdcp-cli
 
 ## Stability
 
-**Pre-1.0:** There is **no API stability guarantee** until **1.0.0**. CLI commands, flags, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read package changelogs before upgrading.
+**Pre-1.0:** Until this package reaches **1.0.0**, there is **no API stability guarantee**. CLI commands, flags, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read the package changelog before upgrading.
 
 ### Get involved
 

--- a/docs/client-core/overview.md
+++ b/docs/client-core/overview.md
@@ -20,4 +20,4 @@ The CLI (`@bwilliamson/mdcp-cli`) depends on this package. Install `@bwilliamson
 
 ## Stability
 
-**Pre-1.0:** There is **no API stability guarantee** until **1.0.0**. Exported functions, types, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read package changelogs before upgrading.
+**Pre-1.0:** Until this package reaches **1.0.0**, there is **no API stability guarantee**. Exported functions, types, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read the package changelog before upgrading.

--- a/docs/developer/versioning-and-releases.md
+++ b/docs/developer/versioning-and-releases.md
@@ -27,7 +27,7 @@ If a prior run versioned/published but failed before tags/Releases finished, the
 
 ## Pre-1.0 policy (`0.x.y`)
 
-The project is **pre-1.0** (open alpha). Until **1.0.0**, there is **no API stability guarantee**. **Major bumps are disabled** (`pnpm changeset:reject-major`). Use **patch**, **minor** (including breaking-within-0.x), or **build** via `pnpm release:build`.
+Packages and Agent Skills are **pre-1.0** while on `0.x.y`. Until a given item reaches **1.0.0**, that item has **no API stability guarantee**. **Major bumps are disabled** (`pnpm changeset:reject-major`). Use **patch**, **minor** (including breaking-within-0.x), or **build** via `pnpm release:build`.
 
 | Bump      | When                                                                       |
 | --------- | -------------------------------------------------------------------------- |

--- a/docs/features/protocol/00-vision-and-roadmap.md
+++ b/docs/features/protocol/00-vision-and-roadmap.md
@@ -38,7 +38,7 @@ Filter for new capabilities: [Direct value bar](../design-constraints/direct-val
   V3 delivery      HTTPS API + API keys (optional)
 ```
 
-**V1 phase ≠ semver 1.0.** Roadmap phase names describe delivery surfaces; npm stability promises align at npm **1.0.0** — not during open alpha.
+**V1 phase ≠ semver 1.0.** Roadmap phase names describe delivery surfaces. Each package or skill’s stability promise begins at that item’s **1.0.0** — packages and skills version independently and currently publish as `0.x`.
 
 Later phases (MCP, hosted API) are alternate **delivery** surfaces; they do not redefine the documentation domain.
 

--- a/docs/features/protocol/mdcp-1.0-spec.md
+++ b/docs/features/protocol/mdcp-1.0-spec.md
@@ -2,7 +2,7 @@
 
 Normative specification for the MarkDown Context Protocol. Parent: [GitHub #48](https://github.com/betsalel-williamson/mdcp/issues/48).
 
-> **Status:** Draft — reference implementation leads; prose reconciled against `mdcp-core` before npm **1.0.0**. Agent entrypoint is the parent **Agent Skill** (`/mdcp`).
+> **Status:** Draft — reference implementation leads; prose reconciled against `mdcp-core` before calling the specification final. Protocol versioning is independent of package semver. Agent entrypoint is the parent **Agent Skill** (`/mdcp`).
 
 ## 1. Introduction
 

--- a/docs/repo-readme/this-repository.md
+++ b/docs/repo-readme/this-repository.md
@@ -13,7 +13,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 ## Status
 
-**Pre-1.0:** There is **no API stability guarantee** until npm 1.0.
+**Pre-1.0:** Packages and Agent Skills version independently. Until a given package or skill reaches **1.0.0**, that item has **no API stability guarantee**.
 
 **Get involved:** [GitHub Issues](https://github.com/betsalel-williamson/mdcp/issues) for feedback and bugs; [adoption stories](https://github.com/betsalel-williamson/mdcp/issues/new?template=adoption-story.yml) for real-world use.
 

--- a/packages/mdcp-cli/README.md
+++ b/packages/mdcp-cli/README.md
@@ -51,7 +51,7 @@ npm install -g @bwilliamson/mdcp-cli
 
 ### Stability
 
-**Pre-1.0:** There is **no API stability guarantee** until **1.0.0**. CLI commands, flags, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read package changelogs before upgrading.
+**Pre-1.0:** Until this package reaches **1.0.0**, there is **no API stability guarantee**. CLI commands, flags, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read the package changelog before upgrading.
 
 #### Get involved
 

--- a/packages/mdcp-core/README.md
+++ b/packages/mdcp-core/README.md
@@ -44,7 +44,7 @@ The CLI (`@bwilliamson/mdcp-cli`) depends on this package. Install `@bwilliamson
 
 ### Stability
 
-**Pre-1.0:** There is **no API stability guarantee** until **1.0.0**. Exported functions, types, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read package changelogs before upgrading.
+**Pre-1.0:** Until this package reaches **1.0.0**, there is **no API stability guarantee**. Exported functions, types, `mdcp.config.json` schema, and compile output may change in any `0.x.y` release. Read the package changelog before upgrading.
 
 <!-- mdcp-shard: end ../../docs/client-core/overview.md -->
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Durable docs incorrectly implied a single monorepo **“npm 1.0”** gate for API stability and for finishing the MDCP 1.0 spec draft. That conflicts with independent package/skill versioning (and with protocol version ≠ package semver).

## Protocol / skill versions

- **protocolVersion** (four-part): N/A (wording only; no contract change)
- **Parent skill** (`skills/mdcp` `metadata.version`): N/A
- **mdcp-cli** (if relevant): patch via changeset (compiled README stability copy)

## Changes

- **README / repo-readme:** per-package/skill stability until that item’s **1.0.0**
- **Versioning + client package overviews:** drop stale “open alpha”; say “this package” / “a given item”
- **Vision/roadmap:** V1 phase still ≠ semver 1.0; stability is per item at **1.0.0**
- **MDCP 1.0 spec status:** reconcile against `mdcp-core` before calling the spec final — not before npm 1.0.0
- Patch changeset for compiled package READMEs

Historical CHANGELOG lines about `vstable` / npm 1.0.0 are left as release history.

## Checklist

- [x] Scope matches the linked issue / work item (one concern)
- [x] Docs shards updated when behavior or contributor workflow changed (`pnpm docs:check`)
- [x] Tests / validation green for the surfaces touched
- [x] Changeset added when a published package’s user-facing behavior changes

## Test plan

- [x] `pnpm docs:check`
- [x] Pre-commit hook: typecheck/build for touched packages + `docs:compile:repo` + `mdcp check`

## Related

Quick docs correction (no GitHub issue).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52da643e-39f7-4d41-bd9d-4c132a8fd3c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52da643e-39f7-4d41-bd9d-4c132a8fd3c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

