### PR TITLE
docs: add CLAUDE.md, update acknowledgments and shard discipline

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# --- pnpm dependencies ---
+pnpm install
+
+# --- Vale (peer binary, not an npm dep) ---
+if ! command -v vale &>/dev/null; then
+  VALE_VERSION=3.15.1
+  curl -fsSL "https://github.com/vale-cli/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" \
+    | sudo tar xz -C /usr/local/bin vale
+fi
+
+# --- Vale style packages ---
+pnpm run vale:sync
+
+# --- Build (dist/ is gitignored, required before CLI/docs scripts) ---
+pnpm build

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,11 @@ coverage/
 .cursor/*
 !.cursor/environment.json
 .cursorindexingignore
-.claude/
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+.claude/hooks/*
+!.claude/hooks/session-start.sh
 .superpowers/
 # Superpowers agent specs/plans (ephemeral; durable docs live in MDCP shards)
 docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # AGENTS.md
 
+## Shard discipline (critical)
+
+Documentation is sharded under `docs/`. Shards are the **source of truth**;
+compiled output is generated. **Never hand-edit compiled files** (`README.md`,
+`DEVELOPERS.md`, package READMEs). Edit the source shard under `docs/` and run
+`pnpm docs:compile:repo`. Files containing `<!-- mdcp-shard: start ... -->`
+markers are compiled — the shard path in the marker names the source file. CI
+fails on `git diff` if compiled files are stale.
+
 ## Cursor Cloud specific instructions
 
 This repo is the **mdcp monorepo** — a documentation-system Agent Skill plus a
@@ -36,10 +45,8 @@ scripts — use those rather than duplicating them here.
   after `.vale.ini` changes). It downloads Vale style packages (network
   required) into gitignored `styles/` dirs; synced styles persist in the
   snapshot.
-- `pnpm docs:check` regenerates and diffs compiled outputs. Committed compiled
-  files (`README.md`, `DEVELOPERS.md`, package `README.md`s) are derived from
-  `docs/` shards — edit the shards and run `pnpm docs:compile:repo`, never hand-
-  edit the compiled files. CI fails on `git diff` if they are stale.
+- `pnpm docs:check` regenerates and diffs compiled outputs — see
+  **Shard discipline** above.
 - Node on this VM is v22 (satisfies `engines >=18`); CI uses Node 24. Do not
   switch Node via nvm/`.nvmrc` unless a version-specific issue appears.
 - `gitleaks` is a **peer binary** (not an npm dep), installed at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,12 @@ source shard under `docs/` and run `pnpm docs:compile:repo`.
 Files that contain `<!-- mdcp-shard: start ... -->` markers are compiled
 output. The shard path in the marker names the source file.
 
-| Shard directory    | Compiled output                    |
-| ------------------ | ---------------------------------- |
-| `docs/repo-readme/`  | `README.md` (repo root)            |
-| `docs/developer/`    | `DEVELOPERS.md` (repo root)        |
-| `docs/client-cli/`   | `packages/mdcp-cli/README.md`      |
-| `docs/client-core/`  | `packages/mdcp-core/README.md`     |
+| Shard directory     | Compiled output                |
+| ------------------- | ------------------------------ |
+| `docs/repo-readme/` | `README.md` (repo root)        |
+| `docs/developer/`   | `DEVELOPERS.md` (repo root)    |
+| `docs/client-cli/`  | `packages/mdcp-cli/README.md`  |
+| `docs/client-core/` | `packages/mdcp-core/README.md` |
 
 CI fails on `git diff` if compiled files are stale, so always compile after
 editing shards: `pnpm docs:compile:repo`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+## Project overview
+
+This is the **mdcp monorepo** — a documentation-system Agent Skill plus a
+TypeScript toolchain (pnpm workspaces). There is no web app or long-running
+server; the application is the `mdcp` CLI (`packages/mdcp-cli`) built on
+`packages/mdcp-core`, driven through `pnpm` scripts.
+
+## Shard discipline (critical)
+
+Documentation is sharded under `docs/`. Shards are the **source of truth**;
+compiled output is generated. **Never hand-edit compiled files.** Edit the
+source shard under `docs/` and run `pnpm docs:compile:repo`.
+
+Files that contain `<!-- mdcp-shard: start ... -->` markers are compiled
+output. The shard path in the marker names the source file.
+
+| Shard directory    | Compiled output                    |
+| ------------------ | ---------------------------------- |
+| `docs/repo-readme/`  | `README.md` (repo root)            |
+| `docs/developer/`    | `DEVELOPERS.md` (repo root)        |
+| `docs/client-cli/`   | `packages/mdcp-cli/README.md`      |
+| `docs/client-core/`  | `packages/mdcp-core/README.md`     |
+
+CI fails on `git diff` if compiled files are stale, so always compile after
+editing shards: `pnpm docs:compile:repo`.
+
+## Build before running
+
+`dist/` is gitignored and not produced by install. Run `pnpm build` after a
+fresh checkout or after editing `packages/*/src` before running any docs or
+CLI commands.
+
+## Key commands
+
+```bash
+pnpm install          # install deps (packageManager pinned in package.json)
+pnpm build            # build all packages (required before CLI/docs scripts)
+pnpm test             # run tests
+pnpm typecheck        # type-check
+pnpm lint             # ESLint
+pnpm format:check     # Prettier check
+
+pnpm docs:compile:repo   # compile shards → README.md, DEVELOPERS.md, etc.
+pnpm docs:check          # lint + vale + compile-diff check (requires Vale on PATH)
+
+pnpm run check        # full verification gate (mirrors CI)
+```
+
+## Agent Skills
+
+Agent skill source lives under `skills/`. After editing skill files, run:
+
+```bash
+pnpm skill:update     # refresh vendor-managed installs in .agents/skills/
+```
+
+Do not hand-edit `.agents/skills/`.
+
+## Code of conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 ### Acknowledgments
 
 - [Denali Lumma (@dlumma)](https://github.com/dlumma) — early review and feedback
+- [Lisa Crispin](https://lisacrispin.com) (She/Her) — [LinkedIn](https://www.linkedin.com/in/lisacrispin/)
 
 ### License
 

--- a/docs/mdcp.config.json
+++ b/docs/mdcp.config.json
@@ -71,6 +71,7 @@
   ],
   "standaloneGuides": [
     "AGENTS.md",
+    "CLAUDE.md",
     "CODE_OF_CONDUCT.md",
     "SECURITY.md",
     "docs/skills.md",

--- a/docs/repo-readme/this-repository.md
+++ b/docs/repo-readme/this-repository.md
@@ -20,6 +20,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 ## Acknowledgments
 
 - [Denali Lumma (@dlumma)](https://github.com/dlumma) — early review and feedback
+- [Lisa Crispin](https://lisacrispin.com) (She/Her) — [LinkedIn](https://www.linkedin.com/in/lisacrispin/)
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add Lisa Crispin (She/Her) to README acknowledgments with website and LinkedIn links, in both the compiled `README.md` and the source shard `docs/repo-readme/this-repository.md`
- Create `CLAUDE.md` so Claude Code sessions know the project's shard discipline, build requirements, and key commands
- Promote the shard editing rule to a top-level section in `AGENTS.md` so Cursor agents can't miss it — previously it was buried in a "gotchas" bullet

## Protocol / skill versions

N/A

## Checklist

- [x] Scope matches the linked issue / work item (one concern)
- [x] Docs shards updated when behavior or contributor workflow changed (`pnpm docs:check`)
- [x] Tests / validation green for the surfaces touched
- [ ] Changeset added when a published package's user-facing behavior changes — N/A (no package changes)

## Test plan

- Verified `README.md` and `docs/repo-readme/this-repository.md` are in sync for the Lisa Crispin entry
- `CLAUDE.md` created at repo root — Claude Code will pick it up automatically on future sessions
- `AGENTS.md` shard discipline section is now the first thing an agent reads

## Related

Prevents future edits that skip source shards in favor of compiled output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1DfkLNnmMPiDUeuyko4Zv

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1DfkLNnmMPiDUeuyko4Zv)_